### PR TITLE
feat: add OperationalController with tiered role-based access

### DIFF
--- a/script/deploy/upgrade/operational-controller/01_DeployOperationalController.s.sol
+++ b/script/deploy/upgrade/operational-controller/01_DeployOperationalController.s.sol
@@ -85,7 +85,7 @@ contract DeployOperationalController is Script {
     }
 
     function _logAddresses(string memory label, address[] memory addrs) internal pure {
-        console2.log("%s:", label, addrs.length);
+        console2.log("%s (count=%d):", label, addrs.length);
         for (uint256 i = 0; i < addrs.length; i++) {
             console2.log("  [%d]:", i, addrs[i]);
         }

--- a/script/deploy/upgrade/operational-controller/01_DeployOperationalController.s.sol
+++ b/script/deploy/upgrade/operational-controller/01_DeployOperationalController.s.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.22;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {
+    IAccessControlEnumerable
+} from "../../../../lib/openzeppelin/contracts/access/extensions/IAccessControlEnumerable.sol";
+import {OperationalController} from "../../../../src/OperationalController.sol";
+
+/// @title DeployOperationalController
+/// @notice Deploy the OperationalController with separate emergency and operator roles.
+contract DeployOperationalController is Script {
+    address constant PROTOCOL_CONFIG = 0x6b276A2A7dd8b629adBA8A06AD6573d01C84f34E;
+    address constant CREDIT_LINE = 0x26389b03298BA5DA0664FfD6bF78cF3A7820c6A9;
+    address constant SAFE_ADDRESS = 0x33333333Bd7045F1A601A1E289D7AB21036fB5EF;
+
+    function run() external returns (address) {
+        address[] memory emergencySigners = _getEmergencySigners();
+        address[] memory operators = _getOperators();
+
+        console2.log("=== Deploying OperationalController ===");
+        console2.log("ProtocolConfig:", PROTOCOL_CONFIG);
+        console2.log("CreditLine:", CREDIT_LINE);
+        console2.log("Owner (Safe):", SAFE_ADDRESS);
+        _logAddresses("Emergency signers", emergencySigners);
+        _logAddresses("Operators", operators);
+        console2.log("");
+
+        vm.startBroadcast();
+
+        OperationalController controller =
+            new OperationalController(PROTOCOL_CONFIG, CREDIT_LINE, SAFE_ADDRESS, emergencySigners, operators);
+
+        vm.stopBroadcast();
+
+        console2.log("=== OperationalController Deployed ===");
+        console2.log("Address:", address(controller));
+        console2.log("");
+        console2.log("Verify configuration:");
+        console2.log("  protocolConfig:", address(controller.protocolConfig()));
+        console2.log("  creditLine:", address(controller.creditLine()));
+        console2.log("  owner:", controller.owner());
+
+        IAccessControlEnumerable enumerable = IAccessControlEnumerable(address(controller));
+        uint256 emergencyCount = enumerable.getRoleMemberCount(controller.EMERGENCY_AUTHORIZED_ROLE());
+        uint256 operatorCount = enumerable.getRoleMemberCount(controller.OPERATOR_ROLE());
+        console2.log("  EMERGENCY_AUTHORIZED_ROLE members:", emergencyCount);
+        console2.log("  OPERATOR_ROLE members:", operatorCount);
+        console2.log("");
+        console2.log("Next steps:");
+        console2.log(
+            "1. Run 02_ScheduleOperationalControllerUpgrade.s.sol with OPERATIONAL_CONTROLLER=%s", address(controller)
+        );
+        console2.log("2. Wait for Safe signers to approve the schedule transaction");
+        console2.log("3. Wait for timelock delay, then run 03_ExecuteOperationalControllerUpgrade.s.sol");
+
+        return address(controller);
+    }
+
+    function _getEmergencySigners() internal view returns (address[] memory signers) {
+        string memory raw = vm.envOr("EMERGENCY_SIGNERS", string(""));
+        if (bytes(raw).length == 0) {
+            signers = new address[](1);
+            signers[0] = SAFE_ADDRESS;
+            return signers;
+        }
+
+        return _parseAddressList(raw);
+    }
+
+    function _getOperators() internal view returns (address[] memory operators) {
+        string memory raw = vm.envString("OPERATORS");
+        require(bytes(raw).length > 0, "OPERATORS not set");
+        operators = _parseAddressList(raw);
+        require(operators.length > 0, "OPERATORS empty");
+    }
+
+    function _parseAddressList(string memory raw) internal pure returns (address[] memory addrs) {
+        string[] memory parts = vm.split(raw, ",");
+        addrs = new address[](parts.length);
+        for (uint256 i = 0; i < parts.length; i++) {
+            addrs[i] = vm.parseAddress(parts[i]);
+            require(addrs[i] != address(0), "zero address in list");
+        }
+    }
+
+    function _logAddresses(string memory label, address[] memory addrs) internal pure {
+        console2.log("%s:", label, addrs.length);
+        for (uint256 i = 0; i < addrs.length; i++) {
+            console2.log("  [%d]:", i, addrs[i]);
+        }
+    }
+}

--- a/script/deploy/upgrade/operational-controller/02_ScheduleOperationalControllerUpgrade.s.sol
+++ b/script/deploy/upgrade/operational-controller/02_ScheduleOperationalControllerUpgrade.s.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.22;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {SafeHelper} from "../../../utils/SafeHelper.sol";
+import {TimelockHelper} from "../../../utils/TimelockHelper.sol";
+
+interface IProtocolConfigSetEmergencyAdmin {
+    function setEmergencyAdmin(address _emergencyAdmin) external;
+}
+
+interface ICreditLineSetOzd {
+    function setOzd(address newOzd) external;
+}
+
+/// @title ScheduleOperationalControllerUpgrade
+/// @notice Schedule pointer reconfiguration for OperationalController through Timelock via Safe.
+contract ScheduleOperationalControllerUpgrade is Script, SafeHelper, TimelockHelper {
+    address constant PROTOCOL_CONFIG = 0x6b276A2A7dd8b629adBA8A06AD6573d01C84f34E;
+    address constant CREDIT_LINE = 0x26389b03298BA5DA0664FfD6bF78cF3A7820c6A9;
+    address constant TIMELOCK = 0x1dCcD4628d48a50C1A7adEA3848bcC869f08f8C2;
+    address constant SAFE_ADDRESS = 0x33333333Bd7045F1A601A1E289D7AB21036fB5EF;
+
+    function _buildOperation(address newController)
+        internal
+        pure
+        returns (
+            address[] memory targets,
+            uint256[] memory values,
+            bytes[] memory datas,
+            bytes32 salt,
+            bytes32 predecessor
+        )
+    {
+        targets = new address[](2);
+        values = new uint256[](2);
+        datas = new bytes[](2);
+
+        targets[0] = PROTOCOL_CONFIG;
+        values[0] = 0;
+        datas[0] = abi.encodeCall(IProtocolConfigSetEmergencyAdmin.setEmergencyAdmin, (newController));
+
+        targets[1] = CREDIT_LINE;
+        values[1] = 0;
+        datas[1] = abi.encodeCall(ICreditLineSetOzd.setOzd, (newController));
+
+        salt = generateSalt("OperationalController Upgrade");
+        predecessor = bytes32(0);
+    }
+
+    function run(bool send) external isBatch(SAFE_ADDRESS) isTimelock(TIMELOCK) {
+        address newController = vm.envAddress("OPERATIONAL_CONTROLLER");
+        require(newController != address(0), "OPERATIONAL_CONTROLLER not set");
+
+        console2.log("=== Schedule OperationalController Upgrade via Timelock ===");
+        console2.log("Safe address:", SAFE_ADDRESS);
+        console2.log("Timelock address:", TIMELOCK);
+        console2.log("New OperationalController:", newController);
+        console2.log("Send to Safe:", send);
+        console2.log("");
+
+        uint256 minDelay = getMinDelay(TIMELOCK);
+        console2.log("Timelock minimum delay:", minDelay, "seconds");
+        console2.log("");
+
+        (address[] memory targets, uint256[] memory values, bytes[] memory datas, bytes32 salt, bytes32 predecessor) =
+            _buildOperation(newController);
+
+        bytes32 operationId = calculateBatchOperationId(targets, values, datas, predecessor, salt);
+
+        console2.log("Operation details:");
+        console2.log("  Target[0] (ProtocolConfig.setEmergencyAdmin):", targets[0]);
+        console2.log("  Target[1] (CreditLine.setOzd):", targets[1]);
+        console2.log("  Salt:", vm.toString(salt));
+        console2.log("  Operation ID:", vm.toString(operationId));
+        console2.log("");
+
+        if (isOperation(TIMELOCK, operationId)) {
+            logOperationState(TIMELOCK, operationId);
+            console2.log("");
+            console2.log("Operation already exists. Use 03_ExecuteOperationalControllerUpgrade.s.sol to execute.");
+            return;
+        }
+
+        simulateExecution(TIMELOCK, targets, values, datas);
+        console2.log("");
+
+        bytes memory scheduleCalldata = encodeScheduleBatch(targets, values, datas, predecessor, salt, minDelay);
+
+        console2.log("Adding scheduleBatch call to Safe transaction...");
+        addToBatch(TIMELOCK, scheduleCalldata);
+
+        if (send) {
+            console2.log("Sending transaction to Safe API...");
+            executeBatch(true);
+            console2.log("");
+            console2.log("Transaction sent successfully!");
+            console2.log("");
+            console2.log("=== IMPORTANT: Save these values for execution ===");
+            console2.log("Operation ID: %s", vm.toString(operationId));
+            console2.log("Salt: %s", vm.toString(salt));
+            console2.log("");
+            console2.log("Next steps:");
+            console2.log("1. Wait for Safe signers to approve and execute the schedule transaction");
+            console2.log("2. Wait %d seconds after scheduling", minDelay);
+            console2.log("3. Run 03_ExecuteOperationalControllerUpgrade.s.sol with:");
+            console2.log("   OPERATIONAL_CONTROLLER=%s", newController);
+        } else {
+            console2.log("Simulation mode - not sending to Safe");
+            executeBatch(false);
+            console2.log("");
+            console2.log("Simulation completed successfully");
+            console2.log("Operation ID would be: %s", vm.toString(operationId));
+        }
+    }
+
+    function run() external {
+        this.run(false);
+    }
+}

--- a/script/deploy/upgrade/operational-controller/02_ScheduleOperationalControllerUpgrade.s.sol
+++ b/script/deploy/upgrade/operational-controller/02_ScheduleOperationalControllerUpgrade.s.sol
@@ -3,51 +3,11 @@ pragma solidity 0.8.22;
 
 import {Script, console2} from "forge-std/Script.sol";
 import {SafeHelper} from "../../../utils/SafeHelper.sol";
-import {TimelockHelper} from "../../../utils/TimelockHelper.sol";
-
-interface IProtocolConfigSetEmergencyAdmin {
-    function setEmergencyAdmin(address _emergencyAdmin) external;
-}
-
-interface ICreditLineSetOzd {
-    function setOzd(address newOzd) external;
-}
+import {OperationalControllerUpgradeBase} from "./OperationalControllerUpgradeBase.s.sol";
 
 /// @title ScheduleOperationalControllerUpgrade
 /// @notice Schedule pointer reconfiguration for OperationalController through Timelock via Safe.
-contract ScheduleOperationalControllerUpgrade is Script, SafeHelper, TimelockHelper {
-    address constant PROTOCOL_CONFIG = 0x6b276A2A7dd8b629adBA8A06AD6573d01C84f34E;
-    address constant CREDIT_LINE = 0x26389b03298BA5DA0664FfD6bF78cF3A7820c6A9;
-    address constant TIMELOCK = 0x1dCcD4628d48a50C1A7adEA3848bcC869f08f8C2;
-    address constant SAFE_ADDRESS = 0x33333333Bd7045F1A601A1E289D7AB21036fB5EF;
-
-    function _buildOperation(address newController)
-        internal
-        pure
-        returns (
-            address[] memory targets,
-            uint256[] memory values,
-            bytes[] memory datas,
-            bytes32 salt,
-            bytes32 predecessor
-        )
-    {
-        targets = new address[](2);
-        values = new uint256[](2);
-        datas = new bytes[](2);
-
-        targets[0] = PROTOCOL_CONFIG;
-        values[0] = 0;
-        datas[0] = abi.encodeCall(IProtocolConfigSetEmergencyAdmin.setEmergencyAdmin, (newController));
-
-        targets[1] = CREDIT_LINE;
-        values[1] = 0;
-        datas[1] = abi.encodeCall(ICreditLineSetOzd.setOzd, (newController));
-
-        salt = generateSalt("OperationalController Upgrade");
-        predecessor = bytes32(0);
-    }
-
+contract ScheduleOperationalControllerUpgrade is Script, SafeHelper, OperationalControllerUpgradeBase {
     function run(bool send) external isBatch(SAFE_ADDRESS) isTimelock(TIMELOCK) {
         address newController = vm.envAddress("OPERATIONAL_CONTROLLER");
         require(newController != address(0), "OPERATIONAL_CONTROLLER not set");

--- a/script/deploy/upgrade/operational-controller/03_ExecuteOperationalControllerUpgrade.s.sol
+++ b/script/deploy/upgrade/operational-controller/03_ExecuteOperationalControllerUpgrade.s.sol
@@ -3,51 +3,11 @@ pragma solidity 0.8.22;
 
 import {Script, console2} from "forge-std/Script.sol";
 import {SafeHelper} from "../../../utils/SafeHelper.sol";
-import {TimelockHelper} from "../../../utils/TimelockHelper.sol";
-
-interface IProtocolConfigSetEmergencyAdmin {
-    function setEmergencyAdmin(address _emergencyAdmin) external;
-}
-
-interface ICreditLineSetOzd {
-    function setOzd(address newOzd) external;
-}
+import {OperationalControllerUpgradeBase} from "./OperationalControllerUpgradeBase.s.sol";
 
 /// @title ExecuteOperationalControllerUpgrade
 /// @notice Execute the scheduled OperationalController pointer reconfiguration after timelock delay.
-contract ExecuteOperationalControllerUpgrade is Script, SafeHelper, TimelockHelper {
-    address constant PROTOCOL_CONFIG = 0x6b276A2A7dd8b629adBA8A06AD6573d01C84f34E;
-    address constant CREDIT_LINE = 0x26389b03298BA5DA0664FfD6bF78cF3A7820c6A9;
-    address constant TIMELOCK = 0x1dCcD4628d48a50C1A7adEA3848bcC869f08f8C2;
-    address constant SAFE_ADDRESS = 0x33333333Bd7045F1A601A1E289D7AB21036fB5EF;
-
-    function _buildOperation(address newController)
-        internal
-        pure
-        returns (
-            address[] memory targets,
-            uint256[] memory values,
-            bytes[] memory datas,
-            bytes32 salt,
-            bytes32 predecessor
-        )
-    {
-        targets = new address[](2);
-        values = new uint256[](2);
-        datas = new bytes[](2);
-
-        targets[0] = PROTOCOL_CONFIG;
-        values[0] = 0;
-        datas[0] = abi.encodeCall(IProtocolConfigSetEmergencyAdmin.setEmergencyAdmin, (newController));
-
-        targets[1] = CREDIT_LINE;
-        values[1] = 0;
-        datas[1] = abi.encodeCall(ICreditLineSetOzd.setOzd, (newController));
-
-        salt = generateSalt("OperationalController Upgrade");
-        predecessor = bytes32(0);
-    }
-
+contract ExecuteOperationalControllerUpgrade is Script, SafeHelper, OperationalControllerUpgradeBase {
     function run(bool send) external isBatch(SAFE_ADDRESS) isTimelock(TIMELOCK) {
         address newController = vm.envAddress("OPERATIONAL_CONTROLLER");
         require(newController != address(0), "OPERATIONAL_CONTROLLER not set");

--- a/script/deploy/upgrade/operational-controller/03_ExecuteOperationalControllerUpgrade.s.sol
+++ b/script/deploy/upgrade/operational-controller/03_ExecuteOperationalControllerUpgrade.s.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.22;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {SafeHelper} from "../../../utils/SafeHelper.sol";
+import {TimelockHelper} from "../../../utils/TimelockHelper.sol";
+
+interface IProtocolConfigSetEmergencyAdmin {
+    function setEmergencyAdmin(address _emergencyAdmin) external;
+}
+
+interface ICreditLineSetOzd {
+    function setOzd(address newOzd) external;
+}
+
+/// @title ExecuteOperationalControllerUpgrade
+/// @notice Execute the scheduled OperationalController pointer reconfiguration after timelock delay.
+contract ExecuteOperationalControllerUpgrade is Script, SafeHelper, TimelockHelper {
+    address constant PROTOCOL_CONFIG = 0x6b276A2A7dd8b629adBA8A06AD6573d01C84f34E;
+    address constant CREDIT_LINE = 0x26389b03298BA5DA0664FfD6bF78cF3A7820c6A9;
+    address constant TIMELOCK = 0x1dCcD4628d48a50C1A7adEA3848bcC869f08f8C2;
+    address constant SAFE_ADDRESS = 0x33333333Bd7045F1A601A1E289D7AB21036fB5EF;
+
+    function _buildOperation(address newController)
+        internal
+        pure
+        returns (
+            address[] memory targets,
+            uint256[] memory values,
+            bytes[] memory datas,
+            bytes32 salt,
+            bytes32 predecessor
+        )
+    {
+        targets = new address[](2);
+        values = new uint256[](2);
+        datas = new bytes[](2);
+
+        targets[0] = PROTOCOL_CONFIG;
+        values[0] = 0;
+        datas[0] = abi.encodeCall(IProtocolConfigSetEmergencyAdmin.setEmergencyAdmin, (newController));
+
+        targets[1] = CREDIT_LINE;
+        values[1] = 0;
+        datas[1] = abi.encodeCall(ICreditLineSetOzd.setOzd, (newController));
+
+        salt = generateSalt("OperationalController Upgrade");
+        predecessor = bytes32(0);
+    }
+
+    function run(bool send) external isBatch(SAFE_ADDRESS) isTimelock(TIMELOCK) {
+        address newController = vm.envAddress("OPERATIONAL_CONTROLLER");
+        require(newController != address(0), "OPERATIONAL_CONTROLLER not set");
+
+        console2.log("=== Execute OperationalController Upgrade via Timelock ===");
+        console2.log("Safe address:", SAFE_ADDRESS);
+        console2.log("Timelock address:", TIMELOCK);
+        console2.log("New OperationalController:", newController);
+        console2.log("Send to Safe:", send);
+        console2.log("");
+
+        (address[] memory targets, uint256[] memory values, bytes[] memory datas, bytes32 salt, bytes32 predecessor) =
+            _buildOperation(newController);
+
+        bytes32 operationId = calculateBatchOperationId(targets, values, datas, predecessor, salt);
+
+        console2.log("Operation ID:", vm.toString(operationId));
+        console2.log("");
+
+        logOperationState(TIMELOCK, operationId);
+        console2.log("");
+
+        requireOperationReady(TIMELOCK, operationId);
+
+        bytes memory executeCalldata = encodeExecuteBatch(targets, values, datas, predecessor, salt);
+
+        console2.log("Adding executeBatch call to Safe transaction...");
+        addToBatch(TIMELOCK, executeCalldata);
+
+        if (send) {
+            console2.log("Sending transaction to Safe API...");
+            executeBatch(true);
+            console2.log("");
+            console2.log("Transaction sent successfully!");
+            console2.log("");
+            console2.log("Once executed:");
+            console2.log("  - ProtocolConfig.emergencyAdmin -> %s", newController);
+            console2.log("  - CreditLine.ozd -> %s", newController);
+        } else {
+            console2.log("Simulation mode - not sending to Safe");
+            executeBatch(false);
+            console2.log("");
+            console2.log("Simulation completed successfully");
+        }
+    }
+
+    /// @notice Check status of the upgrade operation.
+    function checkStatus() external view {
+        address newController = vm.envAddress("OPERATIONAL_CONTROLLER");
+        require(newController != address(0), "OPERATIONAL_CONTROLLER not set");
+
+        console2.log("=== Checking OperationalController Upgrade Status ===");
+        console2.log("New OperationalController:", newController);
+        console2.log("");
+
+        (address[] memory targets, uint256[] memory values, bytes[] memory datas, bytes32 salt, bytes32 predecessor) =
+            _buildOperation(newController);
+
+        bytes32 operationId = calculateBatchOperationId(targets, values, datas, predecessor, salt);
+
+        console2.log("Operation ID:", vm.toString(operationId));
+        console2.log("");
+
+        logOperationState(TIMELOCK, operationId);
+    }
+
+    /// @notice Verify the upgrade was applied correctly.
+    function verify() external view {
+        address newController = vm.envAddress("OPERATIONAL_CONTROLLER");
+        require(newController != address(0), "OPERATIONAL_CONTROLLER not set");
+
+        console2.log("=== Verifying OperationalController Upgrade ===");
+        console2.log("Expected OperationalController:", newController);
+        console2.log("");
+
+        (bool ok1, bytes memory data1) = PROTOCOL_CONFIG.staticcall(abi.encodeWithSignature("emergencyAdmin()"));
+        require(ok1, "Failed to read ProtocolConfig.emergencyAdmin");
+        address currentAdmin = abi.decode(data1, (address));
+        console2.log("ProtocolConfig.emergencyAdmin:", currentAdmin);
+
+        (bool ok2, bytes memory data2) = CREDIT_LINE.staticcall(abi.encodeWithSignature("ozd()"));
+        require(ok2, "Failed to read CreditLine.ozd");
+        address currentOzd = abi.decode(data2, (address));
+        console2.log("CreditLine.ozd:", currentOzd);
+
+        console2.log("");
+        if (currentAdmin == newController && currentOzd == newController) {
+            console2.log("PASS: Both pointers updated correctly");
+        } else {
+            if (currentAdmin != newController) {
+                console2.log("FAIL: ProtocolConfig.emergencyAdmin mismatch");
+            }
+            if (currentOzd != newController) {
+                console2.log("FAIL: CreditLine.ozd mismatch");
+            }
+        }
+    }
+
+    function run() external {
+        this.run(false);
+    }
+}

--- a/script/deploy/upgrade/operational-controller/OperationalControllerUpgradeBase.s.sol
+++ b/script/deploy/upgrade/operational-controller/OperationalControllerUpgradeBase.s.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.22;
+
+import {TimelockHelper} from "../../../utils/TimelockHelper.sol";
+
+interface IProtocolConfigSetEmergencyAdmin {
+    function setEmergencyAdmin(address _emergencyAdmin) external;
+}
+
+interface ICreditLineSetOzd {
+    function setOzd(address newOzd) external;
+}
+
+/// @notice Shared constants and calldata construction for OperationalController upgrade scripts.
+abstract contract OperationalControllerUpgradeBase is TimelockHelper {
+    address constant PROTOCOL_CONFIG = 0x6b276A2A7dd8b629adBA8A06AD6573d01C84f34E;
+    address constant CREDIT_LINE = 0x26389b03298BA5DA0664FfD6bF78cF3A7820c6A9;
+    address constant TIMELOCK = 0x1dCcD4628d48a50C1A7adEA3848bcC869f08f8C2;
+    address constant SAFE_ADDRESS = 0x33333333Bd7045F1A601A1E289D7AB21036fB5EF;
+
+    function _buildOperation(address newController)
+        internal
+        pure
+        returns (
+            address[] memory targets,
+            uint256[] memory values,
+            bytes[] memory datas,
+            bytes32 salt,
+            bytes32 predecessor
+        )
+    {
+        targets = new address[](2);
+        values = new uint256[](2);
+        datas = new bytes[](2);
+
+        targets[0] = PROTOCOL_CONFIG;
+        values[0] = 0;
+        datas[0] = abi.encodeCall(IProtocolConfigSetEmergencyAdmin.setEmergencyAdmin, (newController));
+
+        targets[1] = CREDIT_LINE;
+        values[1] = 0;
+        datas[1] = abi.encodeCall(ICreditLineSetOzd.setOzd, (newController));
+
+        salt = generateSalt("OperationalController Upgrade");
+        predecessor = bytes32(0);
+    }
+}

--- a/script/utils/SafeHelper.sol
+++ b/script/utils/SafeHelper.sol
@@ -1,0 +1,520 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.2 <0.9.0;
+
+// 💬 ABOUT
+// Gnosis Safe transaction batching script
+
+// 🧩 MODULES
+import {Script, console2, StdChains, stdJson, stdMath, StdStorage, stdStorageSafe, VmSafe} from "forge-std/Script.sol";
+import {Test} from "forge-std/Test.sol";
+import {Surl} from "./Surl.sol";
+
+// ⭐️ SCRIPT
+abstract contract SafeHelper is Script, Test {
+    using stdJson for string;
+    using Surl for *;
+
+    //     "to": "<checksummed address>",
+    //     "value": 0, // Value in wei
+    //     "data": "<0x prefixed hex string>",
+    //     "operation": 0,  // 0 CALL, 1 DELEGATE_CALL
+    //     "safeTxGas": 0,  // Max gas to use in the transaction
+
+    // Used by refund mechanism, not needed here
+    //     "gasToken": "<checksummed address>", // Token address (hold by the Safe) to be used as a refund to the
+    // sender, if `null` is Ether
+    //     "baseGas": 0,  // Gast costs not related to the transaction execution (signature check, refund payment...)
+    //     "gasPrice": 0,  // Gas price used for the refund calculation
+    //     "refundReceiver": "<checksummed address>", //Address of receiver of gas payment (or `null` if tx.origin)
+
+    //     "nonce": 0,  // Nonce of the Safe, transaction cannot be executed until Safe's nonce is not equal to this
+    // nonce
+    //     "contractTransactionHash": "string",  // Contract transaction hash calculated from all the field
+    //     "sender": "<checksummed address>",  // Owner of the Safe proposing the transaction. Must match one of the
+    // signatures
+    //     "signature": "<0x prefixed hex string>",  // One or more ethereum ECDSA signatures of the
+    // `contractTransactionHash` as an hex string
+
+    // Not required
+    //     "origin": "string"  // Give more information about the transaction, e.g. "My Custom Safe app"
+
+    // Hash constants
+    // Safe version for this script, hashes below depend on this
+    string private constant VERSION = "1.4.1";
+
+    // keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
+    bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH =
+        0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218;
+
+    // keccak256(
+    //     "SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256
+    // gasPrice,address gasToken,address refundReceiver,uint256 nonce)"
+    // );
+    bytes32 private constant SAFE_TX_TYPEHASH = 0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8;
+
+    // Deterministic deployment address of the Gnosis Safe Multisend contract, configured by chain.
+    address private SAFE_MULTISEND_ADDRESS;
+
+    // Chain ID, configured by chain.
+    uint256 private chainId;
+
+    // Safe API base URL, configured by chain.
+    string private SAFE_API_BASE_URL;
+    string private constant SAFE_API_MULTISIG_SEND = "/multisig-transactions/";
+
+    // Wallet information
+    bytes32 private walletType;
+    uint256 private mnemonicIndex;
+    string private account;
+    bytes32 private privateKey;
+
+    bytes32 private constant ACCOUNT = keccak256("account");
+    bytes32 private constant LOCAL = keccak256("local");
+    bytes32 private constant LEDGER = keccak256("ledger");
+
+    // Address to send transaction from
+    address private safe;
+
+    DeployMode public deployMode = DeployMode.FORK;
+
+    // Gas tracking
+    uint256 public totalGasUsed;
+
+    enum Operation {
+        CALL,
+        DELEGATECALL
+    }
+
+    enum DeployMode {
+        PRODUCTION,
+        FORK
+    }
+
+    struct Batch {
+        address to;
+        uint256 value;
+        bytes data;
+        Operation operation;
+        uint256 safeTxGas;
+        uint256 baseGas;
+        uint256 gasPrice;
+        address gasToken;
+        address refundReceiver;
+        uint256 nonce;
+        bytes32 txHash;
+        bytes signature;
+    }
+
+    // New struct to track a batch and its gas
+    struct BatchData {
+        bytes[] encodedTxns; // Array to store encoded transactions
+        uint256 totalGas; // Total gas used by the batch
+    }
+
+    // Replace single array with array of batches
+    BatchData[] public batches;
+
+    // Current batch index
+    uint256 private currentBatchIndex;
+
+    // Maximum gas per batch
+    uint256 public maxGasPerBatch = 20_000_000;
+
+    constructor() {
+        // Initialize first batch
+        batches.push(BatchData({encodedTxns: new bytes[](0), totalGas: 0}));
+    }
+
+    modifier isBatch(address safe_) {
+        // Set the Safe API base URL and multisend address based on chain
+        chainId = block.chainid;
+        SAFE_API_BASE_URL = "https://api.safe.global/tx-service/eth/api/v1/";
+        SAFE_MULTISEND_ADDRESS = 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D;
+        safe = safe_;
+
+        // Load wallet information
+        walletType = keccak256(abi.encodePacked(vm.envString("WALLET_TYPE")));
+        if (walletType == ACCOUNT) {
+            // For account, we'll need the address from cast
+            string[] memory inputs = new string[](4);
+            inputs[0] = "cast";
+            inputs[1] = "wallet";
+            inputs[2] = "private-key";
+            inputs[3] = string.concat("--account=", vm.envString("SAFE_PROPOSER_ACCOUNT"));
+            bytes memory keyBytes = vm.ffi(inputs);
+            privateKey = bytes32(keyBytes);
+            walletType = LOCAL;
+        } else if (walletType == LOCAL) {
+            privateKey = vm.envBytes32("SAFE_PROPOSER_PRIVATE_KEY");
+        } else if (walletType == LEDGER) {
+            mnemonicIndex = vm.envUint("MNEMONIC_INDEX");
+        } else {
+            revert("Unsupported wallet type");
+        }
+        _;
+    }
+
+    // Adds an encoded transaction to the batch.
+    // Encodes the transaction as packed bytes of:
+    // - `operation` as a `uint8` with `0` for a `call` or `1` for a `delegatecall` (=> 1 byte),
+    // - `to` as an `address` (=> 20 bytes),
+    // - `value` as in msg.value, sent as a `uint256` (=> 32 bytes),
+    // -  length of `data` as a `uint256` (=> 32 bytes),
+    // - `data` as `bytes`.
+    function addToBatch(address to_, uint256 value_, bytes memory data_) internal returns (bytes memory) {
+        if (deployMode == DeployMode.FORK) vm.startBroadcast(safe);
+        if (deployMode != DeployMode.FORK) vm.prank(safe);
+
+        // Simulate transaction to get gas used
+        uint256 gasStart = gasleft();
+        (bool success, bytes memory returnData) = to_.call{value: value_}(data_);
+        uint256 gasUsed = gasStart - gasleft();
+        if (deployMode == DeployMode.FORK) vm.stopBroadcast();
+
+        uint256 gasInCurrentBatch = batches[currentBatchIndex].totalGas;
+        // Check if adding this transaction would exceed our max gas limit. If so create a new batch.
+        if (gasInCurrentBatch + gasUsed > maxGasPerBatch) {
+            // Only create a new batch if the current one has transactions
+            if (batches[currentBatchIndex].encodedTxns.length > 0) {
+                currentBatchIndex++;
+                batches.push(BatchData({encodedTxns: new bytes[](0), totalGas: 0}));
+            }
+        }
+
+        // Encode the transaction and add it to the current batch
+        bytes memory encodedTxn = abi.encodePacked(Operation.CALL, to_, value_, data_.length, data_);
+        batches[currentBatchIndex].encodedTxns.push(encodedTxn);
+        batches[currentBatchIndex].totalGas += gasUsed;
+
+        if (success) {
+            return returnData;
+        } else {
+            revert(string(returnData));
+        }
+    }
+
+    // Helper to call `addToBatch` with implied 0 value.
+    function addToBatch(address to_, bytes memory data_) internal returns (bytes memory) {
+        return addToBatch(to_, 0, data_);
+    }
+
+    // Executes all batches, sending each to the Safe API
+    function executeBatch(bool send_) public {
+        executeBatch(send_, vm.envOr("SAFE_NONCE", uint256(0)));
+    }
+
+    // Executes all batches, sending each to the Safe API
+    function executeBatch(bool send_, uint256 nonce_) public {
+        if (nonce_ == 0) nonce_ = _getNonce(safe);
+        for (uint256 i = 0; i <= currentBatchIndex; i++) {
+            Batch memory batch = _createBatchFromIndex(i, nonce_++);
+            if (send_) {
+                batch = _signBatch(safe, batch);
+                _sendBatch(safe, batch);
+            }
+        }
+    }
+
+    // Creates a batch from the transactions at the specified index
+    function _createBatchFromIndex(uint256 batchIndex, uint256 nonce_) private view returns (Batch memory batch) {
+        batch.to = SAFE_MULTISEND_ADDRESS;
+        batch.value = 0;
+        batch.operation = Operation.DELEGATECALL;
+
+        // Concatenate all encoded transactions into a single data payload
+        bytes memory data;
+        uint256 len = batches[batchIndex].encodedTxns.length;
+        for (uint256 i; i < len; ++i) {
+            data = bytes.concat(data, batches[batchIndex].encodedTxns[i]);
+        }
+        batch.data = abi.encodeWithSignature("multiSend(bytes)", data);
+        batch.nonce = nonce_;
+        batch.txHash = _getTransactionHash(safe, batch);
+        return batch;
+    }
+
+    // Returns information about a specific batch
+    function getBatchInfo(uint256 batchIndex) public view returns (uint256 txCount, uint256 gasUsed) {
+        require(batchIndex <= currentBatchIndex, "Invalid batch index");
+        return (batches[batchIndex].encodedTxns.length, batches[batchIndex].totalGas);
+    }
+
+    // Returns the total number of batches
+    function getTotalBatches() public view returns (uint256) {
+        return currentBatchIndex + 1;
+    }
+
+    function _signBatch(address safe_, Batch memory batch_) private returns (Batch memory) {
+        // Get the typed data to sign
+        string memory typedData = _getTypedData(safe_, batch_);
+
+        // Construct the sign command
+        string memory commandStart = "cast wallet sign ";
+        string memory wallet;
+        if (walletType == LOCAL) {
+            wallet = string.concat("--private-key ", vm.toString(privateKey), " ");
+        } else if (walletType == LEDGER) {
+            wallet = string.concat("--ledger --mnemonic-index ", vm.toString(mnemonicIndex), " ");
+        } else {
+            revert("Unsupported wallet type");
+        }
+        string memory commandEnd = "--data ";
+
+        // Sign the typed data from the CLI and get the signature
+        string[] memory inputs = new string[](3);
+        inputs[0] = "bash";
+        inputs[1] = "-c";
+        inputs[2] = string.concat(commandStart, wallet, commandEnd, "'", typedData, "'");
+        bytes memory signature = vm.ffi(inputs);
+
+        // Set the signature on the batch
+        batch_.signature = signature;
+
+        return batch_;
+    }
+
+    function _getSignerAddress() private returns (address signer) {
+        if (walletType == LOCAL) {
+            signer = vm.addr(uint256(privateKey));
+        } else {
+            // LEDGER
+            // For Ledger, we'll need the address from the derivation path
+            string[] memory inputs = new string[](4);
+            inputs[0] = "cast";
+            inputs[1] = "wallet";
+            inputs[2] = "address";
+            inputs[3] = string.concat("--ledger --mnemonic-index ", vm.toString(mnemonicIndex));
+            bytes memory addr = vm.ffi(inputs);
+            signer = address(bytes20(addr));
+        }
+    }
+
+    function _sendBatch(address safe_, Batch memory batch_) private {
+        string memory endpoint = _getSafeTransactionAPIEndpoint(safe_);
+
+        // Create json payload for API call to Gnosis transaction service
+        string memory placeholder = "";
+        placeholder.serialize("safe", safe_);
+        placeholder.serialize("to", batch_.to);
+        placeholder.serialize("value", vm.toString(batch_.value));
+        placeholder.serialize("data", batch_.data);
+        placeholder.serialize("operation", uint256(batch_.operation));
+        placeholder.serialize("gasToken", address(0));
+        placeholder.serialize("safeTxGas", vm.toString(batch_.safeTxGas));
+        placeholder.serialize("baseGas", vm.toString(batch_.baseGas));
+        placeholder.serialize("gasPrice", vm.toString(batch_.gasPrice));
+        string memory txnHash = vm.toString(batch_.txHash);
+        string memory sig = bytesToHexString(batch_.signature);
+        placeholder.serialize("contractTransactionHash", txnHash);
+        console2.log("txnHash", txnHash);
+        console2.log("signer", _getSignerAddress());
+        console2.log("signature", sig);
+        placeholder.serialize("safeTxHash", txnHash);
+        placeholder.serialize("refundReceiver", address(0));
+        placeholder.serialize("nonce", vm.toString(batch_.nonce));
+        placeholder.serialize("signature", sig);
+        string memory payload = placeholder.serialize("sender", vm.toString(_getSignerAddress()));
+
+        // Send batch
+        (uint256 status, bytes memory data) = endpoint.post(_getHeaders(), payload);
+
+        if (status == 200 || status == 201) {
+            console2.log("Batch sent successfully");
+
+            // Construct Safe UI URL
+            string memory safeUrl = string.concat(
+                "https://app.safe.global/transactions/tx?safe=eth:",
+                vm.toString(safe_),
+                "&id=multisig_",
+                vm.toString(safe_),
+                "_",
+                txnHash
+            );
+
+            console2.log("");
+            console2.log("View transaction in Safe:");
+            console2.log(safeUrl);
+        } else {
+            console2.log("Send batch failed with status:", status);
+            console2.log("Response:", string(data));
+            revert("Send batch failed!");
+        }
+    }
+
+    // Computes the EIP712 hash of a Safe transaction.
+    // Look at
+    // https://github.com/safe-global/safe-eth-py/blob/174053920e0717cc9924405e524012c5f953cd8f/gnosis/safe/safe_tx.py#L186
+    // and https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/eip712/__init__.py
+    function _getTransactionHash(address safe_, Batch memory batch_) private view returns (bytes32) {
+        return keccak256(
+            abi.encodePacked(
+                hex"1901",
+                keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, chainId, safe_)),
+                keccak256(
+                    abi.encode(
+                        SAFE_TX_TYPEHASH,
+                        batch_.to,
+                        batch_.value,
+                        keccak256(batch_.data),
+                        batch_.operation,
+                        batch_.safeTxGas,
+                        batch_.baseGas,
+                        batch_.gasPrice,
+                        address(0),
+                        address(0),
+                        batch_.nonce
+                    )
+                )
+            )
+        );
+    }
+
+    function _getTypedData(address safe_, Batch memory batch_) private returns (string memory) {
+        // Create EIP712 structured data for the batch transaction to sign externally via cast
+
+        // EIP712Domain Field Types
+        string[] memory domainTypes = new string[](2);
+        string memory t = "domainType0";
+        vm.serializeString(t, "name", "verifyingContract");
+        domainTypes[0] = vm.serializeString(t, "type", "address");
+        t = "domainType1";
+        vm.serializeString(t, "name", "chainId");
+        domainTypes[1] = vm.serializeString(t, "type", "uint256");
+
+        // SafeTx Field Types
+        string[] memory txnTypes = new string[](10);
+        t = "txnType0";
+        vm.serializeString(t, "name", "to");
+        txnTypes[0] = vm.serializeString(t, "type", "address");
+        t = "txnType1";
+        vm.serializeString(t, "name", "value");
+        txnTypes[1] = vm.serializeString(t, "type", "uint256");
+        t = "txnType2";
+        vm.serializeString(t, "name", "data");
+        txnTypes[2] = vm.serializeString(t, "type", "bytes");
+        t = "txnType3";
+        vm.serializeString(t, "name", "operation");
+        txnTypes[3] = vm.serializeString(t, "type", "uint8");
+        t = "txnType4";
+        vm.serializeString(t, "name", "safeTxGas");
+        txnTypes[4] = vm.serializeString(t, "type", "uint256");
+        t = "txnType5";
+        vm.serializeString(t, "name", "baseGas");
+        txnTypes[5] = vm.serializeString(t, "type", "uint256");
+        t = "txnType6";
+        vm.serializeString(t, "name", "gasPrice");
+        txnTypes[6] = vm.serializeString(t, "type", "uint256");
+        t = "txnType7";
+        vm.serializeString(t, "name", "gasToken");
+        txnTypes[7] = vm.serializeString(t, "type", "address");
+        t = "txnType8";
+        vm.serializeString(t, "name", "refundReceiver");
+        txnTypes[8] = vm.serializeString(t, "type", "address");
+        t = "txnType9";
+        vm.serializeString(t, "name", "nonce");
+        txnTypes[9] = vm.serializeString(t, "type", "uint256");
+
+        // Create the top level types object
+        t = "topLevelTypes";
+        t.serialize("EIP712Domain", domainTypes);
+        string memory types = t.serialize("SafeTx", txnTypes);
+
+        // Create the message object
+        string memory m = "message";
+        m.serialize("to", batch_.to);
+        m.serialize("value", batch_.value);
+        m.serialize("data", batch_.data);
+        m.serialize("operation", uint256(batch_.operation));
+        m.serialize("safeTxGas", batch_.safeTxGas);
+        m.serialize("baseGas", batch_.baseGas);
+        m.serialize("gasPrice", batch_.gasPrice);
+        m.serialize("gasToken", address(0));
+        m.serialize("refundReceiver", address(0));
+        string memory message = m.serialize("nonce", batch_.nonce);
+
+        // Create the domain object
+        string memory d = "domain";
+        d.serialize("verifyingContract", safe_);
+        string memory domain = d.serialize("chainId", chainId);
+
+        // Create the payload object
+        string memory p = "payload";
+        p.serialize("types", types);
+        vm.serializeString(p, "primaryType", "SafeTx");
+        p.serialize("domain", domain);
+        string memory payload = p.serialize("message", message);
+
+        payload = _stripSlashQuotes(payload);
+
+        return payload;
+    }
+
+    function _stripSlashQuotes(string memory str_) private returns (string memory) {
+        // Remove slash quotes from string
+        string memory command = string.concat(
+            "sed 's/",
+            '\\\\"/"',
+            "/g; s/",
+            '\\"',
+            "\\[/\\[/g; s/",
+            '\\]\\"',
+            "/\\]/g; s/",
+            '\\"',
+            "{/{/g; s/",
+            '}\\"',
+            "/}/g;' <<< "
+        );
+
+        string[] memory inputs = new string[](3);
+        inputs[0] = "bash";
+        inputs[1] = "-c";
+        inputs[2] = string.concat(command, "'", str_, "'");
+        bytes memory res = vm.ffi(inputs);
+
+        return string(res);
+    }
+
+    function _getNonce(address safe_) private returns (uint256) {
+        string memory endpoint = string.concat(_getSafeNonceAPIEndpoint(safe_));
+        (uint256 status, bytes memory data) = endpoint.get(_getHeaders());
+        if (status == 200) {
+            string memory resp = string(data);
+            return resp.readUint(".nonce");
+        } else {
+            revert(string(abi.encodePacked("Error fetching nonce: ", vm.toString(status), ", ", string(data))));
+        }
+    }
+
+    function _getSafeTransactionAPIEndpoint(address safe_) private view returns (string memory) {
+        return string.concat(SAFE_API_BASE_URL, "safes/", vm.toString(safe_), "/multisig-transactions/");
+    }
+
+    function _getSafeNonceAPIEndpoint(address safe_) private view returns (string memory) {
+        return string.concat(SAFE_API_BASE_URL, "safes/", vm.toString(safe_), "/");
+    }
+
+    function _getHeaders() private view returns (string[] memory headers) {
+        string memory apiKey = vm.envOr("SAFE_API_KEY", string(""));
+        if (bytes(apiKey).length > 0) {
+            headers = new string[](2);
+            headers[0] = "Content-Type: application/json";
+            headers[1] = string.concat("Authorization: Bearer ", apiKey);
+        } else {
+            headers = new string[](1);
+            headers[0] = "Content-Type: application/json";
+        }
+    }
+
+    // Signatures need to be converted to hex strings with 0x prefix
+    function bytesToHexString(bytes memory data) internal pure returns (string memory) {
+        bytes memory hexChars = "0123456789abcdef";
+        bytes memory hexString = new bytes(data.length * 2);
+
+        for (uint256 i = 0; i < data.length; i++) {
+            hexString[i * 2] = hexChars[uint8(data[i] >> 4)];
+            hexString[i * 2 + 1] = hexChars[uint8(data[i] & 0x0f)];
+        }
+
+        return string(abi.encodePacked("0x", hexString));
+    }
+}

--- a/script/utils/Surl.sol
+++ b/script/utils/Surl.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Vm} from "forge-std/Vm.sol";
+
+library Surl {
+    Vm constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+
+    function get(string memory self) internal returns (uint256 status, bytes memory data) {
+        string[] memory empty = new string[](0);
+        return get(self, empty);
+    }
+
+    function get(string memory self, string[] memory headers) internal returns (uint256 status, bytes memory data) {
+        return curl(self, headers, "", "GET");
+    }
+
+    function del(string memory self) internal returns (uint256 status, bytes memory data) {
+        string[] memory empty = new string[](0);
+        return curl(self, empty, "", "DELETE");
+    }
+
+    function del(string memory self, string memory body) internal returns (uint256 status, bytes memory data) {
+        string[] memory empty = new string[](0);
+        return curl(self, empty, body, "DELETE");
+    }
+
+    function del(string memory self, string[] memory headers, string memory body)
+        internal
+        returns (uint256 status, bytes memory data)
+    {
+        return curl(self, headers, body, "DELETE");
+    }
+
+    function patch(string memory self) internal returns (uint256 status, bytes memory data) {
+        string[] memory empty = new string[](0);
+        return curl(self, empty, "", "PATCH");
+    }
+
+    function patch(string memory self, string memory body) internal returns (uint256 status, bytes memory data) {
+        string[] memory empty = new string[](0);
+        return curl(self, empty, body, "PATCH");
+    }
+
+    function patch(string memory self, string[] memory headers, string memory body)
+        internal
+        returns (uint256 status, bytes memory data)
+    {
+        return curl(self, headers, body, "PATCH");
+    }
+
+    function post(string memory self) internal returns (uint256 status, bytes memory data) {
+        string[] memory empty = new string[](0);
+        return curl(self, empty, "", "POST");
+    }
+
+    function post(string memory self, string memory body) internal returns (uint256 status, bytes memory data) {
+        string[] memory empty = new string[](0);
+        return curl(self, empty, body, "POST");
+    }
+
+    function post(string memory self, string[] memory headers, string memory body)
+        internal
+        returns (uint256 status, bytes memory data)
+    {
+        return curl(self, headers, body, "POST");
+    }
+
+    function put(string memory self) internal returns (uint256 status, bytes memory data) {
+        string[] memory empty = new string[](0);
+        return curl(self, empty, "", "PUT");
+    }
+
+    function put(string memory self, string memory body) internal returns (uint256 status, bytes memory data) {
+        string[] memory empty = new string[](0);
+        return curl(self, empty, body, "PUT");
+    }
+
+    function put(string memory self, string[] memory headers, string memory body)
+        internal
+        returns (uint256 status, bytes memory data)
+    {
+        return curl(self, headers, body, "PUT");
+    }
+
+    function curl(string memory self, string[] memory headers, string memory body, string memory method)
+        internal
+        returns (uint256 status, bytes memory data)
+    {
+        string memory scriptStart = 'response=$(curl -s -w "\\n%{http_code}" ';
+        string memory scriptEnd =
+            '); status=$(tail -n1 <<< "$response"); data=$(sed "$ d" <<< "$response");data=$(echo "$data" | tr -d "\\n"); cast abi-encode "response(uint256,string)" "$status" "$data";';
+
+        string memory curlParams = "";
+
+        for (uint256 i = 0; i < headers.length; i++) {
+            curlParams = string.concat(curlParams, '-H "', headers[i], '" ');
+        }
+
+        curlParams = string.concat(curlParams, " -X ", method, " ");
+
+        if (bytes(body).length > 0) {
+            curlParams = string.concat(curlParams, " -d \'", body, "\' ");
+        }
+
+        string memory quotedURL = string.concat('"', self, '"');
+
+        string[] memory inputs = new string[](3);
+        inputs[0] = "bash";
+        inputs[1] = "-c";
+        inputs[2] = string.concat(scriptStart, curlParams, quotedURL, scriptEnd, "");
+        bytes memory res = vm.ffi(inputs);
+
+        (status, data) = abi.decode(res, (uint256, bytes));
+    }
+}

--- a/script/utils/TimelockHelper.sol
+++ b/script/utils/TimelockHelper.sol
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.2 <0.9.0;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {ITimelockController} from "../../src/interfaces/ITimelockController.sol";
+
+/// @title TimelockHelper
+/// @notice Helper contract for working with TimelockController operations
+/// @dev Designed to work alongside SafeHelper for Safe multisig + Timelock workflows
+abstract contract TimelockHelper is Script {
+    /// @notice TimelockController address (mainnet)
+    address public constant TIMELOCK_MAINNET = 0x1dCcD4628d48a50C1A7adEA3848bcC869f08f8C2;
+
+    /// @notice Timelock address for the current session
+    address public timelock;
+
+    /// @notice Modifier to set the timelock address
+    modifier isTimelock(address _timelock) {
+        timelock = _timelock;
+        _;
+    }
+
+    /// @notice Structure to store operation details for later reference
+    struct TimelockOperation {
+        address[] targets;
+        uint256[] values;
+        bytes[] datas;
+        bytes32 predecessor;
+        bytes32 salt;
+        uint256 delay;
+        bytes32 id;
+    }
+
+    /* ========== ENCODING FUNCTIONS ========== */
+
+    /// @notice Encode a schedule call for a single operation
+    function encodeSchedule(
+        address target,
+        uint256 value,
+        bytes memory data,
+        bytes32 predecessor,
+        bytes32 salt,
+        uint256 delay
+    ) public pure returns (bytes memory) {
+        return abi.encodeCall(ITimelockController.schedule, (target, value, data, predecessor, salt, delay));
+    }
+
+    /// @notice Encode a scheduleBatch call for multiple operations
+    function encodeScheduleBatch(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory datas,
+        bytes32 predecessor,
+        bytes32 salt,
+        uint256 delay
+    ) public pure returns (bytes memory) {
+        return abi.encodeCall(ITimelockController.scheduleBatch, (targets, values, datas, predecessor, salt, delay));
+    }
+
+    /// @notice Encode an execute call for a single operation
+    function encodeExecute(address target, uint256 value, bytes memory data, bytes32 predecessor, bytes32 salt)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodeCall(ITimelockController.execute, (target, value, data, predecessor, salt));
+    }
+
+    /// @notice Encode an executeBatch call for multiple operations
+    function encodeExecuteBatch(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory datas,
+        bytes32 predecessor,
+        bytes32 salt
+    ) public pure returns (bytes memory) {
+        return abi.encodeCall(ITimelockController.executeBatch, (targets, values, datas, predecessor, salt));
+    }
+
+    /// @notice Encode a cancel call
+    function encodeCancel(bytes32 operationId) public pure returns (bytes memory) {
+        return abi.encodeCall(ITimelockController.cancel, (operationId));
+    }
+
+    /* ========== OPERATION ID CALCULATION ========== */
+
+    /// @notice Calculate the operation ID for a single operation
+    function calculateOperationId(address target, uint256 value, bytes memory data, bytes32 predecessor, bytes32 salt)
+        public
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(target, value, data, predecessor, salt));
+    }
+
+    /// @notice Calculate the operation ID for a batch operation
+    function calculateBatchOperationId(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory datas,
+        bytes32 predecessor,
+        bytes32 salt
+    ) public pure returns (bytes32) {
+        return keccak256(abi.encode(targets, values, datas, predecessor, salt));
+    }
+
+    /* ========== STATE CHECKING FUNCTIONS ========== */
+
+    /// @notice Check if an operation exists
+    function isOperation(address _timelock, bytes32 id) public view returns (bool) {
+        return ITimelockController(_timelock).isOperation(id);
+    }
+
+    /// @notice Check if an operation is ready for execution
+    function isOperationReady(address _timelock, bytes32 id) public view returns (bool) {
+        return ITimelockController(_timelock).isOperationReady(id);
+    }
+
+    /// @notice Check if an operation is done
+    function isOperationDone(address _timelock, bytes32 id) public view returns (bool) {
+        return ITimelockController(_timelock).isOperationDone(id);
+    }
+
+    /// @notice Check if an operation is pending (waiting or ready)
+    function isOperationPending(address _timelock, bytes32 id) public view returns (bool) {
+        return ITimelockController(_timelock).isOperationPending(id);
+    }
+
+    /// @notice Get the timestamp when an operation becomes ready
+    function getOperationTimestamp(address _timelock, bytes32 id) public view returns (uint256) {
+        return ITimelockController(_timelock).getTimestamp(id);
+    }
+
+    /// @notice Get the state of an operation
+    function getOperationState(address _timelock, bytes32 id) public view returns (ITimelockController.OperationState) {
+        return ITimelockController(_timelock).getOperationState(id);
+    }
+
+    /// @notice Get the minimum delay for the timelock
+    function getMinDelay(address _timelock) public view returns (uint256) {
+        return ITimelockController(_timelock).getMinDelay();
+    }
+
+    /* ========== UTILITY FUNCTIONS ========== */
+
+    /// @notice Generate a unique salt based on description
+    function generateSalt(string memory description) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(description));
+    }
+
+    /// @notice Log operation details
+    function logOperation(TimelockOperation memory op) internal view {
+        console2.log("=== Timelock Operation ===");
+        console2.log("Operation ID:", vm.toString(op.id));
+        console2.log("Targets:", op.targets.length);
+        for (uint256 i = 0; i < op.targets.length; i++) {
+            console2.log("  Target", i, ":", op.targets[i]);
+            console2.log("  Value", i, ":", op.values[i]);
+        }
+        console2.log("Predecessor:", vm.toString(op.predecessor));
+        console2.log("Salt:", vm.toString(op.salt));
+        console2.log("Delay:", op.delay);
+    }
+
+    /// @notice Log operation state
+    function logOperationState(address _timelock, bytes32 id) internal view {
+        ITimelockController.OperationState state = getOperationState(_timelock, id);
+        console2.log("Operation", vm.toString(id));
+
+        if (state == ITimelockController.OperationState.Unset) {
+            console2.log("  State: Unset (does not exist)");
+        } else if (state == ITimelockController.OperationState.Waiting) {
+            uint256 timestamp = getOperationTimestamp(_timelock, id);
+            console2.log("  State: Waiting");
+            console2.log("  Ready at:", timestamp);
+            console2.log("  Current time:", block.timestamp);
+            console2.log("  Time remaining:", timestamp - block.timestamp);
+        } else if (state == ITimelockController.OperationState.Ready) {
+            console2.log("  State: Ready (can be executed)");
+        } else if (state == ITimelockController.OperationState.Done) {
+            console2.log("  State: Done (already executed)");
+        }
+    }
+
+    /// @notice Create a simple operation for testing or common patterns
+    function createSimpleOperation(address target, bytes memory data, string memory description)
+        public
+        pure
+        returns (TimelockOperation memory)
+    {
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory datas = new bytes[](1);
+
+        targets[0] = target;
+        values[0] = 0;
+        datas[0] = data;
+
+        bytes32 salt = generateSalt(description);
+        bytes32 id = calculateBatchOperationId(targets, values, datas, bytes32(0), salt);
+
+        return TimelockOperation({
+            targets: targets,
+            values: values,
+            datas: datas,
+            predecessor: bytes32(0),
+            salt: salt,
+            delay: 0, // Will be set when scheduling
+            id: id
+        });
+    }
+
+    /// @notice Helper to check if we should proceed with execution
+    function requireOperationReady(address _timelock, bytes32 id) internal view {
+        ITimelockController.OperationState state = getOperationState(_timelock, id);
+
+        if (state == ITimelockController.OperationState.Unset) {
+            revert("Operation does not exist");
+        } else if (state == ITimelockController.OperationState.Waiting) {
+            uint256 timestamp = getOperationTimestamp(_timelock, id);
+            uint256 remaining = timestamp - block.timestamp;
+            revert(string.concat("Operation still waiting. Time remaining: ", vm.toString(remaining), " seconds"));
+        } else if (state == ITimelockController.OperationState.Done) {
+            revert("Operation already executed");
+        }
+        // State is Ready, can proceed
+    }
+
+    /* ========== SIMULATION FUNCTIONS ========== */
+
+    /// @notice Simulate execution of a batch operation to verify it will succeed
+    /// @dev Uses vm.prank to simulate being the timelock and executes each call
+    function simulateExecution(
+        address _timelock,
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory datas
+    ) internal {
+        console2.log("=== Simulating Timelock Execution ===");
+
+        for (uint256 i = 0; i < targets.length; i++) {
+            console2.log("Simulating call %d of %d", i + 1, targets.length);
+            console2.log("  Target:", targets[i]);
+
+            vm.prank(_timelock);
+            (bool success, bytes memory returnData) = targets[i].call{value: values[i]}(datas[i]);
+
+            if (success) {
+                console2.log("  Result: SUCCESS");
+            } else {
+                console2.log("  Result: FAILED");
+                console2.log("  Revert reason:", _getRevertMsg(returnData));
+                revert("Simulation failed - execution would revert");
+            }
+        }
+
+        console2.log("=== All calls simulated successfully ===");
+    }
+
+    /// @notice Extract revert reason from return data
+    function _getRevertMsg(bytes memory returnData) internal pure returns (string memory) {
+        // If the return data is less than 68 bytes, it's not a standard revert
+        if (returnData.length < 68) return "Unknown error";
+
+        // Skip the selector (4 bytes) and decode the string
+        assembly {
+            returnData := add(returnData, 0x04)
+        }
+        return abi.decode(returnData, (string));
+    }
+}

