### PR TITLE
fix(sUSD3): account for locked share burns in loss absorption

### DIFF
--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -11,7 +11,6 @@ import {SharesMathLib} from "../libraries/SharesMathLib.sol";
 import {IERC4626} from "../../lib/openzeppelin/contracts/interfaces/IERC4626.sol";
 import {Pausable} from "../../lib/openzeppelin/contracts/utils/Pausable.sol";
 import {TokenizedStrategyStorageLib, ERC20} from "@periphery/libraries/TokenizedStrategyStorageLib.sol";
-import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
 import {IProtocolConfig} from "../interfaces/IProtocolConfig.sol";
 import {ProtocolConfigLib} from "../libraries/ProtocolConfigLib.sol";
 
@@ -501,12 +500,11 @@ contract USD3 is BaseHooksUpgradeable {
 
         _preReportHook();
         (profit, loss) = _reportInternal();
-
-        _postReportHookWithPre(profit, loss, preAssets, preSupply);
+        _postReportHook(profit, loss, preAssets, preSupply);
     }
 
     /// @dev Post-report hook to handle loss absorption by burning sUSD3's shares
-    function _postReportHookWithPre(uint256 _profit, uint256 loss, uint256 preAssets, uint256 preSupply) internal {
+    function _postReportHook(uint256 _profit, uint256 loss, uint256 preAssets, uint256 preSupply) internal {
         if (loss == 0 || sUSD3 == address(0)) return;
 
         // Get sUSD3's current USD3 balance

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -11,6 +11,7 @@ import {SharesMathLib} from "../libraries/SharesMathLib.sol";
 import {IERC4626} from "../../lib/openzeppelin/contracts/interfaces/IERC4626.sol";
 import {Pausable} from "../../lib/openzeppelin/contracts/utils/Pausable.sol";
 import {TokenizedStrategyStorageLib, ERC20} from "@periphery/libraries/TokenizedStrategyStorageLib.sol";
+import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
 import {IProtocolConfig} from "../interfaces/IProtocolConfig.sol";
 import {ProtocolConfigLib} from "../libraries/ProtocolConfigLib.sol";
 
@@ -489,31 +490,48 @@ contract USD3 is BaseHooksUpgradeable {
         }
     }
 
+    /**
+     * @notice Report profit and loss with pre-report context for accurate loss absorption
+     * @return profit Amount of profit generated
+     * @return loss Amount of loss incurred
+     */
+    function report() external override returns (uint256 profit, uint256 loss) {
+        uint256 preSupply = TokenizedStrategy.totalSupply();
+        uint256 preAssets = TokenizedStrategy.totalAssets();
+
+        _preReportHook();
+        (profit, loss) = _reportInternal();
+
+        _postReportHookWithPre(profit, loss, preAssets, preSupply);
+    }
+
     /// @dev Post-report hook to handle loss absorption by burning sUSD3's shares
-    function _postReportHook(uint256 profit, uint256 loss) internal override {
-        if (loss > 0 && sUSD3 != address(0)) {
-            // Get sUSD3's current USD3 balance
-            uint256 susd3Balance = TokenizedStrategy.balanceOf(sUSD3);
+    function _postReportHookWithPre(uint256 _profit, uint256 loss, uint256 preAssets, uint256 preSupply) internal {
+        if (loss == 0 || sUSD3 == address(0)) return;
 
-            if (susd3Balance > 0) {
-                // Calculate how many shares are needed to cover the loss
-                // IMPORTANT: We must use pre-report values to calculate the correct share amount
-                // The report has already reduced totalAssets, so we add the loss back
-                uint256 totalSupply = TokenizedStrategy.totalSupply();
-                uint256 totalAssets = TokenizedStrategy.totalAssets();
+        // Get sUSD3's current USD3 balance
+        uint256 susd3Balance = TokenizedStrategy.balanceOf(sUSD3);
+        if (susd3Balance == 0) return;
 
-                // Calculate shares to burn using pre-loss exchange rate
-                uint256 sharesToBurn = loss.mulDiv(totalSupply, totalAssets + loss, Math.Rounding.Floor);
+        if (preAssets == 0 || preSupply == 0) return;
 
-                // Cap at sUSD3's actual balance - they can't lose more than they have
-                if (sharesToBurn > susd3Balance) {
-                    sharesToBurn = susd3Balance;
-                }
+        // Total shares required to cover the loss at the pre-report PPS
+        uint256 totalBurnNeeded = loss.mulDiv(preSupply, preAssets, Math.Rounding.Floor);
 
-                if (sharesToBurn > 0) {
-                    _burnSharesFromSusd3(sharesToBurn);
-                }
-            }
+        // Internal burn from locked shares is reflected in the post-report totalSupply
+        uint256 postSupply = TokenizedStrategy.totalSupply();
+        uint256 lockedBurn = preSupply > postSupply ? preSupply - postSupply : 0;
+
+        // Burn only the remaining shares from sUSD3
+        uint256 sharesToBurn = totalBurnNeeded > lockedBurn ? totalBurnNeeded - lockedBurn : 0;
+
+        // Cap at sUSD3's actual balance - they can't lose more than they have
+        if (sharesToBurn > susd3Balance) {
+            sharesToBurn = susd3Balance;
+        }
+
+        if (sharesToBurn > 0) {
+            _burnSharesFromSusd3(sharesToBurn);
         }
     }
 

--- a/src/usd3/base/BaseHooksUpgradeable.sol
+++ b/src/usd3/base/BaseHooksUpgradeable.sol
@@ -158,8 +158,15 @@ abstract contract BaseHooksUpgradeable is BaseStrategyUpgradeable, Hooks {
      */
     function report() external virtual returns (uint256 profit, uint256 loss) {
         _preReportHook();
+        (profit, loss) = _reportInternal();
+        _postReportHook(profit, loss);
+    }
+
+    /**
+     * @dev Internal report execution hook to centralize delegatecall logic.
+     */
+    function _reportInternal() internal returns (uint256 profit, uint256 loss) {
         (profit, loss) =
             abi.decode(_delegateCall(abi.encodeCall(ITokenizedStrategy(address(this)).report, ())), (uint256, uint256));
-        _postReportHook(profit, loss);
     }
 }


### PR DESCRIPTION
## Summary

- Fix double-counting in sUSD3 loss absorption: `TokenizedStrategy.report()` burns locked profit shares to offset PPS decline, then `_postReportHook` burned sUSD3 shares for the same loss, causing PPS to **increase** after a loss
- sUSD3 now only absorbs the residual loss not already covered by the internal locked share burn
- Extract `_reportInternal()` helper in `BaseHooksUpgradeable` so USD3 can override `report()` and capture pre-report state cleanly

## Test plan

- [ ] `test_loss_with_locked_shares_no_pps_increase` passes (was failing before fix)
- [ ] `test_loss_calculation_bug` still passes (no locked shares scenario)
- [ ] `test_loss_exceeds_susd3_balance` still passes (sUSD3 balance cap)
- [ ] Full `yarn test:forge` passes with no regressions