### PR TITLE
refactor(morpho): bytecode savings

### DIFF
--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -82,8 +82,12 @@ abstract contract Morpho is IMorphoStaticTyping, Initializable {
 
     /// @dev Reverts if the caller is not the owner.
     modifier onlyOwner() {
-        if (msg.sender != owner) revert ErrorsLib.NotOwner();
+        requireOwner();
         _;
+    }
+
+    function requireOwner() internal {
+        if (msg.sender != owner) revert ErrorsLib.NotOwner();
     }
 
     /* ONLY OWNER FUNCTIONS */


### PR DESCRIPTION
Optimizes bytecode size by ~178B:

- Extract only owner check into a function
- Remove unused param from _getRepaymentStatus

These changes reduce contract size while maintaining functionality.