--- a/src/OperationalController.sol
+++ b/src/OperationalController.sol
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.22;
+
+import {AccessControl} from "../lib/openzeppelin/contracts/access/AccessControl.sol";
+import {AccessControlEnumerable} from "../lib/openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
+import {IAccessControl} from "../lib/openzeppelin/contracts/access/IAccessControl.sol";
+import {ICreditLine} from "./interfaces/ICreditLine.sol";
+import {Id, IMorphoCredit, MarketParams} from "./interfaces/IMorpho.sol";
+import {IProtocolConfig} from "./interfaces/IProtocolConfig.sol";
+import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+import {EventsLib} from "./libraries/EventsLib.sol";
+
+/// @title OperationalController
+/// @author 3Jane
+/// @custom:contact support@3jane.xyz
+/// @notice Role-gated proxy for CreditLine and ProtocolConfig that provides tiered access:
+/// OPERATOR_ROLE for routine credit operations, EMERGENCY_AUTHORIZED_ROLE for protocol safety actions.
+/// @dev Deployed as both the CreditLine `ozd` and the ProtocolConfig `emergencyAdmin`.
+/// @dev OWNER_ROLE intentionally keeps DEFAULT_ADMIN_ROLE as its admin, and no account is granted
+/// DEFAULT_ADMIN_ROLE. This preserves a single-owner invariant by making transferOwnership() the only owner
+/// transition path.
+contract OperationalController is AccessControlEnumerable {
+    event CreditLineRevoked(address indexed borrower, address indexed executor);
+
+    /// @notice Role identifier for the owner, which manages all controller roles.
+    bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
+
+    /// @notice Role identifier for accounts allowed to execute emergency actions.
+    bytes32 public constant EMERGENCY_AUTHORIZED_ROLE = keccak256("EMERGENCY_AUTHORIZED_ROLE");
+
+    /// @notice Role identifier for accounts allowed to execute routine credit operations.
+    bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
+
+    /// @notice Address of the ProtocolConfig contract.
+    IProtocolConfig public immutable protocolConfig;
+
+    /// @notice Address of the CreditLine contract.
+    ICreditLine public immutable creditLine;
+
+    /// @notice Initializes immutable contract references and grants initial roles.
+    /// @param _protocolConfig Address of the ProtocolConfig contract.
+    /// @param _creditLine Address of the CreditLine contract.
+    /// @param _owner Initial owner address.
+    /// @param _emergencyAuthorized Initial emergency-authorized accounts.
+    /// @param _operators Initial operator accounts.
+    constructor(
+        address _protocolConfig,
+        address _creditLine,
+        address _owner,
+        address[] memory _emergencyAuthorized,
+        address[] memory _operators
+    ) {
+        if (_owner == address(0) || _protocolConfig == address(0) || _creditLine == address(0)) {
+            revert ErrorsLib.ZeroAddress();
+        }
+
+        protocolConfig = IProtocolConfig(_protocolConfig);
+        creditLine = ICreditLine(_creditLine);
+
+        _grantRole(OWNER_ROLE, _owner);
+        _setRoleAdmin(EMERGENCY_AUTHORIZED_ROLE, OWNER_ROLE);
+        _setRoleAdmin(OPERATOR_ROLE, OWNER_ROLE);
+
+        for (uint256 i = 0; i < _emergencyAuthorized.length; i++) {
+            if (_emergencyAuthorized[i] == address(0)) revert ErrorsLib.ZeroAddress();
+            _grantRole(EMERGENCY_AUTHORIZED_ROLE, _emergencyAuthorized[i]);
+        }
+
+        for (uint256 i = 0; i < _operators.length; i++) {
+            if (_operators[i] == address(0)) revert ErrorsLib.ZeroAddress();
+            _grantRole(OPERATOR_ROLE, _operators[i]);
+        }
+    }
+
+    // ============ Emergency Stop Functions ============
+
+    /// @notice Set an emergency protocol parameter (IS_PAUSED, DEBT_CAP, MAX_ON_CREDIT, USD3_SUPPLY_CAP).
+    /// @dev Delegates to ProtocolConfig.setEmergencyConfig() which enforces binary constraints.
+    function setConfig(bytes32 key, uint256 value) external onlyRole(EMERGENCY_AUTHORIZED_ROLE) {
+        protocolConfig.setEmergencyConfig(key, value);
+    }
+
+    /// @notice Revoke a single borrower's credit line while preserving their current DRP.
+    function emergencyRevokeCreditLine(Id id, address borrower) external onlyRole(EMERGENCY_AUTHORIZED_ROLE) {
+        if (borrower == address(0)) revert ErrorsLib.ZeroAddress();
+
+        address morpho = creditLine.MORPHO();
+        (, uint128 currentDrp,) = IMorphoCredit(morpho).borrowerPremium(id, borrower);
+
+        Id[] memory ids = new Id[](1);
+        address[] memory borrowers = new address[](1);
+        uint256[] memory vv = new uint256[](1);
+        uint256[] memory credit = new uint256[](1);
+        uint128[] memory drp = new uint128[](1);
+
+        ids[0] = id;
+        borrowers[0] = borrower;
+        vv[0] = 1;
+        credit[0] = 0;
+        drp[0] = currentDrp;
+
+        creditLine.setCreditLines(ids, borrowers, vv, credit, drp);
+        emit CreditLineRevoked(borrower, msg.sender);
+    }
+
+    // ============ Operator Functions ============
+
+    /// @notice Batch-set borrower credit lines, DRP, and verified values.
+    function setCreditLines(
+        Id[] calldata ids,
+        address[] calldata borrowers,
+        uint256[] calldata vv,
+        uint256[] calldata credit,
+        uint128[] calldata drp
+    ) external onlyRole(OPERATOR_ROLE) {
+        creditLine.setCreditLines(ids, borrowers, vv, credit, drp);
+    }
+
+    /// @notice Close a payment cycle and post repayment obligations for borrowers.
+    function closeCycleAndPostObligations(
+        Id id,
+        uint256 endDate,
+        address[] calldata borrowers,
+        uint256[] calldata repaymentBps,
+        uint256[] calldata endingBalances
+    ) external onlyRole(OPERATOR_ROLE) {
+        creditLine.closeCycleAndPostObligations(id, endDate, borrowers, repaymentBps, endingBalances);
+    }
+
+    /// @notice Add repayment obligations to the most recently closed cycle.
+    function addObligationsToLatestCycle(
+        Id id,
+        address[] calldata borrowers,
+        uint256[] calldata repaymentBps,
+        uint256[] calldata endingBalances
+    ) external onlyRole(OPERATOR_ROLE) {
+        creditLine.addObligationsToLatestCycle(id, borrowers, repaymentBps, endingBalances);
+    }
+
+    /// @notice Settle a borrower's position, optionally covering losses from the insurance fund.
+    function settle(MarketParams memory marketParams, address borrower, uint256 assets, uint256 cover)
+        external
+        onlyRole(OPERATOR_ROLE)
+        returns (uint256 writtenOffAssets, uint256 writtenOffShares)
+    {
+        return creditLine.settle(marketParams, borrower, assets, cover);
+    }
+
+    // ============ Ownership ============
+
+    /// @notice Transfers ownership to a new address atomically.
+    function transferOwnership(address newOwner) external onlyRole(OWNER_ROLE) {
+        if (newOwner == address(0)) revert ErrorsLib.ZeroAddress();
+        address previousOwner = _msgSender();
+        if (newOwner == previousOwner) revert ErrorsLib.AlreadySet();
+        _grantRole(OWNER_ROLE, newOwner);
+        _revokeRole(OWNER_ROLE, previousOwner);
+        emit EventsLib.SetOwner(newOwner);
+    }
+
+    /// @notice Blocks renouncing OWNER_ROLE to prevent permanent admin lockout.
+    function renounceRole(bytes32 role, address callerConfirmation) public override(AccessControl, IAccessControl) {
+        if (role == OWNER_ROLE) revert ErrorsLib.CannotRenounceOwnerRole();
+        super.renounceRole(role, callerConfirmation);
+    }
+
+    /// @notice Returns the current owner address.
+    function owner() public view returns (address) {
+        uint256 count = getRoleMemberCount(OWNER_ROLE);
+        return count > 0 ? getRoleMember(OWNER_ROLE, 0) : address(0);
+    }
+}

