### PR TITLE
feat(usd3): add restartStrategy reinitializer to reverse emergency shutdown

### DIFF
--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -135,9 +135,10 @@ contract USD3 is BaseHooksUpgradeable {
     }
 
     /**
-     * @notice Reinitialize the USD3 strategy to switch asset from waUSDC to USDC
+     * @notice Legacy v2 migration hook that switched the strategy asset from waUSDC to USDC.
      * @dev This function was used during the one-time migration from the previous USD3 implementation.
-     *      Historical migration sequence (already completed in production):
+     *      The migration is complete and this reinitializer is already consumed in production.
+     *      Historical migration sequence:
      *      1. Set performance fee to 0 (via setPerformanceFee)
      *      2. Set profit unlock time to 0 (via setProfitMaxUnlockTime)
      *      3. Call report() on OLD implementation to finalize state before upgrade
@@ -156,6 +157,14 @@ contract USD3 is BaseHooksUpgradeable {
         TokenizedStrategyStorageLib.StrategyData storage strategyData = TokenizedStrategyStorageLib.getStrategyStorage();
         strategyData.asset = ERC20(usdc);
         IERC20(usdc).forceApprove(address(WAUSDC), type(uint256).max);
+    }
+
+    /**
+     * @notice Restart the strategy after an emergency shutdown.
+     * @dev Intended to be consumed atomically through ProxyAdmin.upgradeAndCall during the v3 restart upgrade.
+     */
+    function restartStrategy() external reinitializer(3) {
+        TokenizedStrategyStorageLib.getStrategyStorage().shutdown = false;
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/forge/usd3/integration/USD3RestartStrategy.t.sol
+++ b/test/forge/usd3/integration/USD3RestartStrategy.t.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.18;
+
+import {Setup} from "../utils/Setup.sol";
+import {USD3} from "../../../../src/usd3/USD3.sol";
+import {IUSD3} from "../../../../src/usd3/interfaces/IUSD3.sol";
+import {MorphoCredit} from "../../../../src/MorphoCredit.sol";
+import {IMorpho} from "../../../../src/interfaces/IMorpho.sol";
+import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
+import {TokenizedStrategyStorageLib} from "@periphery/libraries/TokenizedStrategyStorageLib.sol";
+import {ERC1967Utils} from "../../../../lib/openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+import {Initializable} from "../../../../lib/openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {
+    TransparentUpgradeableProxy,
+    ITransparentUpgradeableProxy
+} from "../../../../lib/openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "../../../../lib/openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+contract USD3RestartStrategyTest is Setup {
+    uint256 internal constant NOT_ENTERED = 1;
+    uint256 internal constant ENTERED_OFFSET = 160;
+    uint256 internal constant SHUTDOWN_OFFSET = 168;
+
+    address internal alice = makeAddr("alice");
+    address internal bob = makeAddr("bob");
+
+    function test_restartStrategyReopensShutdownStrategyAtomically() public {
+        (USD3 usd3, ProxyAdmin proxyAdmin) = _deployRestartableUSD3();
+        ITokenizedStrategy tokenized = ITokenizedStrategy(address(usd3));
+
+        _deposit(usd3, alice, 1_000e6);
+
+        vm.prank(management);
+        tokenized.shutdownStrategy();
+
+        assertTrue(tokenized.isShutdown(), "strategy should be shutdown");
+        _assertPackedStatusSlot(address(usd3), NOT_ENTERED, 1);
+
+        _upgradeAndRestart(usd3, proxyAdmin);
+
+        assertFalse(tokenized.isShutdown(), "strategy should be restarted");
+        _assertPackedStatusSlot(address(usd3), NOT_ENTERED, 0);
+        assertGt(tokenized.maxDeposit(bob), 0, "deposits should be available");
+
+        uint256 shares = _deposit(usd3, bob, 500e6);
+        assertGt(shares, 0, "deposit should succeed after restart");
+    }
+
+    function test_restartStrategyCanOnlyRunOnce() public {
+        (USD3 usd3, ProxyAdmin proxyAdmin) = _deployRestartableUSD3();
+        ITokenizedStrategy tokenized = ITokenizedStrategy(address(usd3));
+
+        _deposit(usd3, alice, 1_000e6);
+
+        vm.prank(management);
+        tokenized.shutdownStrategy();
+
+        _upgradeAndRestart(usd3, proxyAdmin);
+
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        usd3.restartStrategy();
+    }
+
+    function test_restartStrategySupportsEmergencyWithdrawRecoveryPath() public {
+        (USD3 usd3, ProxyAdmin proxyAdmin) = _deployRestartableUSD3();
+        ITokenizedStrategy tokenized = ITokenizedStrategy(address(usd3));
+
+        _deposit(usd3, alice, 1_000e6);
+
+        vm.prank(management);
+        tokenized.shutdownStrategy();
+
+        vm.prank(management);
+        tokenized.emergencyWithdraw(1_000e6);
+
+        _upgradeAndRestart(usd3, proxyAdmin);
+
+        uint256 shares = _deposit(usd3, bob, 500e6);
+
+        vm.prank(bob);
+        uint256 withdrawn = tokenized.redeem(shares, bob, bob);
+
+        assertApproxEqAbs(withdrawn, 500e6, 1, "redeem should work after restart");
+    }
+
+    function _deployRestartableUSD3() internal returns (USD3 usd3, ProxyAdmin proxyAdmin) {
+        USD3 implementation = new USD3();
+        USD3 setupStrategy = USD3(address(strategy));
+
+        bytes memory initData = abi.encodeWithSelector(
+            USD3.initialize.selector,
+            address(setupStrategy.morphoCredit()),
+            setupStrategy.marketId(),
+            management,
+            keeper
+        );
+
+        TransparentUpgradeableProxy proxy =
+            new TransparentUpgradeableProxy(address(implementation), address(this), initData);
+
+        proxyAdmin = ProxyAdmin(address(uint160(uint256(vm.load(address(proxy), ERC1967Utils.ADMIN_SLOT)))));
+        usd3 = USD3(address(proxy));
+
+        usd3.reinitialize();
+
+        vm.prank(management);
+        ITokenizedStrategy(address(usd3)).setEmergencyAdmin(emergencyAdmin);
+
+        IMorpho morpho = setupStrategy.morphoCredit();
+        vm.prank(morpho.owner());
+        MorphoCredit(address(morpho)).setUsd3(address(usd3));
+    }
+
+    function _upgradeAndRestart(USD3 usd3, ProxyAdmin proxyAdmin) internal {
+        USD3 newImplementation = new USD3();
+        proxyAdmin.upgradeAndCall(
+            ITransparentUpgradeableProxy(address(usd3)),
+            address(newImplementation),
+            abi.encodeCall(USD3.restartStrategy, ())
+        );
+    }
+
+    function _deposit(USD3 usd3, address account, uint256 amount) internal returns (uint256 shares) {
+        mintAndDepositIntoStrategy(IUSD3(address(usd3)), account, amount);
+        shares = ITokenizedStrategy(address(usd3)).balanceOf(account);
+    }
+
+    function _assertPackedStatusSlot(address usd3, uint256 expectedEntered, uint256 expectedShutdown) internal view {
+        uint256 value = uint256(vm.load(usd3, TokenizedStrategyStorageLib.emergencyAdminSlot()));
+
+        assertEq(address(uint160(value)), emergencyAdmin, "emergency admin mismatch");
+        assertEq((value >> ENTERED_OFFSET) & 0xFF, expectedEntered, "entered mismatch");
+        assertEq((value >> SHUTDOWN_OFFSET) & 0xFF, expectedShutdown, "shutdown mismatch");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `USD3.restartStrategy()` (`reinitializer(3)`) that clears the Yearn TokenizedStrategy shutdown flag via the `StrategyData` struct field, preserving the adjacent `entered` reentrancy byte that shares packed slot 12 with `emergencyAdmin` and `shutdown`.
- Retags the v2 `reinitialize()` docstring as historical; v2 behavior unchanged.
- Adds `test/forge/usd3/integration/USD3RestartStrategy.t.sol` covering atomic reopen via `proxyAdmin.upgradeAndCall(.., abi.encodeCall(USD3.restartStrategy, ()))`, one-shot enforcement (`InvalidInitialization()`), packed-slot regression on slot 12, and the full op path.

## Operational runbook (v3 restart)

1. `strategy.shutdownStrategy()` — already done in prod
2. `strategy.emergencyWithdraw(...)` — already done in prod
3. `proxyAdmin.upgradeAndCall(proxy, newImpl, abi.encodeCall(USD3.restartStrategy, ()))` — single atomic tx
4. Verify on-chain: `isShutdown() == false`, deposit/redeem round-trip works

Differs from the v2 multisig pattern (`upgradeAndCall(.., bytes(""))` + separate `reinitialize()`).

## Test plan

- [x] \`yarn build:forge\` — clean
- [x] \`yarn test:forge --match-path 'test/forge/usd3/integration/USD3RestartStrategy.t.sol' -vv\` — 3/3 pass
- [x] \`yarn test:forge --match-path 'test/forge/usd3/unit/ReinitializeTest.t.sol'\` — 8/8 pass (no v2 regression)
- [x] \`yarn test:forge --match-path 'test/forge/usd3/integration/USD3Upgrade*.t.sol'\` — 14/14 pass
- [ ] Fork dry-run: shutdown → emergencyWithdraw → upgradeAndCall → deposit → redeem