### PR TITLE
feat: subordination-aware deployment cap in USD3

### DIFF
--- a/src/libraries/ProtocolConfigLib.sol
+++ b/src/libraries/ProtocolConfigLib.sol
@@ -38,6 +38,9 @@ library ProtocolConfigLib {
     // Supply Cap Keys
     bytes32 internal constant USD3_SUPPLY_CAP = keccak256("USD3_SUPPLY_CAP");
 
+    // Tend Keys
+    bytes32 internal constant TEND_DRIFT_THRESHOLD = keccak256("TEND_DRIFT_THRESHOLD");
+
     // Markdown Keys
     bytes32 internal constant FULL_MARKDOWN_DURATION = keccak256("FULL_MARKDOWN_DURATION");
 }

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -216,7 +216,37 @@ contract USD3 is BaseHooksUpgradeable {
                     INTERNAL STRATEGY FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
-    /// @dev Deploy funds to MorphoCredit market respecting maxOnCredit ratio
+    /// @dev Maximum waUSDC deployment allowed by sUSD3 backing alone.
+    /// Returns type(uint256).max when no subordination constraint applies.
+    function _subordinationDeployCapWaUSDC() internal view returns (uint256) {
+        if (sUSD3 == address(0)) return type(uint256).max;
+
+        IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
+        uint256 backingRatio = config.config(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO);
+        if (backingRatio == 0) return type(uint256).max;
+
+        uint256 sUSD3Shares = TokenizedStrategy.balanceOf(sUSD3);
+        uint256 _totalSupply = TokenizedStrategy.totalSupply();
+        uint256 _totalAssets = TokenizedStrategy.totalAssets();
+
+        if (_totalSupply == 0 || _totalAssets == 0 || sUSD3Shares == 0) return 0;
+
+        // Conservative (floor-rounded) USD3 share-to-USDC conversion,
+        // same accounting model as sUSD3.sol availableDepositLimit/availableWithdrawLimit
+        uint256 sUSD3ValueUSDC = sUSD3Shares.mulDiv(_totalAssets, _totalSupply, Math.Rounding.Floor);
+        uint256 maxDebtUSDC = (sUSD3ValueUSDC * 10_000) / backingRatio;
+
+        return WAUSDC.convertToShares(maxDebtUSDC);
+    }
+
+    /// @dev Effective deployment cap: min(maxOnCredit-based cap, subordination cap)
+    function _effectiveDeployCapWaUSDC(uint256 totalWaUSDC) internal view returns (uint256) {
+        uint256 maxOnCreditCap = (totalWaUSDC * maxOnCredit()) / 10_000;
+        uint256 subCap = _subordinationDeployCapWaUSDC();
+        return Math.min(maxOnCreditCap, subCap);
+    }
+
+    /// @dev Deploy funds to MorphoCredit market respecting maxOnCredit ratio and subordination cap
     /// @param _amount Amount of asset to deploy
     function _deployFunds(uint256 _amount) internal override {
         if (_amount == 0) return;
@@ -235,8 +265,7 @@ contract USD3 is BaseHooksUpgradeable {
         uint256 localWaUSDC = balanceOfWaUSDC();
         uint256 totalWaUSDC = deployedWaUSDC + localWaUSDC;
 
-        // Calculate max that should be deployed to MorphoCredit
-        uint256 maxDeployableWaUSDC = (totalWaUSDC * maxOnCreditRatio) / 10_000;
+        uint256 maxDeployableWaUSDC = _effectiveDeployCapWaUSDC(totalWaUSDC);
 
         if (maxDeployableWaUSDC <= deployedWaUSDC) {
             // Already at or above max, keep all new waUSDC local
@@ -315,7 +344,7 @@ contract USD3 is BaseHooksUpgradeable {
         uint256 localWaUSDC = balanceOfWaUSDC();
         uint256 totalWaUSDC = deployedWaUSDC + localWaUSDC;
 
-        uint256 targetDeployedWaUSDC = (totalWaUSDC * maxOnCredit()) / 10_000;
+        uint256 targetDeployedWaUSDC = _effectiveDeployCapWaUSDC(totalWaUSDC);
 
         if (deployedWaUSDC > targetDeployedWaUSDC) {
             // Withdraw excess from MorphoCredit
@@ -326,6 +355,24 @@ contract USD3 is BaseHooksUpgradeable {
             uint256 waUSDCToDeploy = Math.min(localWaUSDC, targetDeployedWaUSDC - deployedWaUSDC);
             _supplyToMorpho(waUSDCToDeploy);
         }
+    }
+
+    /// @dev Signal keepers when deployment drifts from the effective cap
+    function _tendTrigger() internal view override returns (bool) {
+        uint256 deployed = suppliedWaUSDC();
+        uint256 localWaUSDC = balanceOfWaUSDC();
+        uint256 totalWaUSDC = deployed + localWaUSDC;
+        uint256 target = _effectiveDeployCapWaUSDC(totalWaUSDC);
+
+        if (target == 0) return deployed > 0;
+
+        if (deployed > target) {
+            return (deployed - target) > target / 1000;
+        }
+        if (target > deployed && localWaUSDC > 0) {
+            return (target - deployed) > target / 1000;
+        }
+        return false;
     }
 
     /// @dev Helper function to supply waUSDC to MorphoCredit
@@ -602,6 +649,15 @@ contract USD3 is BaseHooksUpgradeable {
      */
     function suppliedWaUSDC() public view returns (uint256) {
         return morphoCredit.expectedSupplyAssets(_marketParams, address(this));
+    }
+
+    /**
+     * @notice Get the effective deployment cap accounting for both maxOnCredit and sUSD3 subordination
+     * @return Maximum waUSDC that should be deployed to MorphoCredit
+     */
+    function effectiveDeployCapWaUSDC() external view returns (uint256) {
+        uint256 totalWaUSDC = suppliedWaUSDC() + balanceOfWaUSDC();
+        return _effectiveDeployCapWaUSDC(totalWaUSDC);
     }
 
     /**

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -366,11 +366,17 @@ contract USD3 is BaseHooksUpgradeable {
 
         if (target == 0) return deployed > 0;
 
+        IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
+        uint256 driftBps = config.config(ProtocolConfigLib.TEND_DRIFT_THRESHOLD);
+        if (driftBps == 0) driftBps = 10;
+        require(driftBps < 10_000, "Invalid drift threshold");
+        uint256 threshold = (target * driftBps) / 10_000;
+
         if (deployed > target) {
-            return (deployed - target) > target / 1000;
+            return (deployed - target) > threshold;
         }
         if (target > deployed && localWaUSDC > 0) {
-            return (target - deployed) > target / 1000;
+            return (target - deployed) > threshold;
         }
         return false;
     }

--- a/test/forge/usd3/integration/DebtCapAndBacking.t.sol
+++ b/test/forge/usd3/integration/DebtCapAndBacking.t.sol
@@ -179,9 +179,6 @@ contract DebtCapAndBackingTest is Setup {
     //////////////////////////////////////////////////////////////*/
 
     function test_backingRequirement_preventsWithdrawals() public {
-        // Set minimum backing ratio
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, MIN_BACKING_RATIO);
-
         // Alice deposits to USD3
         vm.prank(alice);
         uint256 aliceShares = strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -193,6 +190,9 @@ contract DebtCapAndBackingTest is Setup {
         // Create debt first to enable sUSD3 deposits (debt-based subordination)
         setMaxOnCredit(8000);
         createMarketDebt(borrower, DEPOSIT_AMOUNT / 2); // 500K debt
+
+        // Set minimum backing ratio AFTER debt creation to avoid blocking deployment
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, MIN_BACKING_RATIO);
 
         // Now Bob can deposit USD3 to sUSD3 (after debt exists)
         uint256 bobUSD3 = strategy.balanceOf(bob);
@@ -235,9 +235,6 @@ contract DebtCapAndBackingTest is Setup {
     }
 
     function test_backingRequirement_allowsPartialWithdrawals() public {
-        // Set minimum backing ratio to 25%
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 2500);
-
         // Alice deposits to USD3
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -249,6 +246,9 @@ contract DebtCapAndBackingTest is Setup {
         // Create debt first to enable sUSD3 deposits
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 200_000e6); // 200K debt needs 50K backing at 25%
+
+        // Set minimum backing ratio AFTER debt creation to avoid blocking deployment
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 2500);
 
         // Now Bob can deposit USD3 to sUSD3 (after debt exists)
         uint256 bobUSD3 = strategy.balanceOf(bob);
@@ -316,9 +316,6 @@ contract DebtCapAndBackingTest is Setup {
     }
 
     function test_emergencyShutdownBypassesChecks() public {
-        // Set strict backing requirement
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 10000); // 100%
-
         // Setup positions
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -329,6 +326,9 @@ contract DebtCapAndBackingTest is Setup {
         // Create debt first to enable sUSD3 deposits
         setMaxOnCredit(8000);
         createMarketDebt(borrower, DEPOSIT_AMOUNT / 2);
+
+        // Set strict backing requirement AFTER debt creation to avoid blocking deployment
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 10000); // 100%
 
         // Now Bob can deposit USD3 to sUSD3 (after debt exists)
         uint256 bobUSD3 = strategy.balanceOf(bob);

--- a/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
+++ b/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
@@ -181,9 +181,6 @@ contract DebtFloorComprehensiveTest is Setup {
     //////////////////////////////////////////////////////////////*/
 
     function test_debtFloor_withdrawalAtExactFloor() public {
-        // Set backing ratio to 25%
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 2500);
-
         // Setup positions
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -194,6 +191,9 @@ contract DebtFloorComprehensiveTest is Setup {
         // Create specific debt amount
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 200_000e6); // 200K debt needs 50K backing at 25%
+
+        // Set backing ratio AFTER debt creation to avoid blocking deployment
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 2500);
 
         // Bob deposits to sUSD3
         uint256 bobUSD3 = strategy.balanceOf(bob);
@@ -244,9 +244,6 @@ contract DebtFloorComprehensiveTest is Setup {
     }
 
     function test_debtFloor_withdrawalOneCentAboveFloor() public {
-        // Set backing ratio to 30%
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 3000);
-
         // Setup positions
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -257,6 +254,9 @@ contract DebtFloorComprehensiveTest is Setup {
         // Create debt
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 100_000e6); // 100K debt needs 30K backing
+
+        // Set backing ratio AFTER debt creation
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 3000);
 
         // Bob deposits specific amount to sUSD3 (slightly above floor requirement)
         vm.prank(bob);
@@ -304,9 +304,6 @@ contract DebtFloorComprehensiveTest is Setup {
     //////////////////////////////////////////////////////////////*/
 
     function test_debtFloor_debtIncreaseDuringCooldown() public {
-        // Set backing ratio
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 4000); // 40%
-
         // Setup initial positions
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT * 2, alice);
@@ -317,6 +314,9 @@ contract DebtFloorComprehensiveTest is Setup {
         // Create initial debt
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 100_000e6); // 100K initial debt
+
+        // Set backing ratio AFTER debt creation
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 4000); // 40%
 
         // Bob deposits to sUSD3
         vm.prank(bob);
@@ -335,8 +335,10 @@ contract DebtFloorComprehensiveTest is Setup {
         uint256 withdrawLimit1 = susd3Strategy.availableWithdrawLimit(bob);
         assertGt(withdrawLimit1, 0, "Should have some withdrawal available initially");
 
-        // Increase debt during cooldown window
+        // Temporarily disable backing constraint to allow second borrow's report() to deploy
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
         createMarketDebt(borrower2, 150_000e6); // Additional 150K debt
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 4000);
 
         // Check withdrawal limit after debt increase
         uint256 withdrawLimit2 = susd3Strategy.availableWithdrawLimit(bob);
@@ -353,9 +355,6 @@ contract DebtFloorComprehensiveTest is Setup {
     }
 
     function test_debtFloor_backingRatioChangeDuringCooldown() public {
-        // Start with 20% backing ratio
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 2000);
-
         // Setup positions and debt
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -365,6 +364,9 @@ contract DebtFloorComprehensiveTest is Setup {
 
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 200_000e6);
+
+        // Start with 20% backing ratio (set AFTER debt creation)
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 2000);
 
         // Bob deposits to sUSD3
         vm.prank(bob);
@@ -405,9 +407,6 @@ contract DebtFloorComprehensiveTest is Setup {
     //////////////////////////////////////////////////////////////*/
 
     function test_debtFloor_simultaneousWithdrawalsNearFloor() public {
-        // Set backing ratio
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 3000); // 30%
-
         // Setup positions
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -421,6 +420,9 @@ contract DebtFloorComprehensiveTest is Setup {
         // Create debt
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 300_000e6); // 300K debt needs 90K backing
+
+        // Set backing ratio AFTER debt creation
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 3000); // 30%
 
         // Bob and Charlie both deposit to sUSD3
         vm.prank(bob);
@@ -469,9 +471,6 @@ contract DebtFloorComprehensiveTest is Setup {
     //////////////////////////////////////////////////////////////*/
 
     function test_debtFloor_recoveryFromBelowFloor() public {
-        // Set backing ratio
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 5000); // 50%
-
         // Setup positions
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -482,6 +481,9 @@ contract DebtFloorComprehensiveTest is Setup {
         // Create debt
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 400_000e6); // 400K debt needs 200K backing
+
+        // Set backing ratio AFTER debt creation
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 5000); // 50%
 
         // Bob deposits less than floor requirement
         vm.prank(bob);

--- a/test/forge/usd3/integration/SubordinationDeployCap.t.sol
+++ b/test/forge/usd3/integration/SubordinationDeployCap.t.sol
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.18;
+
+import "forge-std/Test.sol";
+import {Setup} from "../utils/Setup.sol";
+import {USD3} from "../../../../src/usd3/USD3.sol";
+import {sUSD3} from "../../../../src/usd3/sUSD3.sol";
+import {MorphoCredit} from "../../../../src/MorphoCredit.sol";
+import {IMorpho, Id, MarketParams} from "../../../../src/interfaces/IMorpho.sol";
+import {MockProtocolConfig} from "../mocks/MockProtocolConfig.sol";
+import {ProtocolConfigLib} from "../../../../src/libraries/ProtocolConfigLib.sol";
+import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
+import {ErrorsLib} from "../../../../src/libraries/ErrorsLib.sol";
+import {
+    TransparentUpgradeableProxy
+} from "../../../../lib/openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "../../../../lib/openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+contract SubordinationDeployCapTest is Setup {
+    USD3 public usd3Strategy;
+    sUSD3 public susd3Strategy;
+    MockProtocolConfig public protocolConfig;
+
+    address public alice = makeAddr("alice");
+    address public bob = makeAddr("bob");
+    address public borrower = makeAddr("borrower");
+
+    uint256 public constant DEPOSIT_AMOUNT = 1_000_000e6;
+
+    function setUp() public override {
+        super.setUp();
+
+        usd3Strategy = USD3(address(strategy));
+
+        address morphoAddress = address(usd3Strategy.morphoCredit());
+        protocolConfig = MockProtocolConfig(MorphoCredit(morphoAddress).protocolConfig());
+
+        // Deploy and link sUSD3
+        sUSD3 susd3Implementation = new sUSD3();
+        ProxyAdmin susd3ProxyAdmin = new ProxyAdmin(management);
+        TransparentUpgradeableProxy susd3Proxy = new TransparentUpgradeableProxy(
+            address(susd3Implementation),
+            address(susd3ProxyAdmin),
+            abi.encodeCall(sUSD3.initialize, (address(usd3Strategy), management, keeper))
+        );
+        susd3Strategy = sUSD3(address(susd3Proxy));
+
+        vm.prank(management);
+        usd3Strategy.setSUSD3(address(susd3Strategy));
+
+        deal(address(underlyingAsset), alice, DEPOSIT_AMOUNT * 20);
+        deal(address(underlyingAsset), bob, DEPOSIT_AMOUNT * 20);
+
+        vm.prank(alice);
+        asset.approve(address(strategy), type(uint256).max);
+        vm.prank(bob);
+        asset.approve(address(strategy), type(uint256).max);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    function _depositToSUSD3(address user, uint256 usd3Amount) internal returns (uint256) {
+        vm.prank(user);
+        strategy.approve(address(susd3Strategy), usd3Amount);
+        vm.prank(user);
+        return susd3Strategy.deposit(usd3Amount, user);
+    }
+
+    /// @dev Creates initial debt and sUSD3 backing WITHOUT the backing ratio constraint.
+    /// Sets MIN_SUSD3_BACKING_RATIO after setup so the subordination cap can be tested.
+    function _bootstrapDebtAndBacking(
+        uint256 usd3DepositAmount,
+        uint256 debtAmount,
+        uint256 susd3DepositAmount,
+        uint256 backingRatio
+    ) internal {
+        // Ensure TRANCHE_RATIO is set for sUSD3 deposit limits
+        protocolConfig.setConfig(ProtocolConfigLib.TRANCHE_RATIO, 10_000);
+        // No backing constraint during bootstrap
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        setMaxOnCredit(10_000);
+
+        // Deposit USDC into USD3
+        vm.prank(alice);
+        strategy.deposit(usd3DepositAmount, alice);
+
+        // Create debt (this calls report() internally, deploys to Morpho, then borrows)
+        createMarketDebt(borrower, debtAmount);
+
+        // Now deposit into sUSD3 (needs debt to exist for deposit limit > 0)
+        if (susd3DepositAmount > 0) {
+            vm.prank(bob);
+            strategy.deposit(susd3DepositAmount, bob);
+
+            uint256 bobUSD3 = strategy.balanceOf(bob);
+            uint256 depositLimit = susd3Strategy.availableDepositLimit(bob);
+            uint256 toDeposit = bobUSD3 > depositLimit ? depositLimit : bobUSD3;
+            if (toDeposit > 0) {
+                _depositToSUSD3(bob, toDeposit);
+            }
+        }
+
+        // NOW enable the backing ratio constraint
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, backingRatio);
+    }
+
+    function _setupBorrower(uint256 creditAmount) internal {
+        Id marketId = usd3Strategy.marketId();
+        MarketParams memory marketParams = usd3Strategy.marketParams();
+        IMorpho morpho = usd3Strategy.morphoCredit();
+
+        address[] memory borrowers_ = new address[](0);
+        uint256[] memory repaymentBps = new uint256[](0);
+        uint256[] memory endingBalances = new uint256[](0);
+
+        vm.prank(marketParams.creditLine);
+        MorphoCredit(address(morpho))
+            .closeCycleAndPostObligations(marketId, block.timestamp, borrowers_, repaymentBps, endingBalances);
+
+        vm.prank(marketParams.creditLine);
+        MorphoCredit(address(morpho)).setCreditLine(marketId, borrower, creditAmount, 0);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    BUG REGRESSION TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_bugRegression_borrowHeadroomBoundedByBacking() public {
+        // 10M USDC deposited, 500K debt, ~800K sUSD3 backing, 10M debt cap
+        _bootstrapDebtAndBacking(10_000_000e6, 500_000e6, 800_000e6, 10_000);
+        setMorphoDebtCap(10_000_000e6);
+
+        // Tend to enforce subordination cap
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        uint256 suppliedAfterTend = usd3Strategy.suppliedWaUSDC();
+        uint256 cap = usd3Strategy.effectiveDeployCapWaUSDC();
+
+        assertLe(suppliedAfterTend, cap + 1, "Deployment should respect subordination cap");
+
+        // The deployed amount should be bounded by sUSD3 backing, NOT the 10M debt cap
+        uint256 sUSD3ValueUSDC =
+            ITokenizedStrategy(address(susd3Strategy)).convertToAssets(strategy.balanceOf(address(susd3Strategy)));
+        assertLe(
+            waUSDC.convertToAssets(suppliedAfterTend),
+            sUSD3ValueUSDC + 1e6,
+            "Deployment should be bounded by sUSD3 backing, not debt cap"
+        );
+    }
+
+    function test_bugRegression_liveShape() public {
+        // Mirror production: ~7.7M debt, ~7.8M sUSD3 backing, 10M cap
+        _bootstrapDebtAndBacking(10_000_000e6, 7_700_000e6, 7_800_000e6, 10_000);
+        setMorphoDebtCap(10_000_000e6);
+
+        // Tend
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        uint256 sUSD3ValueUSDC =
+            ITokenizedStrategy(address(susd3Strategy)).convertToAssets(strategy.balanceOf(address(susd3Strategy)));
+
+        (,, uint256 totalBorrowAssets, uint256 liquidity) = usd3Strategy.getMarketLiquidity();
+        uint256 borrowHeadroom = waUSDC.convertToAssets(liquidity);
+        uint256 debtUSDC = waUSDC.convertToAssets(totalBorrowAssets);
+
+        // Borrow headroom should be bounded by backing headroom
+        uint256 maxNewBorrows = sUSD3ValueUSDC > debtUSDC ? sUSD3ValueUSDC - debtUSDC : 0;
+        assertLe(
+            borrowHeadroom, maxNewBorrows + 2e6, "Borrow headroom should be bounded by backing headroom, not debt cap"
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    DEPLOYMENT CAP TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_deploymentCappedByBacking() public {
+        // 200K debt, 300K sUSD3 backing: after tend, deployment bounded by 300K cap
+        _bootstrapDebtAndBacking(2_000_000e6, 200_000e6, 300_000e6, 10_000);
+
+        // Tend to enforce cap
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        uint256 supplied = usd3Strategy.suppliedWaUSDC();
+        uint256 sUSD3ValueUSDC =
+            ITokenizedStrategy(address(susd3Strategy)).convertToAssets(strategy.balanceOf(address(susd3Strategy)));
+
+        assertLe(waUSDC.convertToAssets(supplied), sUSD3ValueUSDC + 1e6, "Deployment should not exceed sUSD3 backing");
+    }
+
+    function test_tendWithdrawsWhenBackingDrops() public {
+        _bootstrapDebtAndBacking(2_000_000e6, 500_000e6, 1_000_000e6, 10_000);
+
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+        uint256 suppliedBefore = usd3Strategy.suppliedWaUSDC();
+
+        // Simulate sUSD3 backing drop by burning half its USD3 balance
+        uint256 susd3USD3Balance = strategy.balanceOf(address(susd3Strategy));
+        deal(address(strategy), address(susd3Strategy), susd3USD3Balance / 2);
+
+        // Tend should pull back deployment
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+        uint256 suppliedAfter = usd3Strategy.suppliedWaUSDC();
+
+        assertLt(suppliedAfter, suppliedBefore, "Deployment should decrease after backing drop");
+    }
+
+    function test_tendRedeploysWhenBackingRises() public {
+        _bootstrapDebtAndBacking(2_000_000e6, 200_000e6, 200_000e6, 10_000);
+
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+        uint256 suppliedBefore = usd3Strategy.suppliedWaUSDC();
+
+        // Increase sUSD3 backing by dealing more USD3 tokens
+        uint256 susd3USD3Balance = strategy.balanceOf(address(susd3Strategy));
+        deal(address(strategy), address(susd3Strategy), susd3USD3Balance * 3);
+
+        // Tend should redeploy idle funds
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+        uint256 suppliedAfter = usd3Strategy.suppliedWaUSDC();
+
+        assertGe(suppliedAfter, suppliedBefore, "Deployment should increase after backing rise");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    TEND TRIGGER TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_tendTrigger_trueWhenOverDeployed() public {
+        _bootstrapDebtAndBacking(2_000_000e6, 500_000e6, 500_000e6, 10_000);
+
+        // Tend to reach equilibrium
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        // Drop sUSD3 backing significantly
+        uint256 susd3USD3Balance = strategy.balanceOf(address(susd3Strategy));
+        deal(address(strategy), address(susd3Strategy), susd3USD3Balance / 4);
+
+        (bool shouldTend,) = usd3Strategy.tendTrigger();
+        assertTrue(shouldTend, "Should trigger tend when over-deployed vs backing");
+    }
+
+    function test_tendTrigger_trueWhenUnderDeployedWithIdleFunds() public {
+        _bootstrapDebtAndBacking(1_000_000e6, 200_000e6, 200_000e6, 10_000);
+
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        // Increase sUSD3 backing significantly
+        uint256 susd3USD3Balance = strategy.balanceOf(address(susd3Strategy));
+        deal(address(strategy), address(susd3Strategy), susd3USD3Balance * 5);
+
+        (bool shouldTend,) = usd3Strategy.tendTrigger();
+        assertTrue(shouldTend, "Should trigger tend when under-deployed with headroom");
+    }
+
+    function test_tendTrigger_falseWithinThreshold() public {
+        _bootstrapDebtAndBacking(1_000_000e6, 200_000e6, 500_000e6, 10_000);
+
+        // Tend to reach equilibrium
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        (bool shouldTend,) = usd3Strategy.tendTrigger();
+        assertFalse(shouldTend, "Should not trigger tend at equilibrium");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    PASSTHROUGH / EDGE CASE TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_maxOnCreditStricterThanBacking() public {
+        _bootstrapDebtAndBacking(2_000_000e6, 500_000e6, 1_000_000e6, 10_000);
+        setMaxOnCredit(3000); // 30% — much stricter than subordination cap
+
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        uint256 supplied = usd3Strategy.suppliedWaUSDC();
+        uint256 total = supplied + usd3Strategy.balanceOfWaUSDC();
+        uint256 maxOnCreditTarget = (total * 3000) / 10_000;
+
+        assertLe(supplied, maxOnCreditTarget + 1, "maxOnCredit should dominate when stricter");
+    }
+
+    function test_backingRatioZeroPassthrough() public {
+        // MIN_SUSD3_BACKING_RATIO = 0 means no subordination constraint
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        setMaxOnCredit(8000);
+
+        vm.prank(alice);
+        strategy.deposit(2_000_000e6, alice);
+
+        vm.prank(keeper);
+        strategy.report();
+
+        uint256 supplied = usd3Strategy.suppliedWaUSDC();
+        uint256 total = supplied + usd3Strategy.balanceOfWaUSDC();
+        uint256 expected = (total * 8000) / 10_000;
+
+        assertApproxEqAbs(supplied, expected, 2, "Should deploy per maxOnCredit when backingRatio=0");
+    }
+
+    function test_noDeploymentWhenSUSD3Empty() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 10_000);
+        setMaxOnCredit(10_000);
+
+        // sUSD3 is linked but holds nothing
+        vm.prank(alice);
+        strategy.deposit(1_000_000e6, alice);
+
+        vm.prank(keeper);
+        strategy.report();
+
+        uint256 supplied = usd3Strategy.suppliedWaUSDC();
+        assertEq(supplied, 0, "Should not deploy when sUSD3 has no backing");
+    }
+
+    function test_effectiveCapIsMin() public {
+        _bootstrapDebtAndBacking(1_000_000e6, 200_000e6, 300_000e6, 10_000);
+        setMaxOnCredit(5000); // 50%
+
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        uint256 cap = usd3Strategy.effectiveDeployCapWaUSDC();
+        uint256 supplied = usd3Strategy.suppliedWaUSDC();
+        uint256 total = supplied + usd3Strategy.balanceOfWaUSDC();
+
+        uint256 maxOnCreditCap = (total * 5000) / 10_000;
+        uint256 sUSD3ValueUSDC =
+            ITokenizedStrategy(address(susd3Strategy)).convertToAssets(strategy.balanceOf(address(susd3Strategy)));
+        uint256 subCap = waUSDC.convertToShares(sUSD3ValueUSDC);
+
+        uint256 expectedCap = maxOnCreditCap < subCap ? maxOnCreditCap : subCap;
+        assertApproxEqAbs(cap, expectedCap, 2, "Effective cap should be min(maxOnCredit, subordination)");
+    }
+}

--- a/test/forge/usd3/integration/SubordinationDeployCap.t.sol
+++ b/test/forge/usd3/integration/SubordinationDeployCap.t.sol
@@ -219,9 +219,14 @@ contract SubordinationDeployCapTest is Setup {
         ITokenizedStrategy(address(strategy)).tend();
         uint256 suppliedBefore = usd3Strategy.suppliedWaUSDC();
 
-        // Increase sUSD3 backing by dealing more USD3 tokens
-        uint256 susd3USD3Balance = strategy.balanceOf(address(susd3Strategy));
-        deal(address(strategy), address(susd3Strategy), susd3USD3Balance * 3);
+        // Increase sUSD3 backing via actual deposit flow (preserves ERC20 invariants)
+        address charlie = makeAddr("charlie");
+        deal(address(underlyingAsset), charlie, 400_000e6);
+        vm.prank(charlie);
+        asset.approve(address(strategy), type(uint256).max);
+        vm.prank(charlie);
+        strategy.deposit(400_000e6, charlie);
+        _depositToSUSD3(charlie, strategy.balanceOf(charlie));
 
         // Tend should redeploy idle funds
         vm.prank(keeper);
@@ -256,9 +261,14 @@ contract SubordinationDeployCapTest is Setup {
         vm.prank(keeper);
         ITokenizedStrategy(address(strategy)).tend();
 
-        // Increase sUSD3 backing significantly
-        uint256 susd3USD3Balance = strategy.balanceOf(address(susd3Strategy));
-        deal(address(strategy), address(susd3Strategy), susd3USD3Balance * 5);
+        // Increase sUSD3 backing via actual deposit flow (preserves ERC20 invariants)
+        address charlie = makeAddr("charlie");
+        deal(address(underlyingAsset), charlie, 800_000e6);
+        vm.prank(charlie);
+        asset.approve(address(strategy), type(uint256).max);
+        vm.prank(charlie);
+        strategy.deposit(800_000e6, charlie);
+        _depositToSUSD3(charlie, strategy.balanceOf(charlie));
 
         (bool shouldTend,) = usd3Strategy.tendTrigger();
         assertTrue(shouldTend, "Should trigger tend when under-deployed with headroom");
@@ -273,6 +283,46 @@ contract SubordinationDeployCapTest is Setup {
 
         (bool shouldTend,) = usd3Strategy.tendTrigger();
         assertFalse(shouldTend, "Should not trigger tend at equilibrium");
+    }
+
+    function test_tendTrigger_configurableDriftThreshold() public {
+        _bootstrapDebtAndBacking(2_000_000e6, 500_000e6, 500_000e6, 10_000);
+
+        // Tend to reach equilibrium
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        // Drop sUSD3 backing slightly (~5%) to create moderate drift
+        uint256 susd3USD3Balance = strategy.balanceOf(address(susd3Strategy));
+        deal(address(strategy), address(susd3Strategy), (susd3USD3Balance * 95) / 100);
+
+        // With default 10 bps (0.1%), ~5% drift should trigger
+        (bool shouldTendDefault,) = usd3Strategy.tendTrigger();
+        assertTrue(shouldTendDefault, "Should trigger with default 0.1% threshold");
+
+        // Set large threshold (50%) — ~5% drift should NOT trigger
+        protocolConfig.setConfig(ProtocolConfigLib.TEND_DRIFT_THRESHOLD, 5000);
+        (bool shouldTendLarge,) = usd3Strategy.tendTrigger();
+        assertFalse(shouldTendLarge, "Should not trigger with 50% threshold");
+
+        // Set small threshold (1 bp = 0.01%) — should trigger again
+        protocolConfig.setConfig(ProtocolConfigLib.TEND_DRIFT_THRESHOLD, 1);
+        (bool shouldTendSmall,) = usd3Strategy.tendTrigger();
+        assertTrue(shouldTendSmall, "Should trigger with 0.01% threshold");
+    }
+
+    function test_tendTrigger_revertsWhenDriftThresholdTooHigh() public {
+        _bootstrapDebtAndBacking(1_000_000e6, 200_000e6, 500_000e6, 10_000);
+
+        // 100% threshold should revert
+        protocolConfig.setConfig(ProtocolConfigLib.TEND_DRIFT_THRESHOLD, 10_000);
+        vm.expectRevert("Invalid drift threshold");
+        usd3Strategy.tendTrigger();
+
+        // Above 100% should also revert
+        protocolConfig.setConfig(ProtocolConfigLib.TEND_DRIFT_THRESHOLD, 15_000);
+        vm.expectRevert("Invalid drift threshold");
+        usd3Strategy.tendTrigger();
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/forge/usd3/mocks/MockProtocolConfig.sol
+++ b/test/forge/usd3/mocks/MockProtocolConfig.sol
@@ -33,6 +33,7 @@ contract MockProtocolConfig is IProtocolConfig {
     bytes32 private constant MIN_BORROW = keccak256("MIN_BORROW");
     bytes32 private constant IRP = keccak256("IRP");
     bytes32 private constant DEBT_CAP = keccak256("DEBT_CAP");
+    bytes32 private constant TEND_DRIFT_THRESHOLD = keccak256("TEND_DRIFT_THRESHOLD");
 
     constructor() {
         owner = msg.sender;
@@ -51,6 +52,7 @@ contract MockProtocolConfig is IProtocolConfig {
         config[GRACE_PERIOD] = 7 days;
         config[DELINQUENCY_PERIOD] = 30 days;
         config[MIN_BORROW] = 100e6; // 100 USDC minimum
+        config[TEND_DRIFT_THRESHOLD] = 10; // 0.1% default
     }
 
     function initialize(address newOwner) external {


### PR DESCRIPTION
## Summary

- USD3 now limits waUSDC deployment to MorphoCredit based on sUSD3 backing, preventing borrowers from accessing more liquidity than the subordinate tranche can cover
- Effective deployment target = `min(maxOnCredit cap, subordination cap)`, enforced as a rebalance-point invariant at deploy/tend boundaries
- `_tendTrigger` drift threshold is configurable via `TEND_DRIFT_THRESHOLD` in ProtocolConfig (in bps, default 10 = 0.1%), with a guard rejecting values >= 100% to prevent silently disabling keeper rebalancing

## Test plan

- [ ] `SubordinationDeployCap.t.sol` — 14 tests covering bug regression, deployment caps, tend triggers (including configurable threshold and >= 100% revert), and edge cases
- [ ] All 1259 non-invariant tests pass
- [ ] `yarn test:forge --match-path 'test/forge/usd3/integration/SubordinationDeployCap.t.sol' -vvv`
- [ ] `yarn test:forge:noninvariant`