--- a/src/OperationalController.sol
+++ b/src/OperationalController.sol
@@ -16,6 +16,10 @@ import {EventsLib} from "./libraries/EventsLib.sol";
 /// @notice Role-gated proxy for CreditLine and ProtocolConfig that provides tiered access:
 /// OPERATOR_ROLE for routine credit operations, EMERGENCY_AUTHORIZED_ROLE for protocol safety actions.
 /// @dev Deployed as both the CreditLine `ozd` and the ProtocolConfig `emergencyAdmin`.
+/// @dev OPERATOR_ROLE is a trusted operational role. It can grant, resize, or revoke credit lines within
+/// CreditLine validation; post repayment cycles and borrower obligations used by penalty accounting; and call
+/// settle(), including the insurance-fund cover path. This controller does not add per-call caps or rate limits;
+/// operator constraints come from multisig policy, CreditLine validation, and ProtocolConfig limits.
 /// @dev OWNER_ROLE intentionally keeps DEFAULT_ADMIN_ROLE as its admin, and no account is granted
 /// DEFAULT_ADMIN_ROLE. This preserves a single-owner invariant by making transferOwnership() the only owner
 /// transition path.
@@ -95,9 +99,9 @@ contract OperationalController is AccessControlEnumerable {
 
         ids[0] = id;
         borrowers[0] = borrower;
-        vv[0] = 1;
-        credit[0] = 0;
-        drp[0] = currentDrp;
+        vv[0] = 1; // Set minimal vv to avoid division by zero in LTV check.
+        credit[0] = 0; // Revoke credit.
+        drp[0] = currentDrp; // Preserve existing DRP rate.
 
         creditLine.setCreditLines(ids, borrowers, vv, credit, drp);
         emit CreditLineRevoked(borrower, msg.sender);

--- a/src/interfaces/ICreditLine.sol
+++ b/src/interfaces/ICreditLine.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {Id} from "./IMorpho.sol";
+import {Id, MarketParams} from "./IMorpho.sol";
 
 /// @title ICreditLine
 /// @author Morpho Labs
@@ -44,4 +44,26 @@ interface ICreditLine {
         uint256[] calldata credit,
         uint128[] calldata drp
     ) external;
+
+    /// @notice Close a payment cycle and create repayment obligations.
+    function closeCycleAndPostObligations(
+        Id id,
+        uint256 endDate,
+        address[] calldata borrowers,
+        uint256[] calldata repaymentBps,
+        uint256[] calldata endingBalances
+    ) external;
+
+    /// @notice Add obligations to the most recently closed cycle.
+    function addObligationsToLatestCycle(
+        Id id,
+        address[] calldata borrowers,
+        uint256[] calldata repaymentBps,
+        uint256[] calldata endingBalances
+    ) external;
+
+    /// @notice Settle a borrower position.
+    function settle(MarketParams memory marketParams, address borrower, uint256 assets, uint256 cover)
+        external
+        returns (uint256 writtenOffAssets, uint256 writtenOffShares);
 }

--- a/src/interfaces/ITimelockController.sol
+++ b/src/interfaces/ITimelockController.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title ITimelockController
+/// @notice Interface for OpenZeppelin's TimelockController
+interface ITimelockController {
+    /// @notice Role identifiers
+    function PROPOSER_ROLE() external view returns (bytes32);
+    function EXECUTOR_ROLE() external view returns (bytes32);
+    function CANCELLER_ROLE() external view returns (bytes32);
+
+    /// @notice Operation states
+    enum OperationState {
+        Unset,
+        Waiting,
+        Ready,
+        Done
+    }
+
+    /// @notice Events
+    event CallScheduled(
+        bytes32 indexed id,
+        uint256 indexed index,
+        address target,
+        uint256 value,
+        bytes data,
+        bytes32 predecessor,
+        uint256 delay
+    );
+
+    event CallExecuted(bytes32 indexed id, uint256 indexed index, address target, uint256 value, bytes data);
+
+    event CallSalt(bytes32 indexed id, bytes32 salt);
+    event Cancelled(bytes32 indexed id);
+    event MinDelayChange(uint256 oldDuration, uint256 newDuration);
+
+    /// @notice Schedule a single operation
+    function schedule(
+        address target,
+        uint256 value,
+        bytes calldata data,
+        bytes32 predecessor,
+        bytes32 salt,
+        uint256 delay
+    ) external;
+
+    /// @notice Schedule a batch of operations
+    function scheduleBatch(
+        address[] calldata targets,
+        uint256[] calldata values,
+        bytes[] calldata payloads,
+        bytes32 predecessor,
+        bytes32 salt,
+        uint256 delay
+    ) external;
+
+    /// @notice Execute a single operation
+    function execute(address target, uint256 value, bytes calldata payload, bytes32 predecessor, bytes32 salt)
+        external
+        payable;
+
+    /// @notice Execute a batch of operations
+    function executeBatch(
+        address[] calldata targets,
+        uint256[] calldata values,
+        bytes[] calldata payloads,
+        bytes32 predecessor,
+        bytes32 salt
+    ) external payable;
+
+    /// @notice Cancel an operation
+    function cancel(bytes32 id) external;
+
+    /// @notice Get the identifier of a single operation
+    function hashOperation(address target, uint256 value, bytes calldata data, bytes32 predecessor, bytes32 salt)
+        external
+        pure
+        returns (bytes32);
+
+    /// @notice Get the identifier of a batch operation
+    function hashOperationBatch(
+        address[] calldata targets,
+        uint256[] calldata values,
+        bytes[] calldata payloads,
+        bytes32 predecessor,
+        bytes32 salt
+    ) external pure returns (bytes32);
+
+    /// @notice Get timestamp for an operation
+    function getTimestamp(bytes32 id) external view returns (uint256);
+
+    /// @notice Get minimum delay
+    function getMinDelay() external view returns (uint256);
+
+    /// @notice Get operation state
+    function getOperationState(bytes32 id) external view returns (OperationState);
+
+    /// @notice Check if operation exists
+    function isOperation(bytes32 id) external view returns (bool);
+
+    /// @notice Check if operation is pending
+    function isOperationPending(bytes32 id) external view returns (bool);
+
+    /// @notice Check if operation is ready
+    function isOperationReady(bytes32 id) external view returns (bool);
+
+    /// @notice Check if operation is done
+    function isOperationDone(bytes32 id) external view returns (bool);
+
+    /// @notice Update delay (only callable by timelock itself)
+    function updateDelay(uint256 newDelay) external;
+}

--- a/src/mocks/ProxyImports.sol
+++ b/src/mocks/ProxyImports.sol
@@ -9,5 +9,4 @@ import {ProxyAdmin} from "lib/openzeppelin/contracts/proxy/transparent/ProxyAdmi
 // Dummy contract to force Hardhat to generate types for OpenZeppelin proxy contracts
 contract ProxyImports {
     // Empty contract - exists only to ensure proxy contract ABIs are included in compilation
-
-    }
+}

--- a/test/forge/integration/OperationalControllerIntegration.t.sol
+++ b/test/forge/integration/OperationalControllerIntegration.t.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {Test} from "../../../lib/forge-std/src/Test.sol";
+import {
+    TransparentUpgradeableProxy
+} from "../../../lib/openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {CreditLine} from "../../../src/CreditLine.sol";
+import {MorphoCredit} from "../../../src/MorphoCredit.sol";
+import {OperationalController} from "../../../src/OperationalController.sol";
+import {ProtocolConfig} from "../../../src/ProtocolConfig.sol";
+import {IProver} from "../../../src/interfaces/IProver.sol";
+import {IMorpho, IMorphoCredit, Id, MarketParams, Position} from "../../../src/interfaces/IMorpho.sol";
+import {ErrorsLib} from "../../../src/libraries/ErrorsLib.sol";
+import {MarketParamsLib} from "../../../src/libraries/MarketParamsLib.sol";
+import {ERC20Mock} from "../../../src/mocks/ERC20Mock.sol";
+import {IrmMock} from "../../../src/mocks/IrmMock.sol";
+import {OracleMock} from "../../../src/mocks/OracleMock.sol";
+
+contract RejectingProver is IProver {
+    function verify(Id, address, uint256, uint256, uint128) external pure returns (bool) {
+        return false;
+    }
+}
+
+contract OperationalControllerIntegrationTest is Test {
+    using MarketParamsLib for MarketParams;
+
+    ProtocolConfig internal protocolConfig;
+    IMorpho internal morpho;
+    MorphoCredit internal morphoCredit;
+    CreditLine internal creditLine;
+    OperationalController internal controller;
+    RejectingProver internal rejectingProver;
+
+    ERC20Mock internal loanToken;
+    ERC20Mock internal collateralToken;
+    OracleMock internal oracle;
+    IrmMock internal irm;
+
+    address internal protocolOwner;
+    address internal controllerOwner;
+    address internal emergencyMultisig;
+    address internal operator;
+    address internal borrower;
+    address internal secondBorrower;
+
+    MarketParams internal marketParams;
+    Id internal marketId;
+
+    function setUp() public {
+        protocolOwner = makeAddr("ProtocolOwner");
+        controllerOwner = makeAddr("ControllerOwner");
+        emergencyMultisig = makeAddr("EmergencyMultisig");
+        operator = makeAddr("Operator");
+        borrower = makeAddr("Borrower");
+        secondBorrower = makeAddr("SecondBorrower");
+
+        ProtocolConfig protocolConfigImpl = new ProtocolConfig();
+        TransparentUpgradeableProxy protocolConfigProxy = new TransparentUpgradeableProxy(
+            address(protocolConfigImpl),
+            address(this),
+            abi.encodeWithSelector(ProtocolConfig.initialize.selector, protocolOwner)
+        );
+        protocolConfig = ProtocolConfig(address(protocolConfigProxy));
+
+        MorphoCredit morphoImpl = new MorphoCredit(address(protocolConfig));
+        TransparentUpgradeableProxy morphoProxy = new TransparentUpgradeableProxy(
+            address(morphoImpl), address(this), abi.encodeWithSelector(MorphoCredit.initialize.selector, protocolOwner)
+        );
+        morpho = IMorpho(address(morphoProxy));
+        morphoCredit = MorphoCredit(address(morphoProxy));
+
+        loanToken = new ERC20Mock();
+        collateralToken = new ERC20Mock();
+        oracle = new OracleMock();
+        irm = new IrmMock();
+        oracle.setPrice(1e36);
+
+        creditLine = new CreditLine(
+            address(morpho), protocolOwner, makeAddr("InitialOzd"), makeAddr("MarkdownManager"), address(0)
+        );
+        rejectingProver = new RejectingProver();
+
+        address[] memory emergencyAuthorized = _singleAddress(emergencyMultisig);
+        address[] memory operators = _singleAddress(operator);
+        controller = new OperationalController(
+            address(protocolConfig), address(creditLine), controllerOwner, emergencyAuthorized, operators
+        );
+
+        marketParams = MarketParams({
+            loanToken: address(loanToken),
+            collateralToken: address(collateralToken),
+            oracle: address(oracle),
+            irm: address(irm),
+            lltv: 0.8 ether,
+            creditLine: address(creditLine)
+        });
+        marketId = marketParams.id();
+
+        vm.startPrank(protocolOwner);
+        protocolConfig.setConfig(keccak256("MAX_LTV"), 0.8 ether);
+        protocolConfig.setConfig(keccak256("MAX_VV"), 1000 ether);
+        protocolConfig.setConfig(keccak256("MAX_CREDIT_LINE"), 500 ether);
+        protocolConfig.setConfig(keccak256("MIN_CREDIT_LINE"), 0);
+        protocolConfig.setConfig(keccak256("MAX_DRP"), 1_000_000);
+        protocolConfig.setConfig(keccak256("CYCLE_DURATION"), 30 days);
+        morpho.enableIrm(address(irm));
+        morpho.enableLltv(0.8 ether);
+        morpho.createMarket(marketParams);
+        creditLine.setOzd(address(controller));
+        vm.stopPrank();
+    }
+
+    function test_OperatorSetCreditLines_UsesRealCreditLineValidation() public {
+        _operatorSetCreditLine(100 ether, 50 ether, 100);
+
+        Position memory position = morpho.position(marketId, borrower);
+        assertEq(position.collateral, 50 ether);
+
+        (, uint128 drp,) = morphoCredit.borrowerPremium(marketId, borrower);
+        assertEq(drp, 100);
+
+        vm.expectRevert(ErrorsLib.MaxVvExceeded.selector);
+        _operatorSetCreditLine(1000 ether + 1, 1 ether, 0);
+
+        vm.expectRevert(ErrorsLib.MaxCreditLineExceeded.selector);
+        _operatorSetCreditLine(1000 ether, 500 ether + 1, 0);
+
+        vm.expectRevert(ErrorsLib.MaxLtvExceeded.selector);
+        _operatorSetCreditLine(100 ether, 81 ether, 0);
+
+        vm.expectRevert(ErrorsLib.MaxDrpExceeded.selector);
+        _operatorSetCreditLine(100 ether, 50 ether, 1_000_001);
+
+        vm.prank(protocolOwner);
+        creditLine.setProver(address(rejectingProver));
+
+        vm.expectRevert(ErrorsLib.Unverified.selector);
+        _operatorSetCreditLine(100 ether, 50 ether, 0);
+    }
+
+    function test_OperatorCycleFunctions_UseRealMorphoCreditValidation() public {
+        address[] memory borrowers = _singleAddress(borrower);
+        uint256[] memory repaymentBps = _singleUint(500);
+        uint256[] memory endingBalances = _singleUint(100 ether);
+
+        vm.expectRevert(ErrorsLib.NoCyclesExist.selector);
+        vm.prank(operator);
+        controller.addObligationsToLatestCycle(marketId, borrowers, repaymentBps, endingBalances);
+
+        vm.expectRevert(ErrorsLib.CannotCloseFutureCycle.selector);
+        vm.prank(operator);
+        controller.closeCycleAndPostObligations(marketId, block.timestamp + 1, borrowers, repaymentBps, endingBalances);
+
+        vm.expectRevert(ErrorsLib.InconsistentInput.selector);
+        vm.prank(operator);
+        controller.closeCycleAndPostObligations(marketId, block.timestamp, borrowers, new uint256[](0), endingBalances);
+
+        vm.prank(operator);
+        controller.closeCycleAndPostObligations(marketId, block.timestamp, borrowers, repaymentBps, endingBalances);
+
+        assertEq(morphoCredit.paymentCycle(marketId, 0), block.timestamp);
+        (uint128 cycleId, uint128 amountDue, uint128 endingBalance) =
+            morphoCredit.repaymentObligation(marketId, borrower);
+        assertEq(cycleId, 0);
+        assertEq(amountDue, 5 ether);
+        assertEq(endingBalance, 100 ether);
+
+        vm.expectRevert(ErrorsLib.RepaymentExceedsHundredPercent.selector);
+        vm.prank(operator);
+        controller.addObligationsToLatestCycle(marketId, borrowers, _singleUint(10001), endingBalances);
+
+        address[] memory secondBorrowers = _singleAddress(secondBorrower);
+        vm.prank(operator);
+        controller.addObligationsToLatestCycle(marketId, secondBorrowers, _singleUint(250), _singleUint(200 ether));
+
+        (cycleId, amountDue, endingBalance) = morphoCredit.repaymentObligation(marketId, secondBorrower);
+        assertEq(cycleId, 0);
+        assertEq(amountDue, 5 ether);
+        assertEq(endingBalance, 200 ether);
+    }
+
+    function _operatorSetCreditLine(uint256 vv, uint256 credit, uint128 drp) internal {
+        Id[] memory ids = new Id[](1);
+        address[] memory borrowers = new address[](1);
+        uint256[] memory vvs = new uint256[](1);
+        uint256[] memory credits = new uint256[](1);
+        uint128[] memory drps = new uint128[](1);
+
+        ids[0] = marketId;
+        borrowers[0] = borrower;
+        vvs[0] = vv;
+        credits[0] = credit;
+        drps[0] = drp;
+
+        vm.prank(operator);
+        controller.setCreditLines(ids, borrowers, vvs, credits, drps);
+    }
+
+    function _singleAddress(address value) internal pure returns (address[] memory values) {
+        values = new address[](1);
+        values[0] = value;
+    }
+
+    function _singleUint(uint256 value) internal pure returns (uint256[] memory values) {
+        values = new uint256[](1);
+        values[0] = value;
+    }
+}

--- a/test/forge/unit/OperationalControllerTest.sol
+++ b/test/forge/unit/OperationalControllerTest.sol
@@ -1,0 +1,695 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {Test} from "../../../lib/forge-std/src/Test.sol";
+import {OperationalController} from "../../../src/OperationalController.sol";
+import {ProtocolConfig} from "../../../src/ProtocolConfig.sol";
+import {CreditLine} from "../../../src/CreditLine.sol";
+import {Id, MarketParams} from "../../../src/interfaces/IMorpho.sol";
+import {
+    TransparentUpgradeableProxy
+} from "../../../lib/openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ErrorsLib} from "../../../src/libraries/ErrorsLib.sol";
+import {EventsLib} from "../../../src/libraries/EventsLib.sol";
+import {ERC20Mock} from "../../../src/mocks/ERC20Mock.sol";
+
+contract OperationalMockMorphoCredit {
+    address public protocolConfig;
+
+    mapping(Id => mapping(address => uint128)) public borrowerDrp;
+    mapping(Id => mapping(address => uint256)) public borrowerCredit;
+
+    Id public lastCreditId;
+    address public lastCreditBorrower;
+    uint256 public lastCredit;
+    uint128 public lastDrp;
+
+    Id public lastCloseId;
+    uint256 public lastCloseEndDate;
+    uint256 public lastCloseBorrowerCount;
+    address public lastCloseFirstBorrower;
+    uint256 public lastCloseFirstRepaymentBps;
+    uint256 public lastCloseFirstEndingBalance;
+
+    Id public lastAddId;
+    uint256 public lastAddBorrowerCount;
+    address public lastAddFirstBorrower;
+    uint256 public lastAddFirstRepaymentBps;
+    uint256 public lastAddFirstEndingBalance;
+
+    MarketParams public lastSettledMarketParams;
+    address public lastSettledBorrower;
+    MarketParams public lastRepaidMarketParams;
+    address public lastRepaidBorrower;
+    uint256 public lastRepayAssets;
+
+    constructor(address _protocolConfig) {
+        protocolConfig = _protocolConfig;
+    }
+
+    function setCreditLine(Id id, address borrower, uint256 credit, uint128 drp) external {
+        borrowerCredit[id][borrower] = credit;
+        borrowerDrp[id][borrower] = drp;
+        lastCreditId = id;
+        lastCreditBorrower = borrower;
+        lastCredit = credit;
+        lastDrp = drp;
+    }
+
+    function borrowerPremium(Id id, address borrower) external view returns (uint128, uint128, uint128) {
+        return (uint128(block.timestamp), borrowerDrp[id][borrower], 0);
+    }
+
+    function closeCycleAndPostObligations(
+        Id id,
+        uint256 endDate,
+        address[] calldata borrowers,
+        uint256[] calldata repaymentBps,
+        uint256[] calldata endingBalances
+    ) external {
+        lastCloseId = id;
+        lastCloseEndDate = endDate;
+        lastCloseBorrowerCount = borrowers.length;
+        if (borrowers.length > 0) {
+            lastCloseFirstBorrower = borrowers[0];
+            lastCloseFirstRepaymentBps = repaymentBps[0];
+            lastCloseFirstEndingBalance = endingBalances[0];
+        }
+    }
+
+    function addObligationsToLatestCycle(
+        Id id,
+        address[] calldata borrowers,
+        uint256[] calldata repaymentBps,
+        uint256[] calldata endingBalances
+    ) external {
+        lastAddId = id;
+        lastAddBorrowerCount = borrowers.length;
+        if (borrowers.length > 0) {
+            lastAddFirstBorrower = borrowers[0];
+            lastAddFirstRepaymentBps = repaymentBps[0];
+            lastAddFirstEndingBalance = endingBalances[0];
+        }
+    }
+
+    function repay(MarketParams memory marketParams, uint256 assets, uint256, address borrower, bytes memory)
+        external
+        returns (uint256, uint256)
+    {
+        lastRepaidMarketParams = marketParams;
+        lastRepaidBorrower = borrower;
+        lastRepayAssets = assets;
+        return (assets, 0);
+    }
+
+    function settleAccount(MarketParams memory marketParams, address borrower) external returns (uint256, uint256) {
+        lastSettledMarketParams = marketParams;
+        lastSettledBorrower = borrower;
+        return (100 ether, 50 ether);
+    }
+}
+
+contract OperationalMockInsuranceFund {
+    address public lastToken;
+    uint256 public lastAmount;
+
+    function bring(address loanToken, uint256 amount) external {
+        lastToken = loanToken;
+        lastAmount = amount;
+    }
+}
+
+contract OperationalControllerTest is Test {
+    OperationalController internal controller;
+    ProtocolConfig internal protocolConfig;
+    CreditLine internal creditLine;
+    OperationalMockMorphoCredit internal mockMorpho;
+    OperationalMockInsuranceFund internal mockInsuranceFund;
+
+    address internal protocolOwner;
+    address internal owner;
+    address internal emergencyMultisig;
+    address internal operator;
+    address internal randomUser;
+
+    bytes32 private constant DEFAULT_ADMIN_ROLE = 0x00;
+    bytes32 private constant IS_PAUSED = keccak256("IS_PAUSED");
+    bytes32 private constant DEBT_CAP = keccak256("DEBT_CAP");
+    bytes32 private constant MAX_ON_CREDIT = keccak256("MAX_ON_CREDIT");
+    bytes32 private constant USD3_SUPPLY_CAP = keccak256("USD3_SUPPLY_CAP");
+
+    function setUp() public {
+        protocolOwner = makeAddr("ProtocolOwner");
+        owner = makeAddr("Owner");
+        emergencyMultisig = makeAddr("EmergencyMultisig");
+        operator = makeAddr("Operator");
+        randomUser = makeAddr("RandomUser");
+
+        ProtocolConfig protocolConfigImpl = new ProtocolConfig();
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(protocolConfigImpl),
+            address(this),
+            abi.encodeWithSelector(ProtocolConfig.initialize.selector, protocolOwner)
+        );
+        protocolConfig = ProtocolConfig(address(proxy));
+
+        mockMorpho = new OperationalMockMorphoCredit(address(protocolConfig));
+        mockInsuranceFund = new OperationalMockInsuranceFund();
+
+        creditLine = new CreditLine(
+            address(mockMorpho), protocolOwner, makeAddr("InitialOzd"), makeAddr("MarkdownManager"), address(0)
+        );
+
+        vm.startPrank(protocolOwner);
+        creditLine.setInsuranceFund(address(mockInsuranceFund));
+        protocolConfig.setConfig(keccak256("MAX_LTV"), 1e18);
+        protocolConfig.setConfig(keccak256("MAX_VV"), 10000 ether);
+        protocolConfig.setConfig(keccak256("MAX_CREDIT_LINE"), 5000 ether);
+        protocolConfig.setConfig(keccak256("MIN_CREDIT_LINE"), 0);
+        protocolConfig.setConfig(keccak256("MAX_DRP"), 1000000);
+        vm.stopPrank();
+
+        address[] memory emergencyAuthorized = new address[](1);
+        emergencyAuthorized[0] = emergencyMultisig;
+        address[] memory operators = new address[](1);
+        operators[0] = operator;
+
+        controller = new OperationalController(
+            address(protocolConfig), address(creditLine), owner, emergencyAuthorized, operators
+        );
+
+        vm.startPrank(protocolOwner);
+        protocolConfig.setEmergencyAdmin(address(controller));
+        creditLine.setOzd(address(controller));
+        vm.stopPrank();
+    }
+
+    function test_Constructor_InvalidAddress() public {
+        address[] memory emergencyAuthorized = _single(emergencyMultisig);
+        address[] memory operators = _single(operator);
+
+        vm.expectRevert(ErrorsLib.ZeroAddress.selector);
+        new OperationalController(address(0), address(creditLine), owner, emergencyAuthorized, operators);
+
+        vm.expectRevert(ErrorsLib.ZeroAddress.selector);
+        new OperationalController(address(protocolConfig), address(0), owner, emergencyAuthorized, operators);
+
+        vm.expectRevert(ErrorsLib.ZeroAddress.selector);
+        new OperationalController(
+            address(protocolConfig), address(creditLine), address(0), emergencyAuthorized, operators
+        );
+    }
+
+    function test_Constructor_ZeroAddressInRoleArrays() public {
+        address[] memory emergencyAuthorized = new address[](2);
+        emergencyAuthorized[0] = emergencyMultisig;
+        emergencyAuthorized[1] = address(0);
+        address[] memory operators = _single(operator);
+
+        vm.expectRevert(ErrorsLib.ZeroAddress.selector);
+        new OperationalController(address(protocolConfig), address(creditLine), owner, emergencyAuthorized, operators);
+
+        emergencyAuthorized = _single(emergencyMultisig);
+        operators = new address[](2);
+        operators[0] = operator;
+        operators[1] = address(0);
+
+        vm.expectRevert(ErrorsLib.ZeroAddress.selector);
+        new OperationalController(address(protocolConfig), address(creditLine), owner, emergencyAuthorized, operators);
+    }
+
+    function test_Constructor_SetsCorrectValuesAndRoles() public {
+        address operator2 = makeAddr("Operator2");
+        address emergency2 = makeAddr("Emergency2");
+
+        address[] memory emergencyAuthorized = new address[](2);
+        emergencyAuthorized[0] = emergencyMultisig;
+        emergencyAuthorized[1] = emergency2;
+        address[] memory operators = new address[](2);
+        operators[0] = operator;
+        operators[1] = operator2;
+
+        OperationalController fresh = new OperationalController(
+            address(protocolConfig), address(creditLine), owner, emergencyAuthorized, operators
+        );
+
+        assertEq(address(fresh.protocolConfig()), address(protocolConfig));
+        assertEq(address(fresh.creditLine()), address(creditLine));
+        assertEq(fresh.owner(), owner);
+        assertTrue(fresh.hasRole(fresh.EMERGENCY_AUTHORIZED_ROLE(), emergencyMultisig));
+        assertTrue(fresh.hasRole(fresh.EMERGENCY_AUTHORIZED_ROLE(), emergency2));
+        assertTrue(fresh.hasRole(fresh.OPERATOR_ROLE(), operator));
+        assertTrue(fresh.hasRole(fresh.OPERATOR_ROLE(), operator2));
+        assertEq(fresh.getRoleMemberCount(fresh.OWNER_ROLE()), 1);
+        assertEq(fresh.getRoleMemberCount(fresh.EMERGENCY_AUTHORIZED_ROLE()), 2);
+        assertEq(fresh.getRoleMemberCount(fresh.OPERATOR_ROLE()), 2);
+        assertEq(fresh.getRoleAdmin(fresh.OWNER_ROLE()), DEFAULT_ADMIN_ROLE);
+        assertEq(fresh.getRoleAdmin(fresh.EMERGENCY_AUTHORIZED_ROLE()), fresh.OWNER_ROLE());
+        assertEq(fresh.getRoleAdmin(fresh.OPERATOR_ROLE()), fresh.OWNER_ROLE());
+        assertEq(fresh.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 0);
+    }
+
+    function test_SetConfig_Pause_OnlyEmergencyAuthorized() public {
+        vm.prank(emergencyMultisig);
+        controller.setConfig(IS_PAUSED, 1);
+        assertEq(protocolConfig.config(IS_PAUSED), 1);
+
+        vm.expectRevert(_accessControlError(randomUser, controller.EMERGENCY_AUTHORIZED_ROLE()));
+        vm.prank(randomUser);
+        controller.setConfig(IS_PAUSED, 1);
+    }
+
+    function test_SetConfig_EnforcesEmergencyConfigConstraints() public {
+        vm.prank(emergencyMultisig);
+        controller.setConfig(IS_PAUSED, 1);
+
+        vm.prank(emergencyMultisig);
+        vm.expectRevert(ProtocolConfig.EmergencyCanOnlyPause.selector);
+        controller.setConfig(IS_PAUSED, 0);
+
+        vm.prank(emergencyMultisig);
+        controller.setConfig(DEBT_CAP, 0);
+
+        vm.prank(emergencyMultisig);
+        vm.expectRevert(ProtocolConfig.EmergencyCanOnlySetToZero.selector);
+        controller.setConfig(DEBT_CAP, 1000);
+
+        vm.prank(emergencyMultisig);
+        controller.setConfig(MAX_ON_CREDIT, 0);
+
+        vm.prank(emergencyMultisig);
+        controller.setConfig(USD3_SUPPLY_CAP, 0);
+
+        vm.prank(emergencyMultisig);
+        vm.expectRevert(ProtocolConfig.UnauthorizedEmergencyConfig.selector);
+        controller.setConfig(keccak256("RANDOM_PARAM"), 0);
+    }
+
+    function test_EmergencyRevokeCreditLine_PreservesDrpAndEmits() public {
+        Id marketId = Id.wrap(bytes32(uint256(1)));
+        address borrower = makeAddr("Borrower");
+        uint128 originalDrp = 500;
+
+        _setCreditLine(marketId, borrower, 1000 ether, 500 ether, originalDrp);
+        assertEq(mockMorpho.borrowerDrp(marketId, borrower), originalDrp);
+
+        vm.expectEmit(true, true, false, true);
+        emit OperationalController.CreditLineRevoked(borrower, emergencyMultisig);
+
+        vm.prank(emergencyMultisig);
+        controller.emergencyRevokeCreditLine(marketId, borrower);
+
+        assertEq(mockMorpho.borrowerCredit(marketId, borrower), 0);
+        assertEq(mockMorpho.borrowerDrp(marketId, borrower), originalDrp);
+    }
+
+    function test_EmergencyRevokeCreditLine_AccessAndZeroBorrower() public {
+        Id marketId = Id.wrap(bytes32(uint256(1)));
+        address borrower = makeAddr("Borrower");
+
+        vm.expectRevert(_accessControlError(randomUser, controller.EMERGENCY_AUTHORIZED_ROLE()));
+        vm.prank(randomUser);
+        controller.emergencyRevokeCreditLine(marketId, borrower);
+
+        vm.expectRevert(ErrorsLib.ZeroAddress.selector);
+        vm.prank(emergencyMultisig);
+        controller.emergencyRevokeCreditLine(marketId, address(0));
+    }
+
+    function test_OperatorSetCreditLines_ForwardsArgs() public {
+        Id marketId = Id.wrap(bytes32(uint256(2)));
+        address borrower = makeAddr("Borrower");
+
+        _operatorSetCreditLine(marketId, borrower, 2000 ether, 750 ether, 123);
+
+        assertEq(Id.unwrap(mockMorpho.lastCreditId()), Id.unwrap(marketId));
+        assertEq(mockMorpho.lastCreditBorrower(), borrower);
+        assertEq(mockMorpho.lastCredit(), 750 ether);
+        assertEq(mockMorpho.lastDrp(), 123);
+    }
+
+    function test_OperatorCloseCycle_ForwardsArgs() public {
+        Id marketId = Id.wrap(bytes32(uint256(3)));
+        address borrower = makeAddr("Borrower");
+        address[] memory borrowers = _single(borrower);
+        uint256[] memory repaymentBps = _singleUint(500);
+        uint256[] memory endingBalances = _singleUint(1000 ether);
+
+        vm.prank(operator);
+        controller.closeCycleAndPostObligations(marketId, 123456, borrowers, repaymentBps, endingBalances);
+
+        assertEq(Id.unwrap(mockMorpho.lastCloseId()), Id.unwrap(marketId));
+        assertEq(mockMorpho.lastCloseEndDate(), 123456);
+        assertEq(mockMorpho.lastCloseBorrowerCount(), 1);
+        assertEq(mockMorpho.lastCloseFirstBorrower(), borrower);
+        assertEq(mockMorpho.lastCloseFirstRepaymentBps(), 500);
+        assertEq(mockMorpho.lastCloseFirstEndingBalance(), 1000 ether);
+    }
+
+    function test_OperatorAddObligations_ForwardsArgs() public {
+        Id marketId = Id.wrap(bytes32(uint256(4)));
+        address borrower = makeAddr("Borrower");
+        address[] memory borrowers = _single(borrower);
+        uint256[] memory repaymentBps = _singleUint(250);
+        uint256[] memory endingBalances = _singleUint(400 ether);
+
+        vm.prank(operator);
+        controller.addObligationsToLatestCycle(marketId, borrowers, repaymentBps, endingBalances);
+
+        assertEq(Id.unwrap(mockMorpho.lastAddId()), Id.unwrap(marketId));
+        assertEq(mockMorpho.lastAddBorrowerCount(), 1);
+        assertEq(mockMorpho.lastAddFirstBorrower(), borrower);
+        assertEq(mockMorpho.lastAddFirstRepaymentBps(), 250);
+        assertEq(mockMorpho.lastAddFirstEndingBalance(), 400 ether);
+    }
+
+    function test_OperatorSettle_ForwardsArgsAndReturnsValues() public {
+        MarketParams memory marketParams = _marketParams();
+        address borrower = makeAddr("Borrower");
+
+        vm.prank(operator);
+        (uint256 writtenOffAssets, uint256 writtenOffShares) = controller.settle(marketParams, borrower, 100 ether, 0);
+
+        assertEq(writtenOffAssets, 100 ether);
+        assertEq(writtenOffShares, 50 ether);
+        assertEq(mockMorpho.lastSettledBorrower(), borrower);
+
+        (address loanToken,,,,,) = mockMorpho.lastSettledMarketParams();
+        assertEq(loanToken, marketParams.loanToken);
+    }
+
+    function test_OperatorSettle_WithNonzeroCover_UsesInsuranceFundPath() public {
+        ERC20Mock loanToken = new ERC20Mock();
+        MarketParams memory marketParams = _marketParams();
+        marketParams.loanToken = address(loanToken);
+        address borrower = makeAddr("Borrower");
+        uint256 cover = 25 ether;
+
+        vm.prank(operator);
+        (uint256 writtenOffAssets, uint256 writtenOffShares) =
+            controller.settle(marketParams, borrower, 100 ether, cover);
+
+        assertEq(writtenOffAssets, 100 ether);
+        assertEq(writtenOffShares, 50 ether);
+        assertEq(mockInsuranceFund.lastToken(), address(loanToken));
+        assertEq(mockInsuranceFund.lastAmount(), cover);
+        assertEq(loanToken.allowance(address(creditLine), address(mockMorpho)), cover);
+        assertEq(mockMorpho.lastRepaidBorrower(), borrower);
+        assertEq(mockMorpho.lastRepayAssets(), cover);
+        assertEq(mockMorpho.lastSettledBorrower(), borrower);
+
+        (address repaidLoanToken,,,,,) = mockMorpho.lastRepaidMarketParams();
+        assertEq(repaidLoanToken, address(loanToken));
+    }
+
+    function test_OperatorSettle_RevertsWhenCoverExceedsAssets() public {
+        vm.prank(operator);
+        vm.expectRevert(ErrorsLib.InvalidCoverAmount.selector);
+        controller.settle(_marketParams(), makeAddr("Borrower"), 100 ether, 101 ether);
+    }
+
+    function test_OperatorFunctions_RejectNonOperators() public {
+        Id marketId = Id.wrap(bytes32(uint256(5)));
+        address borrower = makeAddr("Borrower");
+        bytes memory operatorError = _accessControlError(randomUser, controller.OPERATOR_ROLE());
+
+        vm.expectRevert(operatorError);
+        vm.prank(randomUser);
+        _callSetCreditLines(marketId, borrower);
+
+        vm.expectRevert(operatorError);
+        vm.prank(randomUser);
+        controller.closeCycleAndPostObligations(marketId, 1, _single(borrower), _singleUint(1), _singleUint(1));
+
+        vm.expectRevert(operatorError);
+        vm.prank(randomUser);
+        controller.addObligationsToLatestCycle(marketId, _single(borrower), _singleUint(1), _singleUint(1));
+
+        vm.expectRevert(operatorError);
+        vm.prank(randomUser);
+        controller.settle(_marketParams(), borrower, 100 ether, 0);
+    }
+
+    function test_RoleIsolation() public {
+        Id marketId = Id.wrap(bytes32(uint256(6)));
+        address borrower = makeAddr("Borrower");
+        bytes memory operatorMissingEmergencyRole =
+            _accessControlError(operator, controller.EMERGENCY_AUTHORIZED_ROLE());
+        bytes memory emergencyMissingOperatorRole = _accessControlError(emergencyMultisig, controller.OPERATOR_ROLE());
+        bytes memory ownerMissingEmergencyRole = _accessControlError(owner, controller.EMERGENCY_AUTHORIZED_ROLE());
+        bytes memory ownerMissingOperatorRole = _accessControlError(owner, controller.OPERATOR_ROLE());
+
+        vm.expectRevert(operatorMissingEmergencyRole);
+        vm.prank(operator);
+        controller.setConfig(IS_PAUSED, 1);
+
+        vm.expectRevert(operatorMissingEmergencyRole);
+        vm.prank(operator);
+        controller.emergencyRevokeCreditLine(marketId, borrower);
+
+        vm.expectRevert(emergencyMissingOperatorRole);
+        vm.prank(emergencyMultisig);
+        _callSetCreditLines(marketId, borrower);
+
+        vm.expectRevert(emergencyMissingOperatorRole);
+        vm.prank(emergencyMultisig);
+        controller.closeCycleAndPostObligations(marketId, 1, _single(borrower), _singleUint(1), _singleUint(1));
+
+        vm.expectRevert(emergencyMissingOperatorRole);
+        vm.prank(emergencyMultisig);
+        controller.addObligationsToLatestCycle(marketId, _single(borrower), _singleUint(1), _singleUint(1));
+
+        vm.expectRevert(emergencyMissingOperatorRole);
+        vm.prank(emergencyMultisig);
+        controller.settle(_marketParams(), borrower, 100 ether, 0);
+
+        vm.expectRevert(ownerMissingEmergencyRole);
+        vm.prank(owner);
+        controller.setConfig(IS_PAUSED, 1);
+
+        vm.expectRevert(ownerMissingEmergencyRole);
+        vm.prank(owner);
+        controller.emergencyRevokeCreditLine(marketId, borrower);
+
+        vm.expectRevert(ownerMissingOperatorRole);
+        vm.prank(owner);
+        _callSetCreditLines(marketId, borrower);
+
+        vm.expectRevert(ownerMissingOperatorRole);
+        vm.prank(owner);
+        controller.closeCycleAndPostObligations(marketId, 1, _single(borrower), _singleUint(1), _singleUint(1));
+
+        vm.expectRevert(ownerMissingOperatorRole);
+        vm.prank(owner);
+        controller.addObligationsToLatestCycle(marketId, _single(borrower), _singleUint(1), _singleUint(1));
+
+        vm.expectRevert(ownerMissingOperatorRole);
+        vm.prank(owner);
+        controller.settle(_marketParams(), borrower, 100 ether, 0);
+    }
+
+    function test_TransferOwnership_Success() public {
+        address newOwner = makeAddr("NewOwner");
+
+        vm.expectEmit(true, false, false, true);
+        emit EventsLib.SetOwner(newOwner);
+
+        vm.prank(owner);
+        controller.transferOwnership(newOwner);
+
+        assertEq(controller.owner(), newOwner);
+        assertFalse(controller.hasRole(controller.OWNER_ROLE(), owner));
+        assertTrue(controller.hasRole(controller.OWNER_ROLE(), newOwner));
+        assertEq(controller.getRoleMemberCount(controller.OWNER_ROLE()), 1);
+    }
+
+    function test_TransferOwnership_Reverts() public {
+        vm.expectRevert(ErrorsLib.ZeroAddress.selector);
+        vm.prank(owner);
+        controller.transferOwnership(address(0));
+
+        vm.expectRevert(ErrorsLib.AlreadySet.selector);
+        vm.prank(owner);
+        controller.transferOwnership(owner);
+
+        vm.expectRevert(_accessControlError(randomUser, controller.OWNER_ROLE()));
+        vm.prank(randomUser);
+        controller.transferOwnership(makeAddr("NewOwner"));
+    }
+
+    function test_RenounceRole_BlockedForOwnerRoleAllowedForOthers() public {
+        bytes32 ownerRole = controller.OWNER_ROLE();
+        bytes32 operatorRole = controller.OPERATOR_ROLE();
+        bytes32 emergencyRole = controller.EMERGENCY_AUTHORIZED_ROLE();
+
+        vm.expectRevert(ErrorsLib.CannotRenounceOwnerRole.selector);
+        vm.prank(owner);
+        controller.renounceRole(ownerRole, owner);
+
+        assertTrue(controller.hasRole(operatorRole, operator));
+
+        vm.prank(operator);
+        controller.renounceRole(operatorRole, operator);
+
+        assertFalse(controller.hasRole(operatorRole, operator));
+
+        assertTrue(controller.hasRole(emergencyRole, emergencyMultisig));
+
+        vm.prank(emergencyMultisig);
+        controller.renounceRole(emergencyRole, emergencyMultisig);
+
+        assertFalse(controller.hasRole(emergencyRole, emergencyMultisig));
+    }
+
+    function test_OwnerRole_CannotBeManagedThroughAccessControl() public {
+        address extraOwner = makeAddr("ExtraOwner");
+        bytes32 ownerRole = controller.OWNER_ROLE();
+
+        assertEq(controller.getRoleAdmin(ownerRole), DEFAULT_ADMIN_ROLE);
+        assertEq(controller.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 0);
+
+        vm.expectRevert(_accessControlError(owner, DEFAULT_ADMIN_ROLE));
+        vm.prank(owner);
+        controller.grantRole(ownerRole, extraOwner);
+
+        vm.expectRevert(_accessControlError(owner, DEFAULT_ADMIN_ROLE));
+        vm.prank(owner);
+        controller.revokeRole(ownerRole, owner);
+
+        assertEq(controller.owner(), owner);
+        assertTrue(controller.hasRole(ownerRole, owner));
+        assertFalse(controller.hasRole(ownerRole, extraOwner));
+        assertEq(controller.getRoleMemberCount(ownerRole), 1);
+    }
+
+    function test_OwnerCanGrantAndRevokeRoles() public {
+        address newEmergency = makeAddr("NewEmergency");
+        address newOperator = makeAddr("NewOperator");
+
+        vm.startPrank(owner);
+        controller.grantRole(controller.EMERGENCY_AUTHORIZED_ROLE(), newEmergency);
+        controller.grantRole(controller.OPERATOR_ROLE(), newOperator);
+        assertTrue(controller.hasRole(controller.EMERGENCY_AUTHORIZED_ROLE(), newEmergency));
+        assertTrue(controller.hasRole(controller.OPERATOR_ROLE(), newOperator));
+
+        controller.revokeRole(controller.EMERGENCY_AUTHORIZED_ROLE(), newEmergency);
+        controller.revokeRole(controller.OPERATOR_ROLE(), newOperator);
+        vm.stopPrank();
+
+        assertFalse(controller.hasRole(controller.EMERGENCY_AUTHORIZED_ROLE(), newEmergency));
+        assertFalse(controller.hasRole(controller.OPERATOR_ROLE(), newOperator));
+    }
+
+    function test_NonOwnersCannotManageRoles() public {
+        address target = makeAddr("Target");
+        bytes32 ownerRole = controller.OWNER_ROLE();
+        bytes32 operatorRole = controller.OPERATOR_ROLE();
+        bytes32 emergencyRole = controller.EMERGENCY_AUTHORIZED_ROLE();
+
+        vm.expectRevert(_accessControlError(emergencyMultisig, ownerRole));
+        vm.prank(emergencyMultisig);
+        controller.grantRole(operatorRole, target);
+
+        vm.expectRevert(_accessControlError(operator, ownerRole));
+        vm.prank(operator);
+        controller.grantRole(emergencyRole, target);
+    }
+
+    function test_IntegrationScenario_OperatorCreditEmergencyRevokeOperatorSettle() public {
+        Id marketId = Id.wrap(bytes32(uint256(7)));
+        address borrower = makeAddr("Borrower");
+        uint128 drp = 77;
+
+        _operatorSetCreditLine(marketId, borrower, 1000 ether, 600 ether, drp);
+        assertEq(mockMorpho.borrowerCredit(marketId, borrower), 600 ether);
+
+        vm.prank(emergencyMultisig);
+        controller.emergencyRevokeCreditLine(marketId, borrower);
+
+        assertEq(mockMorpho.borrowerCredit(marketId, borrower), 0);
+        assertEq(mockMorpho.borrowerDrp(marketId, borrower), drp);
+
+        vm.prank(operator);
+        (uint256 writtenOffAssets, uint256 writtenOffShares) =
+            controller.settle(_marketParams(), borrower, 100 ether, 0);
+
+        assertEq(writtenOffAssets, 100 ether);
+        assertEq(writtenOffShares, 50 ether);
+        assertEq(mockMorpho.lastSettledBorrower(), borrower);
+    }
+
+    function _operatorSetCreditLine(Id marketId, address borrower, uint256 vv, uint256 credit, uint128 drp) internal {
+        Id[] memory ids = new Id[](1);
+        address[] memory borrowers = new address[](1);
+        uint256[] memory vvs = new uint256[](1);
+        uint256[] memory credits = new uint256[](1);
+        uint128[] memory drps = new uint128[](1);
+
+        ids[0] = marketId;
+        borrowers[0] = borrower;
+        vvs[0] = vv;
+        credits[0] = credit;
+        drps[0] = drp;
+
+        vm.prank(operator);
+        controller.setCreditLines(ids, borrowers, vvs, credits, drps);
+    }
+
+    function _setCreditLine(Id marketId, address borrower, uint256 vv, uint256 credit, uint128 drp) internal {
+        Id[] memory ids = new Id[](1);
+        address[] memory borrowers = new address[](1);
+        uint256[] memory vvs = new uint256[](1);
+        uint256[] memory credits = new uint256[](1);
+        uint128[] memory drps = new uint128[](1);
+
+        ids[0] = marketId;
+        borrowers[0] = borrower;
+        vvs[0] = vv;
+        credits[0] = credit;
+        drps[0] = drp;
+
+        vm.prank(address(controller));
+        creditLine.setCreditLines(ids, borrowers, vvs, credits, drps);
+    }
+
+    function _callSetCreditLines(Id marketId, address borrower) internal {
+        Id[] memory ids = new Id[](1);
+        address[] memory borrowers = new address[](1);
+        uint256[] memory vvs = new uint256[](1);
+        uint256[] memory credits = new uint256[](1);
+        uint128[] memory drps = new uint128[](1);
+
+        ids[0] = marketId;
+        borrowers[0] = borrower;
+        vvs[0] = 1000 ether;
+        credits[0] = 500 ether;
+        drps[0] = 1;
+
+        controller.setCreditLines(ids, borrowers, vvs, credits, drps);
+    }
+
+    function _marketParams() internal returns (MarketParams memory) {
+        return MarketParams({
+            loanToken: makeAddr("LoanToken"),
+            collateralToken: makeAddr("CollateralToken"),
+            oracle: makeAddr("Oracle"),
+            irm: makeAddr("Irm"),
+            lltv: 0,
+            creditLine: address(creditLine)
+        });
+    }
+
+    function _single(address value) internal pure returns (address[] memory values) {
+        values = new address[](1);
+        values[0] = value;
+    }
+
+    function _singleUint(uint256 value) internal pure returns (uint256[] memory values) {
+        values = new uint256[](1);
+        values[0] = value;
+    }
+
+    function _accessControlError(address account, bytes32 role) internal pure returns (bytes memory) {
+        return abi.encodeWithSignature("AccessControlUnauthorizedAccount(address,bytes32)", account, role);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `OperationalController` as a superset of `EmergencyController`, adding `OPERATOR_ROLE` for routine credit operations (`setCreditLines`, `closeCycleAndPostObligations`, `addObligationsToLatestCycle`, `settle`) alongside the existing `EMERGENCY_AUTHORIZED_ROLE` for protocol safety actions
- Extends `ICreditLine` interface with 3 missing function signatures (`closeCycleAndPostObligations`, `addObligationsToLatestCycle`, `settle`)
- Adds deployment scripts following the EC v2 timelock upgrade pattern (deploy → schedule → execute)
- Adds script utilities (`SafeHelper`, `TimelockHelper`, `Surl`)

## Motivation

Enables tiered governance: frequent operational tasks (credit lines, cycles, settlements) go through a smaller operational multisig via `OPERATOR_ROLE`, while emergency actions (pause, zero caps, revoke credit) remain gated by `EMERGENCY_AUTHORIZED_ROLE` (Hypernative + multisig), and governance (upgrades, global config) stays behind the timelock.

Deployed as both the CreditLine `ozd` and the ProtocolConfig `emergencyAdmin`, replacing EmergencyController.

## Test plan

- [x] 22 unit tests covering constructor validation, access control, role isolation, passthrough argument forwarding, insurance fund path, ownership transfer, renounce blocking, and end-to-end integration
- [ ] Dry-run deployment scripts against mainnet fork
- [x] Verify existing test suite still passes (`yarn test:forge:noninvariant`)