### PR TITLE
feat(usd3): add committed liquidity facility

### DIFF
--- a/src/libraries/ProtocolConfigLib.sol
+++ b/src/libraries/ProtocolConfigLib.sol
@@ -9,6 +9,7 @@ library ProtocolConfigLib {
     bytes32 internal constant IS_PAUSED = keccak256("IS_PAUSED");
     bytes32 internal constant MAX_ON_CREDIT = keccak256("MAX_ON_CREDIT");
     bytes32 internal constant DEBT_CAP = keccak256("DEBT_CAP");
+    bytes32 internal constant COMMITTED_LIQUIDITY = keccak256("COMMITTED_LIQUIDITY");
 
     // Credit Line Keys
     bytes32 internal constant MIN_LOAN_DURATION = keccak256("MIN_LOAN_DURATION");

--- a/src/libraries/ProtocolConfigLib.sol
+++ b/src/libraries/ProtocolConfigLib.sol
@@ -10,6 +10,7 @@ library ProtocolConfigLib {
     bytes32 internal constant MAX_ON_CREDIT = keccak256("MAX_ON_CREDIT");
     bytes32 internal constant DEBT_CAP = keccak256("DEBT_CAP");
     bytes32 internal constant COMMITTED_LIQUIDITY = keccak256("COMMITTED_LIQUIDITY");
+    bytes32 internal constant COMMITTED_LIQUIDITY_FACILITY = keccak256("COMMITTED_LIQUIDITY_FACILITY");
 
     // Credit Line Keys
     bytes32 internal constant MIN_LOAN_DURATION = keccak256("MIN_LOAN_DURATION");

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -13,6 +13,7 @@ import {Pausable} from "../../lib/openzeppelin/contracts/utils/Pausable.sol";
 import {TokenizedStrategyStorageLib, ERC20} from "@periphery/libraries/TokenizedStrategyStorageLib.sol";
 import {IProtocolConfig} from "../interfaces/IProtocolConfig.sol";
 import {ProtocolConfigLib} from "../libraries/ProtocolConfigLib.sol";
+import {UtilsLib} from "../libraries/UtilsLib.sol";
 
 /**
  * @title USD3
@@ -400,6 +401,7 @@ contract USD3 is BaseHooksUpgradeable {
         }
 
         uint256 availableLiquidity = idleAsset + WAUSDC.convertToAssets(availableWaUSDC);
+        availableLiquidity = UtilsLib.zeroFloorSub(availableLiquidity, committedLiquidity());
 
         // During shutdown, bypass all checks
         if (TokenizedStrategy.isShutdown()) {
@@ -640,6 +642,15 @@ contract USD3 is BaseHooksUpgradeable {
     function supplyCap() public view returns (uint256) {
         IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
         return config.config(ProtocolConfigLib.USD3_SUPPLY_CAP);
+    }
+
+    /**
+     * @notice Get the liquidity reserved from USD3 withdrawals to back committed future loans
+     * @return Reserved amount in asset (USDC) units
+     */
+    function committedLiquidity() public view returns (uint256) {
+        IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
+        return config.config(ProtocolConfigLib.COMMITTED_LIQUIDITY);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -231,21 +231,14 @@ contract USD3 is BaseHooksUpgradeable {
     /// @dev Get the strategy's currently liquid assets, including local and Morpho-redeemable waUSDC.
     function _liquidAssets() internal view returns (uint256) {
         uint256 idleAsset = asset.balanceOf(address(this));
+        if (Pausable(address(WAUSDC)).paused()) return idleAsset;
 
         (, uint256 waUSDCMax, uint256 waUSDCLiquidity) = getPosition();
+        uint256 localWaUSDC = Math.min(balanceOfWaUSDC(), WAUSDC.maxRedeem(address(this)));
+        uint256 morphoWaUSDC = Math.min(waUSDCMax, waUSDCLiquidity);
+        morphoWaUSDC = Math.min(morphoWaUSDC, WAUSDC.maxRedeem(address(morphoCredit)));
 
-        uint256 availableWaUSDC;
-
-        if (Pausable(address(WAUSDC)).paused()) {
-            availableWaUSDC = 0;
-        } else {
-            uint256 localWaUSDC = Math.min(balanceOfWaUSDC(), WAUSDC.maxRedeem(address(this)));
-            uint256 morphoWaUSDC = Math.min(waUSDCMax, waUSDCLiquidity);
-            morphoWaUSDC = Math.min(morphoWaUSDC, WAUSDC.maxRedeem(address(morphoCredit)));
-            availableWaUSDC = localWaUSDC + morphoWaUSDC;
-        }
-
-        return idleAsset + WAUSDC.convertToAssets(availableWaUSDC);
+        return idleAsset + WAUSDC.convertToAssets(localWaUSDC + morphoWaUSDC);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -762,10 +755,7 @@ contract USD3 is BaseHooksUpgradeable {
         require(config.getIsPaused() == 0, "Protocol paused");
         require(assets <= availableCommittedLiquidity(), "Exceeds commitment");
 
-        uint256 idleAssets = asset.balanceOf(address(this));
-        if (assets > idleAssets) {
-            _freeFunds(assets - idleAssets);
-        }
+        _freeFunds(UtilsLib.zeroFloorSub(assets, asset.balanceOf(address(this))));
         require(asset.balanceOf(address(this)) >= assets, "Insufficient liquidity");
 
         committedLiquidityDrawn += assets;

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -754,19 +754,19 @@ contract USD3 is BaseHooksUpgradeable {
      * @param assets Amount of USDC to draw
      */
     function drawCommittedLiquidity(uint256 assets) external {
-        require(assets > 0, "USD3/zero-draw");
+        require(assets > 0, "Invalid draw amount");
         address facility = committedLiquidityFacility();
-        require(facility != address(0) && msg.sender == facility, "USD3/not-facility");
-        require(!TokenizedStrategy.isShutdown(), "USD3/shutdown");
+        require(facility != address(0) && msg.sender == facility, "Unauthorized facility");
+        require(!TokenizedStrategy.isShutdown(), "Strategy shutdown");
         IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
-        require(config.getIsPaused() == 0, "USD3/paused");
-        require(assets <= availableCommittedLiquidity(), "USD3/exceeds-commitment");
+        require(config.getIsPaused() == 0, "Protocol paused");
+        require(assets <= availableCommittedLiquidity(), "Exceeds commitment");
 
         uint256 idleAssets = asset.balanceOf(address(this));
-        if (idleAssets < assets) {
+        if (assets > idleAssets) {
             _freeFunds(assets - idleAssets);
         }
-        require(asset.balanceOf(address(this)) >= assets, "USD3/insufficient-liquid");
+        require(asset.balanceOf(address(this)) >= assets, "Insufficient liquidity");
 
         committedLiquidityDrawn += assets;
         IERC20(asset).safeTransfer(facility, assets);
@@ -780,8 +780,8 @@ contract USD3 is BaseHooksUpgradeable {
     function repayCommittedLiquidity(uint256 assets) external {
         uint256 drawn = committedLiquidityDrawn;
         if (assets == type(uint256).max) assets = drawn;
-        require(assets > 0, "USD3/zero-repay");
-        require(assets <= drawn, "USD3/overpayment");
+        require(assets > 0, "Invalid repay amount");
+        require(assets <= drawn, "Repay exceeds drawn");
 
         committedLiquidityDrawn = drawn - assets;
         IERC20(asset).safeTransferFrom(msg.sender, address(this), assets);
@@ -794,7 +794,7 @@ contract USD3 is BaseHooksUpgradeable {
      */
     function writeDownCommittedLiquidity(uint256 assets) external onlyManagement {
         uint256 drawn = committedLiquidityDrawn;
-        require(assets > 0 && assets <= drawn, "USD3/bad-writedown");
+        require(assets > 0 && assets <= drawn, "Invalid writedown amount");
 
         committedLiquidityDrawn = drawn - assets;
         emit CommittedLiquidityWrittenDown(assets, committedLiquidityDrawn);

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -92,6 +92,9 @@ contract USD3 is BaseHooksUpgradeable {
     /// @dev Used to enforce commitment periods
     mapping(address => uint256) public depositTimestamp;
 
+    /// @notice Principal drawn through the committed liquidity facility and not yet repaid or written down
+    uint256 public committedLiquidityDrawn;
+
     /*//////////////////////////////////////////////////////////////
                             EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -100,6 +103,9 @@ contract USD3 is BaseHooksUpgradeable {
     event DepositorWhitelistUpdated(address indexed depositor, bool allowed);
     event MinDepositUpdated(uint256 newMinDeposit);
     event TrancheShareSynced(uint256 trancheShare);
+    event CommittedLiquidityDrawn(address indexed facility, uint256 assets, uint256 totalDrawn);
+    event CommittedLiquidityRepaid(address indexed payer, uint256 assets, uint256 totalDrawn);
+    event CommittedLiquidityWrittenDown(uint256 assets, uint256 totalDrawn);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -222,6 +228,26 @@ contract USD3 is BaseHooksUpgradeable {
         waUSDCMax = shares.toAssetsDown(totalSupplyAssets, totalShares);
     }
 
+    /// @dev Get the strategy's currently liquid assets, including local and Morpho-redeemable waUSDC.
+    function _liquidAssets() internal view returns (uint256) {
+        uint256 idleAsset = asset.balanceOf(address(this));
+
+        (, uint256 waUSDCMax, uint256 waUSDCLiquidity) = getPosition();
+
+        uint256 availableWaUSDC;
+
+        if (Pausable(address(WAUSDC)).paused()) {
+            availableWaUSDC = 0;
+        } else {
+            uint256 localWaUSDC = Math.min(balanceOfWaUSDC(), WAUSDC.maxRedeem(address(this)));
+            uint256 morphoWaUSDC = Math.min(waUSDCMax, waUSDCLiquidity);
+            morphoWaUSDC = Math.min(morphoWaUSDC, WAUSDC.maxRedeem(address(morphoCredit)));
+            availableWaUSDC = localWaUSDC + morphoWaUSDC;
+        }
+
+        return idleAsset + WAUSDC.convertToAssets(availableWaUSDC);
+    }
+
     /*//////////////////////////////////////////////////////////////
                     INTERNAL STRATEGY FUNCTIONS
     //////////////////////////////////////////////////////////////*/
@@ -309,7 +335,7 @@ contract USD3 is BaseHooksUpgradeable {
 
         uint256 totalWaUSDC = suppliedWaUSDC() + balanceOfWaUSDC();
 
-        return WAUSDC.convertToAssets(totalWaUSDC) + asset.balanceOf(address(this));
+        return WAUSDC.convertToAssets(totalWaUSDC) + asset.balanceOf(address(this)) + committedLiquidityDrawn;
     }
 
     /// @dev Rebalances between idle and deployed funds to maintain maxOnCredit ratio
@@ -384,24 +410,7 @@ contract USD3 is BaseHooksUpgradeable {
     /// @param _owner Address to check limit for
     /// @return Maximum amount that can be withdrawn
     function availableWithdrawLimit(address _owner) public view override returns (uint256) {
-        // Get available liquidity first
-        uint256 idleAsset = asset.balanceOf(address(this));
-
-        (, uint256 waUSDCMax, uint256 waUSDCLiquidity) = getPosition();
-
-        uint256 availableWaUSDC;
-
-        if (Pausable(address(WAUSDC)).paused()) {
-            availableWaUSDC = 0;
-        } else {
-            uint256 localWaUSDC = Math.min(balanceOfWaUSDC(), WAUSDC.maxRedeem(address(this)));
-            uint256 morphoWaUSDC = Math.min(waUSDCMax, waUSDCLiquidity);
-            morphoWaUSDC = Math.min(morphoWaUSDC, WAUSDC.maxRedeem(address(morphoCredit)));
-            availableWaUSDC = localWaUSDC + morphoWaUSDC;
-        }
-
-        uint256 availableLiquidity = idleAsset + WAUSDC.convertToAssets(availableWaUSDC);
-        availableLiquidity = UtilsLib.zeroFloorSub(availableLiquidity, committedLiquidity());
+        uint256 availableLiquidity = UtilsLib.zeroFloorSub(_liquidAssets(), availableCommittedLiquidity());
 
         // During shutdown, bypass all checks
         if (TokenizedStrategy.isShutdown()) {
@@ -653,6 +662,31 @@ contract USD3 is BaseHooksUpgradeable {
         return config.config(ProtocolConfigLib.COMMITTED_LIQUIDITY);
     }
 
+    /**
+     * @notice Get the authorized committed liquidity facility address
+     * @return Facility address stored in ProtocolConfig, or the zero address if unset
+     */
+    function committedLiquidityFacility() public view returns (address) {
+        IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
+        return address(uint160(config.config(ProtocolConfigLib.COMMITTED_LIQUIDITY_FACILITY)));
+    }
+
+    /**
+     * @notice Get the undrawn committed liquidity still reserved from USD3 withdrawals
+     * @return Undrawn commitment amount in asset (USDC) units
+     */
+    function availableCommittedLiquidity() public view returns (uint256) {
+        return UtilsLib.zeroFloorSub(committedLiquidity(), committedLiquidityDrawn);
+    }
+
+    /**
+     * @notice Get the maximum amount the committed liquidity facility can currently draw
+     * @return Drawable amount in asset (USDC) units
+     */
+    function maxCommittedLiquidityDraw() public view returns (uint256) {
+        return Math.min(availableCommittedLiquidity(), _liquidAssets());
+    }
+
     /*//////////////////////////////////////////////////////////////
                         MANAGEMENT FUNCTIONS
     //////////////////////////////////////////////////////////////*/
@@ -709,6 +743,61 @@ contract USD3 is BaseHooksUpgradeable {
     function setMinDeposit(uint256 _minDeposit) external onlyManagement {
         minDeposit = _minDeposit;
         emit MinDepositUpdated(_minDeposit);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        FACILITY FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Draw USDC from the committed liquidity facility
+     * @param assets Amount of USDC to draw
+     */
+    function drawCommittedLiquidity(uint256 assets) external {
+        require(assets > 0, "USD3/zero-draw");
+        address facility = committedLiquidityFacility();
+        require(facility != address(0) && msg.sender == facility, "USD3/not-facility");
+        require(!TokenizedStrategy.isShutdown(), "USD3/shutdown");
+        IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
+        require(config.getIsPaused() == 0, "USD3/paused");
+        require(assets <= availableCommittedLiquidity(), "USD3/exceeds-commitment");
+
+        uint256 idleAssets = asset.balanceOf(address(this));
+        if (idleAssets < assets) {
+            _freeFunds(assets - idleAssets);
+        }
+        require(asset.balanceOf(address(this)) >= assets, "USD3/insufficient-liquid");
+
+        committedLiquidityDrawn += assets;
+        IERC20(asset).safeTransfer(facility, assets);
+        emit CommittedLiquidityDrawn(facility, assets, committedLiquidityDrawn);
+    }
+
+    /**
+     * @notice Repay drawn committed liquidity principal
+     * @param assets Amount of USDC to repay, or type(uint256).max to repay all drawn principal
+     */
+    function repayCommittedLiquidity(uint256 assets) external {
+        uint256 drawn = committedLiquidityDrawn;
+        if (assets == type(uint256).max) assets = drawn;
+        require(assets > 0, "USD3/zero-repay");
+        require(assets <= drawn, "USD3/overpayment");
+
+        committedLiquidityDrawn = drawn - assets;
+        IERC20(asset).safeTransferFrom(msg.sender, address(this), assets);
+        emit CommittedLiquidityRepaid(msg.sender, assets, committedLiquidityDrawn);
+    }
+
+    /**
+     * @notice Write down drawn committed liquidity principal as a loss
+     * @param assets Amount of drawn principal to write down
+     */
+    function writeDownCommittedLiquidity(uint256 assets) external onlyManagement {
+        uint256 drawn = committedLiquidityDrawn;
+        require(assets > 0 && assets <= drawn, "USD3/bad-writedown");
+
+        committedLiquidityDrawn = drawn - assets;
+        emit CommittedLiquidityWrittenDown(assets, committedLiquidityDrawn);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -770,5 +859,5 @@ contract USD3 is BaseHooksUpgradeable {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[40] private __gap;
+    uint256[39] private __gap;
 }

--- a/src/usd3/interfaces/IUSD3.sol
+++ b/src/usd3/interfaces/IUSD3.sol
@@ -13,6 +13,9 @@ interface IUSD3 is IStrategy {
     event WhitelistUpdated(address indexed user, bool allowed);
     event MinDepositUpdated(uint256 newMinDeposit);
     event TrancheShareSynced(uint256 trancheShare);
+    event CommittedLiquidityDrawn(address indexed facility, uint256 assets, uint256 totalDrawn);
+    event CommittedLiquidityRepaid(address indexed payer, uint256 assets, uint256 totalDrawn);
+    event CommittedLiquidityWrittenDown(uint256 assets, uint256 totalDrawn);
 
     /*//////////////////////////////////////////////////////////////
                         VIEW FUNCTIONS
@@ -34,6 +37,11 @@ interface IUSD3 is IStrategy {
     function minCommitmentTime() external view returns (uint256);
     function depositTimestamp(address user) external view returns (uint256);
     function maxSubordinationRatio() external view returns (uint256);
+    function committedLiquidity() external view returns (uint256);
+    function committedLiquidityDrawn() external view returns (uint256);
+    function committedLiquidityFacility() external view returns (address);
+    function availableCommittedLiquidity() external view returns (uint256);
+    function maxCommittedLiquidityDraw() external view returns (uint256);
 
     /*//////////////////////////////////////////////////////////////
                     MANAGEMENT FUNCTIONS
@@ -44,6 +52,9 @@ interface IUSD3 is IStrategy {
     function setWhitelist(address _user, bool _allowed) external;
     function setDepositorWhitelist(address _depositor, bool _allowed) external;
     function setMinDeposit(uint256 _minDeposit) external;
+    function drawCommittedLiquidity(uint256 assets) external;
+    function repayCommittedLiquidity(uint256 assets) external;
+    function writeDownCommittedLiquidity(uint256 assets) external;
 
     /*//////////////////////////////////////////////////////////////
                         KEEPER FUNCTIONS

--- a/src/usd3/interfaces/IUSD3.sol
+++ b/src/usd3/interfaces/IUSD3.sol
@@ -52,9 +52,14 @@ interface IUSD3 is IStrategy {
     function setWhitelist(address _user, bool _allowed) external;
     function setDepositorWhitelist(address _depositor, bool _allowed) external;
     function setMinDeposit(uint256 _minDeposit) external;
+    function writeDownCommittedLiquidity(uint256 assets) external;
+
+    /*//////////////////////////////////////////////////////////////
+                        FACILITY FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
     function drawCommittedLiquidity(uint256 assets) external;
     function repayCommittedLiquidity(uint256 assets) external;
-    function writeDownCommittedLiquidity(uint256 assets) external;
 
     /*//////////////////////////////////////////////////////////////
                         KEEPER FUNCTIONS

--- a/src/usd3/sUSD3.sol
+++ b/src/usd3/sUSD3.sol
@@ -420,27 +420,36 @@ contract sUSD3 is BaseHooksUpgradeable {
         return config.config(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO);
     }
 
+    /// @dev Returns Morpho market debt converted to USDC, plus drawn committed liquidity.
+    function _actualExposureInUSDC(USD3 usd3) internal view returns (uint256) {
+        (,, uint256 totalBorrowAssetsWaUSDC,) = usd3.getMarketLiquidity();
+        return usd3.WAUSDC().convertToAssets(totalBorrowAssetsWaUSDC) + usd3.committedLiquidityDrawn();
+    }
+
+    /// @dev Returns Morpho debt cap converted to USDC, plus full committed liquidity.
+    function _potentialExposureInUSDC(USD3 usd3) internal view returns (uint256) {
+        IProtocolConfig config = IProtocolConfig(IMorphoCredit(morphoCredit).protocolConfig());
+        uint256 debtCap = config.config(ProtocolConfigLib.DEBT_CAP);
+
+        uint256 potentialExposureUSDC = usd3.committedLiquidity();
+        if (debtCap > 0) {
+            potentialExposureUSDC += usd3.WAUSDC().convertToAssets(debtCap);
+        }
+
+        return potentialExposureUSDC;
+    }
+
     /**
-     * @notice Calculate maximum sUSD3 deposits allowed based on debt and subordination ratio
-     * @dev Returns the cap amount for subordinated debt based on actual or potential market debt
+     * @notice Calculate maximum sUSD3 deposits allowed based on exposure and subordination ratio
+     * @dev Returns the cap amount based on actual exposure or potential debt plus committed liquidity
      * @return Maximum subordinated debt cap, expressed in USDC
      */
     function getSubordinatedDebtCapInUSDC() public view returns (uint256) {
         USD3 usd3 = USD3(address(asset));
 
-        // Get actual borrowed amount
-        (,, uint256 totalBorrowAssetsWaUSDC,) = usd3.getMarketLiquidity();
-        uint256 actualDebtUSDC = usd3.WAUSDC().convertToAssets(totalBorrowAssetsWaUSDC);
-
-        // Get potential debt based on debt ceiling
-        IProtocolConfig config = IProtocolConfig(IMorphoCredit(morphoCredit).protocolConfig());
-        uint256 debtCap = config.config(ProtocolConfigLib.DEBT_CAP);
-
-        uint256 potentialDebtUSDC;
-        if (debtCap > 0) {
-            potentialDebtUSDC = usd3.WAUSDC().convertToAssets(debtCap);
-        }
-        uint256 maxDebtUSDC = Math.max(actualDebtUSDC, potentialDebtUSDC);
+        uint256 actualExposureUSDC = _actualExposureInUSDC(usd3);
+        uint256 potentialExposureUSDC = _potentialExposureInUSDC(usd3);
+        uint256 maxDebtUSDC = Math.max(actualExposureUSDC, potentialExposureUSDC);
 
         if (maxDebtUSDC == 0) {
             return 0; // No debt to subordinate
@@ -453,7 +462,7 @@ contract sUSD3 is BaseHooksUpgradeable {
     }
 
     /**
-     * @notice Calculate minimum sUSD3 backing required for current market debt
+     * @notice Calculate minimum sUSD3 backing required for current exposure
      * @dev Returns the floor amount of sUSD3 assets needed based on MIN_SUSD3_BACKING_RATIO
      * @return Minimum backing amount required, expressed in USDC
      */
@@ -466,9 +475,7 @@ contract sUSD3 is BaseHooksUpgradeable {
 
         USD3 usd3 = USD3(address(asset));
 
-        // Get actual borrowed amount
-        (,, uint256 totalBorrowAssetsWaUSDC,) = usd3.getMarketLiquidity();
-        uint256 debtUSDC = usd3.WAUSDC().convertToAssets(totalBorrowAssetsWaUSDC);
+        uint256 debtUSDC = _actualExposureInUSDC(usd3);
 
         // Calculate minimum required backing
         return (debtUSDC * backingRatio) / MAX_BPS;

--- a/test/forge/usd3/Invariants.t.sol
+++ b/test/forge/usd3/Invariants.t.sol
@@ -6,17 +6,21 @@ import {Setup, ERC20} from "./utils/Setup.sol";
 import {USD3} from "../../../src/usd3/USD3.sol";
 import {sUSD3} from "../../../src/usd3/sUSD3.sol";
 import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
+import {Pausable} from "../../../lib/openzeppelin/contracts/utils/Pausable.sol";
 import {
     TransparentUpgradeableProxy
 } from "../../../lib/openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "../../../lib/openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import {InvariantHandler} from "./handlers/InvariantHandler.sol";
+import {SharesMathLib} from "../../../src/libraries/SharesMathLib.sol";
 
 /**
  * @title InvariantsTest
  * @notice Invariant tests for USD3/sUSD3 protocol safety properties
  */
 contract InvariantsTest is StdInvariant, Setup {
+    using SharesMathLib for uint256;
+
     USD3 public usd3Strategy;
     sUSD3 public susd3Strategy;
     InvariantHandler public handler;
@@ -121,11 +125,25 @@ contract InvariantsTest is StdInvariant, Setup {
 
         uint256 idleUsdc = underlyingAsset.balanceOf(address(usd3Strategy));
         uint256 totalWaUsdc = usd3Strategy.balanceOfWaUSDC() + usd3Strategy.suppliedWaUSDC();
-        uint256 modeledAssets = idleUsdc + usd3Strategy.WAUSDC().convertToAssets(totalWaUsdc);
+        uint256 modeledAssets =
+            idleUsdc + usd3Strategy.WAUSDC().convertToAssets(totalWaUsdc) + usd3Strategy.committedLiquidityDrawn();
         uint256 reportedAssets = ITokenizedStrategy(address(usd3Strategy)).totalAssets();
 
         // Allow small absolute tolerance for conversion dust, but forbid phantom asset reporting.
         assertLe(reportedAssets, modeledAssets + 5e6, "usd3 overreports assets");
+    }
+
+    function invariant_usd3WithdrawLimitRespectsCommittedLiquidity() public view {
+        uint256 reserveAdjustedLiquidity =
+            _zeroFloorSub(_grossUsd3LiquidAssets(), usd3Strategy.availableCommittedLiquidity());
+
+        for (uint256 i; i < actors.length; ++i) {
+            assertLe(
+                usd3Strategy.availableWithdrawLimit(actors[i]),
+                reserveAdjustedLiquidity,
+                "withdraw exceeds reserve-adjusted liquidity"
+            );
+        }
     }
 
     function invariant_usd3LocalAndDeployedWaUsdcTotalsAreConsistent() public view {
@@ -252,5 +270,33 @@ contract InvariantsTest is StdInvariant, Setup {
         // A loss event should not cause PPS increase when locked shares + sUSD3 are present.
         // Allow one asset-unit worth of PPS dust from share/asset rounding.
         assertLe(handler.maxPpsIncreaseOnLossWithLocked(), 1e6, "pps increased after locked-share loss report");
+    }
+
+    function _grossUsd3LiquidAssets() internal view returns (uint256) {
+        uint256 idleUsdc = underlyingAsset.balanceOf(address(usd3Strategy));
+
+        if (Pausable(address(usd3Strategy.WAUSDC())).paused()) {
+            return idleUsdc;
+        }
+
+        (uint256 totalSupplyAssets, uint256 totalShares,, uint256 waUsdcLiquidity) = usd3Strategy.getMarketLiquidity();
+        uint256 supplyShares =
+            usd3Strategy.morphoCredit().position(usd3Strategy.marketId(), address(usd3Strategy)).supplyShares;
+        uint256 waUsdcMax = supplyShares.toAssetsDown(totalSupplyAssets, totalShares);
+
+        uint256 localWaUsdc =
+            _min(usd3Strategy.balanceOfWaUSDC(), usd3Strategy.WAUSDC().maxRedeem(address(usd3Strategy)));
+        uint256 morphoWaUsdc = _min(waUsdcMax, waUsdcLiquidity);
+        morphoWaUsdc = _min(morphoWaUsdc, usd3Strategy.WAUSDC().maxRedeem(address(usd3Strategy.morphoCredit())));
+
+        return idleUsdc + usd3Strategy.WAUSDC().convertToAssets(localWaUsdc + morphoWaUsdc);
+    }
+
+    function _zeroFloorSub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a > b ? a - b : 0;
+    }
+
+    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
     }
 }

--- a/test/forge/usd3/Invariants.t.sol
+++ b/test/forge/usd3/Invariants.t.sol
@@ -7,12 +7,14 @@ import {USD3} from "../../../src/usd3/USD3.sol";
 import {sUSD3} from "../../../src/usd3/sUSD3.sol";
 import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
 import {Pausable} from "../../../lib/openzeppelin/contracts/utils/Pausable.sol";
+import {Math} from "../../../lib/openzeppelin/contracts/utils/math/Math.sol";
 import {
     TransparentUpgradeableProxy
 } from "../../../lib/openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "../../../lib/openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import {InvariantHandler} from "./handlers/InvariantHandler.sol";
 import {SharesMathLib} from "../../../src/libraries/SharesMathLib.sol";
+import {UtilsLib} from "../../../src/libraries/UtilsLib.sol";
 
 /**
  * @title InvariantsTest
@@ -135,7 +137,7 @@ contract InvariantsTest is StdInvariant, Setup {
 
     function invariant_usd3WithdrawLimitRespectsCommittedLiquidity() public view {
         uint256 reserveAdjustedLiquidity =
-            _zeroFloorSub(_grossUsd3LiquidAssets(), usd3Strategy.availableCommittedLiquidity());
+            UtilsLib.zeroFloorSub(_grossUsd3LiquidAssets(), usd3Strategy.availableCommittedLiquidity());
 
         for (uint256 i; i < actors.length; ++i) {
             assertLe(
@@ -285,18 +287,10 @@ contract InvariantsTest is StdInvariant, Setup {
         uint256 waUsdcMax = supplyShares.toAssetsDown(totalSupplyAssets, totalShares);
 
         uint256 localWaUsdc =
-            _min(usd3Strategy.balanceOfWaUSDC(), usd3Strategy.WAUSDC().maxRedeem(address(usd3Strategy)));
-        uint256 morphoWaUsdc = _min(waUsdcMax, waUsdcLiquidity);
-        morphoWaUsdc = _min(morphoWaUsdc, usd3Strategy.WAUSDC().maxRedeem(address(usd3Strategy.morphoCredit())));
+            Math.min(usd3Strategy.balanceOfWaUSDC(), usd3Strategy.WAUSDC().maxRedeem(address(usd3Strategy)));
+        uint256 morphoWaUsdc = Math.min(waUsdcMax, waUsdcLiquidity);
+        morphoWaUsdc = Math.min(morphoWaUsdc, usd3Strategy.WAUSDC().maxRedeem(address(usd3Strategy.morphoCredit())));
 
         return idleUsdc + usd3Strategy.WAUSDC().convertToAssets(localWaUsdc + morphoWaUsdc);
-    }
-
-    function _zeroFloorSub(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a > b ? a - b : 0;
-    }
-
-    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a < b ? a : b;
     }
 }

--- a/test/forge/usd3/USD3CommittedLiquidity.t.sol
+++ b/test/forge/usd3/USD3CommittedLiquidity.t.sol
@@ -58,6 +58,20 @@ contract USD3CommittedLiquidityTest is Setup {
         usd3Strategy.drawCommittedLiquidity(amount);
     }
 
+    function _seedFacilitySetup() internal {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+    }
+
+    function _repay(address from, uint256 fundAmount, uint256 repayArg) internal {
+        airdrop(underlyingAsset, from, fundAmount);
+        vm.startPrank(from);
+        underlyingAsset.approve(address(usd3Strategy), fundAmount);
+        usd3Strategy.repayCommittedLiquidity(repayArg);
+        vm.stopPrank();
+    }
+
     function _pricePerShare() internal view returns (uint256) {
         uint256 totalSupply = strategy.totalSupply();
         if (totalSupply == 0) return 0;
@@ -181,9 +195,7 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_unauthorizedCallerReverts() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
 
         vm.prank(bob);
         vm.expectRevert("Unauthorized facility");
@@ -191,9 +203,7 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_drawTransfersUsdcAndIncrementsDrawn() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
 
         uint256 facilityBalanceBefore = underlyingAsset.balanceOf(facility);
 
@@ -209,9 +219,7 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_drawUsesIdleUsdcBeforeUnwindingMorpho() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
 
         airdrop(underlyingAsset, address(usd3Strategy), 1_000e6);
         uint256 suppliedBefore = usd3Strategy.suppliedWaUSDC();
@@ -223,9 +231,7 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_drawUnwindsFromMorpho() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
 
         uint256 suppliedBefore = usd3Strategy.suppliedWaUSDC();
         assertGt(suppliedBefore, 0, "setup should deploy to Morpho");
@@ -237,9 +243,7 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_drawExceedingCommitmentReverts() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
 
         vm.prank(facility);
         vm.expectRevert("Exceeds commitment");
@@ -260,9 +264,7 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_drawBlockedDuringShutdown() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
 
         vm.prank(emergencyAdmin);
         strategy.shutdownStrategy();
@@ -273,9 +275,7 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_drawBlockedWhenPaused() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
         _setProtocolPause(1);
 
         vm.prank(facility);
@@ -285,9 +285,7 @@ contract USD3CommittedLiquidityTest is Setup {
 
     function test_facility_drawBypassesCommitmentTime() public {
         _setCommitmentTime(COMMITMENT_TIME);
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
 
         assertEq(usd3Strategy.availableWithdrawLimit(alice), 0, "alice should be locked by commitment time");
 
@@ -297,9 +295,7 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_withdrawLimitUsesUndrawnOnly() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
 
         uint256 beforeDrawLimit = usd3Strategy.availableWithdrawLimit(alice);
 
@@ -310,9 +306,7 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_loweredCommitmentBelowDrawnBlocksFurtherDraws() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
 
         _draw(RESERVE);
         _setCommittedLiquidity(RESERVE - 1);
@@ -335,14 +329,14 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_repayDecreasesDrawn() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
         _draw(RESERVE);
 
         airdrop(underlyingAsset, payer, 1_000e6);
         vm.startPrank(payer);
         underlyingAsset.approve(address(usd3Strategy), 1_000e6);
+        vm.expectEmit(true, true, true, true);
+        emit USD3.CommittedLiquidityRepaid(payer, 1_000e6, RESERVE - 1_000e6);
         usd3Strategy.repayCommittedLiquidity(1_000e6);
         vm.stopPrank();
 
@@ -351,25 +345,17 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_repayMaxRepaysFull() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
         _draw(RESERVE);
 
-        airdrop(underlyingAsset, payer, RESERVE);
-        vm.startPrank(payer);
-        underlyingAsset.approve(address(usd3Strategy), RESERVE);
-        usd3Strategy.repayCommittedLiquidity(type(uint256).max);
-        vm.stopPrank();
+        _repay(payer, RESERVE, type(uint256).max);
 
         assertEq(usd3Strategy.committedLiquidityDrawn(), 0, "max sentinel should repay full drawn amount");
         assertEq(usd3Strategy.availableCommittedLiquidity(), RESERVE, "full capacity should reopen");
     }
 
     function test_facility_repayOverpaymentReverts() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
         _draw(1_000e6);
 
         airdrop(underlyingAsset, payer, 1_001e6);
@@ -381,31 +367,32 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_repayByAnyoneAllowed() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
         _draw(1_000e6);
 
-        airdrop(underlyingAsset, bob, 1_000e6);
-        vm.startPrank(bob);
-        underlyingAsset.approve(address(usd3Strategy), 1_000e6);
-        usd3Strategy.repayCommittedLiquidity(1_000e6);
-        vm.stopPrank();
+        _repay(bob, 1_000e6, 1_000e6);
 
         assertEq(usd3Strategy.committedLiquidityDrawn(), 0, "third-party repayment should clear drawn amount");
     }
 
+    function test_facility_repayAllowedDuringShutdownAndPause() public {
+        _seedFacilitySetup();
+        _draw(1_000e6);
+
+        vm.prank(emergencyAdmin);
+        strategy.shutdownStrategy();
+        _setProtocolPause(1);
+
+        _repay(payer, 1_000e6, 1_000e6);
+
+        assertEq(usd3Strategy.committedLiquidityDrawn(), 0, "repay should remain available during shutdown and pause");
+    }
+
     function test_facility_repaidCapacityCanBeRedrawn() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
         _draw(RESERVE);
 
-        airdrop(underlyingAsset, payer, RESERVE);
-        vm.startPrank(payer);
-        underlyingAsset.approve(address(usd3Strategy), RESERVE);
-        usd3Strategy.repayCommittedLiquidity(RESERVE);
-        vm.stopPrank();
+        _repay(payer, RESERVE, RESERVE);
 
         _draw(RESERVE);
 
@@ -413,9 +400,7 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_reportAfterDrawPreservesSharePrice() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
 
         uint256 ppsBefore = _pricePerShare();
 
@@ -429,7 +414,7 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_writeDownReducesDrawnAndRealizesLossOnReport() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _seedFacilitySetup();
 
         vm.prank(management);
         usd3Strategy.setSUSD3(susd3Holder);
@@ -437,8 +422,6 @@ contract USD3CommittedLiquidityTest is Setup {
         vm.prank(alice);
         usd3Strategy.transfer(susd3Holder, 1_000e6);
 
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
         _draw(1_000e6);
 
         vm.prank(keeper);
@@ -448,6 +431,8 @@ contract USD3CommittedLiquidityTest is Setup {
         assertEq(susd3BalanceBefore, 1_000e6, "setup should seed sUSD3 protection");
 
         vm.prank(management);
+        vm.expectEmit(true, true, true, true);
+        emit USD3.CommittedLiquidityWrittenDown(1_000e6, 0);
         usd3Strategy.writeDownCommittedLiquidity(1_000e6);
 
         vm.prank(keeper);
@@ -459,7 +444,7 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_writeDownAboveSusd3CushionDropsUsd3Pps() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _seedFacilitySetup();
 
         vm.prank(management);
         usd3Strategy.setSUSD3(susd3Holder);
@@ -467,8 +452,6 @@ contract USD3CommittedLiquidityTest is Setup {
         vm.prank(alice);
         usd3Strategy.transfer(susd3Holder, 500e6);
 
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
         _draw(1_000e6);
 
         vm.prank(keeper);
@@ -489,10 +472,24 @@ contract USD3CommittedLiquidityTest is Setup {
         assertLt(_pricePerShare(), ppsBefore, "residual loss should reduce USD3 PPS");
     }
 
+    function test_facility_writeDownAllowedDuringShutdownAndPause() public {
+        _seedFacilitySetup();
+        _draw(1_000e6);
+
+        vm.prank(emergencyAdmin);
+        strategy.shutdownStrategy();
+        _setProtocolPause(1);
+
+        vm.prank(management);
+        usd3Strategy.writeDownCommittedLiquidity(1_000e6);
+
+        assertEq(
+            usd3Strategy.committedLiquidityDrawn(), 0, "write-down should remain available during shutdown and pause"
+        );
+    }
+
     function test_facility_writeDownAboveDrawnReverts() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
         _draw(1_000e6);
 
         vm.prank(management);
@@ -501,9 +498,7 @@ contract USD3CommittedLiquidityTest is Setup {
     }
 
     function test_facility_writeDownByNonManagementReverts() public {
-        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
-        _setCommittedLiquidity(RESERVE);
-        _setFacility(facility);
+        _seedFacilitySetup();
         _draw(1_000e6);
 
         vm.prank(bob);

--- a/test/forge/usd3/USD3CommittedLiquidity.t.sol
+++ b/test/forge/usd3/USD3CommittedLiquidity.t.sol
@@ -18,6 +18,9 @@ contract USD3CommittedLiquidityTest is Setup {
 
     address public alice = makeAddr("alice");
     address public bob = makeAddr("bob");
+    address public facility = makeAddr("facility");
+    address public payer = makeAddr("payer");
+    address public susd3Holder = makeAddr("susd3Holder");
 
     uint256 private constant DEPOSIT = 10_000e6;
     uint256 private constant RESERVE = 2_500e6;
@@ -35,9 +38,30 @@ contract USD3CommittedLiquidityTest is Setup {
         protocolConfig.setConfig(ProtocolConfigLib.COMMITTED_LIQUIDITY, amount);
     }
 
+    function _setFacility(address facility_) internal {
+        vm.prank(protocolConfig.owner());
+        protocolConfig.setConfig(ProtocolConfigLib.COMMITTED_LIQUIDITY_FACILITY, uint256(uint160(facility_)));
+    }
+
     function _setCommitmentTime(uint256 duration) internal {
         vm.prank(protocolConfig.owner());
         protocolConfig.setConfig(ProtocolConfigLib.USD3_COMMITMENT_TIME, duration);
+    }
+
+    function _setProtocolPause(uint256 paused) internal {
+        vm.prank(protocolConfig.owner());
+        protocolConfig.setConfig(ProtocolConfigLib.IS_PAUSED, paused);
+    }
+
+    function _draw(uint256 amount) internal {
+        vm.prank(facility);
+        usd3Strategy.drawCommittedLiquidity(amount);
+    }
+
+    function _pricePerShare() internal view returns (uint256) {
+        uint256 totalSupply = strategy.totalSupply();
+        if (totalSupply == 0) return 0;
+        return strategy.totalAssets() * 1e18 / totalSupply;
     }
 
     function test_committedLiquidity_defaultZeroPreservesWithdrawalBehavior() public {
@@ -46,6 +70,8 @@ contract USD3CommittedLiquidityTest is Setup {
         uint256 shares = strategy.balanceOf(alice);
 
         assertEq(usd3Strategy.committedLiquidity(), 0, "reserve should default to zero");
+        assertEq(usd3Strategy.availableCommittedLiquidity(), 0, "undrawn reserve should default to zero");
+        assertEq(usd3Strategy.maxCommittedLiquidityDraw(), 0, "draw limit should default to zero");
         assertEq(usd3Strategy.availableWithdrawLimit(alice), DEPOSIT, "withdraw limit should be unchanged");
         assertEq(strategy.maxWithdraw(alice), DEPOSIT, "maxWithdraw should be unchanged");
         assertEq(strategy.maxRedeem(alice), shares, "maxRedeem should be unchanged");
@@ -59,6 +85,8 @@ contract USD3CommittedLiquidityTest is Setup {
         uint256 expectedRedeem = strategy.convertToShares(expectedWithdraw);
 
         assertEq(usd3Strategy.committedLiquidity(), RESERVE, "reserve should be set");
+        assertEq(usd3Strategy.availableCommittedLiquidity(), RESERVE, "undrawn reserve should equal reserve");
+        assertEq(usd3Strategy.maxCommittedLiquidityDraw(), RESERVE, "draw limit should equal liquid reserve");
         assertEq(usd3Strategy.availableWithdrawLimit(alice), expectedWithdraw, "withdraw limit should net reserve");
         assertEq(strategy.maxWithdraw(alice), expectedWithdraw, "maxWithdraw should net reserve");
         assertEq(strategy.maxRedeem(alice), expectedRedeem, "maxRedeem should net reserve");
@@ -141,5 +169,345 @@ contract USD3CommittedLiquidityTest is Setup {
         uint256 deployedAfter = usd3Strategy.suppliedWaUSDC();
         assertEq(deployedAfter, deployedBefore, "reserve should not change tend deployment target");
         assertEq(deployedAfter, DEPOSIT / 2, "deployment should still follow maxOnCredit");
+    }
+
+    function test_facility_unsetReverts() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+
+        vm.prank(facility);
+        vm.expectRevert("USD3/not-facility");
+        usd3Strategy.drawCommittedLiquidity(1);
+    }
+
+    function test_facility_unauthorizedCallerReverts() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+
+        vm.prank(bob);
+        vm.expectRevert("USD3/not-facility");
+        usd3Strategy.drawCommittedLiquidity(1);
+    }
+
+    function test_facility_drawTransfersUsdcAndIncrementsDrawn() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+
+        uint256 facilityBalanceBefore = underlyingAsset.balanceOf(facility);
+
+        vm.prank(facility);
+        vm.expectEmit(true, true, true, true);
+        emit USD3.CommittedLiquidityDrawn(facility, RESERVE, RESERVE);
+        usd3Strategy.drawCommittedLiquidity(RESERVE);
+
+        assertEq(underlyingAsset.balanceOf(facility), facilityBalanceBefore + RESERVE, "facility should receive USDC");
+        assertEq(usd3Strategy.committedLiquidityDrawn(), RESERVE, "drawn should increase");
+        assertEq(usd3Strategy.availableCommittedLiquidity(), 0, "undrawn commitment should be consumed");
+        assertEq(usd3Strategy.maxCommittedLiquidityDraw(), 0, "draw limit should be consumed");
+    }
+
+    function test_facility_drawUsesIdleUsdcBeforeUnwindingMorpho() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+
+        airdrop(underlyingAsset, address(usd3Strategy), 1_000e6);
+        uint256 suppliedBefore = usd3Strategy.suppliedWaUSDC();
+
+        _draw(1_000e6);
+
+        assertEq(usd3Strategy.suppliedWaUSDC(), suppliedBefore, "idle USDC draw should not unwind Morpho");
+        assertEq(underlyingAsset.balanceOf(facility), 1_000e6, "facility should receive idle USDC");
+    }
+
+    function test_facility_drawUnwindsFromMorpho() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+
+        uint256 suppliedBefore = usd3Strategy.suppliedWaUSDC();
+        assertGt(suppliedBefore, 0, "setup should deploy to Morpho");
+
+        _draw(RESERVE);
+
+        assertLt(usd3Strategy.suppliedWaUSDC(), suppliedBefore, "draw should unwind Morpho supply");
+        assertEq(underlyingAsset.balanceOf(facility), RESERVE, "facility should receive USDC");
+    }
+
+    function test_facility_drawExceedingCommitmentReverts() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+
+        vm.prank(facility);
+        vm.expectRevert("USD3/exceeds-commitment");
+        usd3Strategy.drawCommittedLiquidity(RESERVE + 1);
+    }
+
+    function test_facility_drawAboveLiquidFundsReverts() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        createMarketDebt(makeAddr("borrower"), DEPOSIT - 1_000e6);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+
+        assertLt(usd3Strategy.maxCommittedLiquidityDraw(), RESERVE, "liquidity should be below commitment");
+
+        vm.prank(facility);
+        vm.expectRevert("USD3/insufficient-liquid");
+        usd3Strategy.drawCommittedLiquidity(RESERVE);
+    }
+
+    function test_facility_drawBlockedDuringShutdown() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+
+        vm.prank(emergencyAdmin);
+        strategy.shutdownStrategy();
+
+        vm.prank(facility);
+        vm.expectRevert("USD3/shutdown");
+        usd3Strategy.drawCommittedLiquidity(1);
+    }
+
+    function test_facility_drawBlockedWhenPaused() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+        _setProtocolPause(1);
+
+        vm.prank(facility);
+        vm.expectRevert("USD3/paused");
+        usd3Strategy.drawCommittedLiquidity(1);
+    }
+
+    function test_facility_drawBypassesCommitmentTime() public {
+        _setCommitmentTime(COMMITMENT_TIME);
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+
+        assertEq(usd3Strategy.availableWithdrawLimit(alice), 0, "alice should be locked by commitment time");
+
+        _draw(RESERVE);
+
+        assertEq(underlyingAsset.balanceOf(facility), RESERVE, "facility draw should bypass commitment time");
+    }
+
+    function test_facility_withdrawLimitUsesUndrawnOnly() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+
+        uint256 beforeDrawLimit = usd3Strategy.availableWithdrawLimit(alice);
+
+        _draw(1_000e6);
+
+        assertEq(usd3Strategy.availableCommittedLiquidity(), RESERVE - 1_000e6, "undrawn should decrease");
+        assertEq(usd3Strategy.availableWithdrawLimit(alice), beforeDrawLimit, "draw should not reduce withdraw limit");
+    }
+
+    function test_facility_loweredCommitmentBelowDrawnBlocksFurtherDraws() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+
+        _draw(RESERVE);
+        _setCommittedLiquidity(RESERVE - 1);
+
+        assertEq(usd3Strategy.availableCommittedLiquidity(), 0, "undrawn commitment should clamp to zero");
+        assertEq(usd3Strategy.maxCommittedLiquidityDraw(), 0, "draw limit should clamp to zero");
+
+        vm.prank(facility);
+        vm.expectRevert("USD3/exceeds-commitment");
+        usd3Strategy.drawCommittedLiquidity(1);
+    }
+
+    function test_facility_maxCommittedLiquidityDrawUsesLiquidityAndUndrawn() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        createMarketDebt(makeAddr("borrower"), DEPOSIT - 1_000e6);
+        _setCommittedLiquidity(RESERVE);
+
+        assertEq(usd3Strategy.availableCommittedLiquidity(), RESERVE, "undrawn should equal reserve");
+        assertApproxEqAbs(usd3Strategy.maxCommittedLiquidityDraw(), 1_000e6, 2, "draw max should be liquidity-bound");
+    }
+
+    function test_facility_repayDecreasesDrawn() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+        _draw(RESERVE);
+
+        airdrop(underlyingAsset, payer, 1_000e6);
+        vm.startPrank(payer);
+        underlyingAsset.approve(address(usd3Strategy), 1_000e6);
+        usd3Strategy.repayCommittedLiquidity(1_000e6);
+        vm.stopPrank();
+
+        assertEq(usd3Strategy.committedLiquidityDrawn(), RESERVE - 1_000e6, "drawn should decrease");
+        assertEq(usd3Strategy.availableCommittedLiquidity(), 1_000e6, "repaid amount should reopen capacity");
+    }
+
+    function test_facility_repayMaxRepaysFull() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+        _draw(RESERVE);
+
+        airdrop(underlyingAsset, payer, RESERVE);
+        vm.startPrank(payer);
+        underlyingAsset.approve(address(usd3Strategy), RESERVE);
+        usd3Strategy.repayCommittedLiquidity(type(uint256).max);
+        vm.stopPrank();
+
+        assertEq(usd3Strategy.committedLiquidityDrawn(), 0, "max sentinel should repay full drawn amount");
+        assertEq(usd3Strategy.availableCommittedLiquidity(), RESERVE, "full capacity should reopen");
+    }
+
+    function test_facility_repayOverpaymentReverts() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+        _draw(1_000e6);
+
+        airdrop(underlyingAsset, payer, 1_001e6);
+        vm.startPrank(payer);
+        underlyingAsset.approve(address(usd3Strategy), 1_001e6);
+        vm.expectRevert("USD3/overpayment");
+        usd3Strategy.repayCommittedLiquidity(1_001e6);
+        vm.stopPrank();
+    }
+
+    function test_facility_repayByAnyoneAllowed() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+        _draw(1_000e6);
+
+        airdrop(underlyingAsset, bob, 1_000e6);
+        vm.startPrank(bob);
+        underlyingAsset.approve(address(usd3Strategy), 1_000e6);
+        usd3Strategy.repayCommittedLiquidity(1_000e6);
+        vm.stopPrank();
+
+        assertEq(usd3Strategy.committedLiquidityDrawn(), 0, "third-party repayment should clear drawn amount");
+    }
+
+    function test_facility_repaidCapacityCanBeRedrawn() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+        _draw(RESERVE);
+
+        airdrop(underlyingAsset, payer, RESERVE);
+        vm.startPrank(payer);
+        underlyingAsset.approve(address(usd3Strategy), RESERVE);
+        usd3Strategy.repayCommittedLiquidity(RESERVE);
+        vm.stopPrank();
+
+        _draw(RESERVE);
+
+        assertEq(usd3Strategy.committedLiquidityDrawn(), RESERVE, "repaid capacity should be drawable again");
+    }
+
+    function test_facility_reportAfterDrawPreservesSharePrice() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+
+        uint256 ppsBefore = _pricePerShare();
+
+        _draw(RESERVE);
+
+        vm.prank(keeper);
+        strategy.report();
+
+        assertEq(_pricePerShare(), ppsBefore, "draw receivable should preserve PPS");
+        assertEq(strategy.totalAssets(), DEPOSIT, "drawn principal should remain in totalAssets");
+    }
+
+    function test_facility_writeDownReducesDrawnAndRealizesLossOnReport() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+
+        vm.prank(management);
+        usd3Strategy.setSUSD3(susd3Holder);
+
+        vm.prank(alice);
+        usd3Strategy.transfer(susd3Holder, 1_000e6);
+
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+        _draw(1_000e6);
+
+        vm.prank(keeper);
+        strategy.report();
+
+        uint256 susd3BalanceBefore = strategy.balanceOf(susd3Holder);
+        assertEq(susd3BalanceBefore, 1_000e6, "setup should seed sUSD3 protection");
+
+        vm.prank(management);
+        usd3Strategy.writeDownCommittedLiquidity(1_000e6);
+
+        vm.prank(keeper);
+        (, uint256 loss) = strategy.report();
+
+        assertEq(loss, 1_000e6, "write-down should realize loss on report");
+        assertEq(usd3Strategy.committedLiquidityDrawn(), 0, "write-down should reduce drawn amount");
+        assertEq(strategy.balanceOf(susd3Holder), 0, "sUSD3 balance should absorb loss first");
+    }
+
+    function test_facility_writeDownAboveSusd3CushionDropsUsd3Pps() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+
+        vm.prank(management);
+        usd3Strategy.setSUSD3(susd3Holder);
+
+        vm.prank(alice);
+        usd3Strategy.transfer(susd3Holder, 500e6);
+
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+        _draw(1_000e6);
+
+        vm.prank(keeper);
+        strategy.report();
+
+        uint256 ppsBefore = _pricePerShare();
+        uint256 totalSupplyBefore = strategy.totalSupply();
+
+        vm.prank(management);
+        usd3Strategy.writeDownCommittedLiquidity(1_000e6);
+
+        vm.prank(keeper);
+        (, uint256 loss) = strategy.report();
+
+        assertEq(loss, 1_000e6, "write-down should realize full loss");
+        assertEq(strategy.balanceOf(susd3Holder), 0, "sUSD3 cushion should be exhausted");
+        assertEq(totalSupplyBefore - strategy.totalSupply(), 500e6, "only available sUSD3 shares should burn");
+        assertLt(_pricePerShare(), ppsBefore, "residual loss should reduce USD3 PPS");
+    }
+
+    function test_facility_writeDownAboveDrawnReverts() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+        _draw(1_000e6);
+
+        vm.prank(management);
+        vm.expectRevert("USD3/bad-writedown");
+        usd3Strategy.writeDownCommittedLiquidity(1_001e6);
+    }
+
+    function test_facility_writeDownByNonManagementReverts() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+        _setFacility(facility);
+        _draw(1_000e6);
+
+        vm.prank(bob);
+        vm.expectRevert();
+        usd3Strategy.writeDownCommittedLiquidity(1);
     }
 }

--- a/test/forge/usd3/USD3CommittedLiquidity.t.sol
+++ b/test/forge/usd3/USD3CommittedLiquidity.t.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+
+import {Setup} from "./utils/Setup.sol";
+import {USD3} from "../../../src/usd3/USD3.sol";
+import {IMorphoCredit} from "../../../src/interfaces/IMorpho.sol";
+import {ProtocolConfigLib} from "../../../src/libraries/ProtocolConfigLib.sol";
+import {MockProtocolConfig} from "./mocks/MockProtocolConfig.sol";
+import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
+
+/**
+ * @title USD3CommittedLiquidityTest
+ * @notice Tests the ProtocolConfig-driven committed liquidity reserve for USD3 withdrawals.
+ */
+contract USD3CommittedLiquidityTest is Setup {
+    USD3 public usd3Strategy;
+    MockProtocolConfig public protocolConfig;
+
+    address public alice = makeAddr("alice");
+    address public bob = makeAddr("bob");
+
+    uint256 private constant DEPOSIT = 10_000e6;
+    uint256 private constant RESERVE = 2_500e6;
+    uint256 private constant COMMITMENT_TIME = 7 days;
+
+    function setUp() public override {
+        super.setUp();
+
+        usd3Strategy = USD3(address(strategy));
+        protocolConfig = MockProtocolConfig(IMorphoCredit(address(usd3Strategy.morphoCredit())).protocolConfig());
+    }
+
+    function _setCommittedLiquidity(uint256 amount) internal {
+        vm.prank(protocolConfig.owner());
+        protocolConfig.setConfig(ProtocolConfigLib.COMMITTED_LIQUIDITY, amount);
+    }
+
+    function _setCommitmentTime(uint256 duration) internal {
+        vm.prank(protocolConfig.owner());
+        protocolConfig.setConfig(ProtocolConfigLib.USD3_COMMITMENT_TIME, duration);
+    }
+
+    function test_committedLiquidity_defaultZeroPreservesWithdrawalBehavior() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+
+        uint256 shares = strategy.balanceOf(alice);
+
+        assertEq(usd3Strategy.committedLiquidity(), 0, "reserve should default to zero");
+        assertEq(usd3Strategy.availableWithdrawLimit(alice), DEPOSIT, "withdraw limit should be unchanged");
+        assertEq(strategy.maxWithdraw(alice), DEPOSIT, "maxWithdraw should be unchanged");
+        assertEq(strategy.maxRedeem(alice), shares, "maxRedeem should be unchanged");
+    }
+
+    function test_committedLiquidity_reducesWithdrawAndRedeemLimits() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+
+        uint256 expectedWithdraw = DEPOSIT - RESERVE;
+        uint256 expectedRedeem = strategy.convertToShares(expectedWithdraw);
+
+        assertEq(usd3Strategy.committedLiquidity(), RESERVE, "reserve should be set");
+        assertEq(usd3Strategy.availableWithdrawLimit(alice), expectedWithdraw, "withdraw limit should net reserve");
+        assertEq(strategy.maxWithdraw(alice), expectedWithdraw, "maxWithdraw should net reserve");
+        assertEq(strategy.maxRedeem(alice), expectedRedeem, "maxRedeem should net reserve");
+    }
+
+    function test_committedLiquidity_equalOrAboveLiquidityBlocksWithdrawals() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(DEPOSIT);
+
+        assertEq(usd3Strategy.availableWithdrawLimit(alice), 0, "reserve should consume available liquidity");
+        assertEq(strategy.maxWithdraw(alice), 0, "maxWithdraw should be zero");
+        assertEq(strategy.maxRedeem(alice), 0, "maxRedeem should be zero");
+
+        vm.prank(alice);
+        vm.expectRevert("ERC4626: withdraw more than max");
+        strategy.withdraw(1, alice, alice);
+
+        vm.prank(alice);
+        vm.expectRevert("ERC4626: redeem more than max");
+        strategy.redeem(1, alice, alice);
+    }
+
+    function test_committedLiquidity_aboveTotalAssetsClampsToZero() public {
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(DEPOSIT + 1);
+
+        assertEq(usd3Strategy.availableWithdrawLimit(alice), 0, "withdraw limit should clamp to zero");
+        assertEq(strategy.maxWithdraw(alice), 0, "maxWithdraw should clamp to zero");
+        assertEq(strategy.maxRedeem(alice), 0, "maxRedeem should clamp to zero");
+    }
+
+    function test_committedLiquidity_shutdownStillEnforcesReserveButBypassesCommitment() public {
+        _setCommitmentTime(COMMITMENT_TIME);
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        _setCommittedLiquidity(RESERVE);
+
+        vm.prank(alice);
+        vm.expectRevert("ERC4626: withdraw more than max");
+        strategy.withdraw(1, alice, alice);
+
+        vm.prank(emergencyAdmin);
+        strategy.shutdownStrategy();
+
+        uint256 availableAfterShutdown = DEPOSIT - RESERVE;
+
+        assertEq(
+            usd3Strategy.availableWithdrawLimit(alice),
+            availableAfterShutdown,
+            "shutdown should bypass commitment but keep reserve"
+        );
+        assertEq(strategy.maxWithdraw(alice), availableAfterShutdown, "shutdown maxWithdraw should keep reserve");
+
+        vm.prank(alice);
+        uint256 sharesBurned = strategy.withdraw(availableAfterShutdown, alice, alice);
+        assertEq(sharesBurned, strategy.convertToShares(availableAfterShutdown), "withdraw should burn expected shares");
+
+        assertEq(usd3Strategy.availableWithdrawLimit(alice), 0, "remaining liquidity should be reserved");
+    }
+
+    function test_committedLiquidity_doesNotAffectDepositLimit() public {
+        uint256 limitBefore = usd3Strategy.availableDepositLimit(bob);
+        _setCommittedLiquidity(type(uint256).max);
+
+        assertEq(usd3Strategy.availableDepositLimit(bob), limitBefore, "deposit limit should ignore reserve");
+
+        mintAndDepositIntoStrategy(strategy, bob, DEPOSIT);
+        assertEq(strategy.balanceOf(bob), DEPOSIT, "deposit should still mint shares");
+    }
+
+    function test_committedLiquidity_doesNotAffectTendDeployment() public {
+        setMaxOnCredit(5000);
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+
+        uint256 deployedBefore = usd3Strategy.suppliedWaUSDC();
+        _setCommittedLiquidity(RESERVE);
+
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        uint256 deployedAfter = usd3Strategy.suppliedWaUSDC();
+        assertEq(deployedAfter, deployedBefore, "reserve should not change tend deployment target");
+        assertEq(deployedAfter, DEPOSIT / 2, "deployment should still follow maxOnCredit");
+    }
+}

--- a/test/forge/usd3/USD3CommittedLiquidity.t.sol
+++ b/test/forge/usd3/USD3CommittedLiquidity.t.sol
@@ -176,7 +176,7 @@ contract USD3CommittedLiquidityTest is Setup {
         _setCommittedLiquidity(RESERVE);
 
         vm.prank(facility);
-        vm.expectRevert("USD3/not-facility");
+        vm.expectRevert("Unauthorized facility");
         usd3Strategy.drawCommittedLiquidity(1);
     }
 
@@ -186,7 +186,7 @@ contract USD3CommittedLiquidityTest is Setup {
         _setFacility(facility);
 
         vm.prank(bob);
-        vm.expectRevert("USD3/not-facility");
+        vm.expectRevert("Unauthorized facility");
         usd3Strategy.drawCommittedLiquidity(1);
     }
 
@@ -242,7 +242,7 @@ contract USD3CommittedLiquidityTest is Setup {
         _setFacility(facility);
 
         vm.prank(facility);
-        vm.expectRevert("USD3/exceeds-commitment");
+        vm.expectRevert("Exceeds commitment");
         usd3Strategy.drawCommittedLiquidity(RESERVE + 1);
     }
 
@@ -255,7 +255,7 @@ contract USD3CommittedLiquidityTest is Setup {
         assertLt(usd3Strategy.maxCommittedLiquidityDraw(), RESERVE, "liquidity should be below commitment");
 
         vm.prank(facility);
-        vm.expectRevert("USD3/insufficient-liquid");
+        vm.expectRevert("Insufficient liquidity");
         usd3Strategy.drawCommittedLiquidity(RESERVE);
     }
 
@@ -268,7 +268,7 @@ contract USD3CommittedLiquidityTest is Setup {
         strategy.shutdownStrategy();
 
         vm.prank(facility);
-        vm.expectRevert("USD3/shutdown");
+        vm.expectRevert("Strategy shutdown");
         usd3Strategy.drawCommittedLiquidity(1);
     }
 
@@ -279,7 +279,7 @@ contract USD3CommittedLiquidityTest is Setup {
         _setProtocolPause(1);
 
         vm.prank(facility);
-        vm.expectRevert("USD3/paused");
+        vm.expectRevert("Protocol paused");
         usd3Strategy.drawCommittedLiquidity(1);
     }
 
@@ -321,7 +321,7 @@ contract USD3CommittedLiquidityTest is Setup {
         assertEq(usd3Strategy.maxCommittedLiquidityDraw(), 0, "draw limit should clamp to zero");
 
         vm.prank(facility);
-        vm.expectRevert("USD3/exceeds-commitment");
+        vm.expectRevert("Exceeds commitment");
         usd3Strategy.drawCommittedLiquidity(1);
     }
 
@@ -375,7 +375,7 @@ contract USD3CommittedLiquidityTest is Setup {
         airdrop(underlyingAsset, payer, 1_001e6);
         vm.startPrank(payer);
         underlyingAsset.approve(address(usd3Strategy), 1_001e6);
-        vm.expectRevert("USD3/overpayment");
+        vm.expectRevert("Repay exceeds drawn");
         usd3Strategy.repayCommittedLiquidity(1_001e6);
         vm.stopPrank();
     }
@@ -496,7 +496,7 @@ contract USD3CommittedLiquidityTest is Setup {
         _draw(1_000e6);
 
         vm.prank(management);
-        vm.expectRevert("USD3/bad-writedown");
+        vm.expectRevert("Invalid writedown amount");
         usd3Strategy.writeDownCommittedLiquidity(1_001e6);
     }
 

--- a/test/forge/usd3/sUSD3.t.sol
+++ b/test/forge/usd3/sUSD3.t.sol
@@ -14,6 +14,7 @@ import {MockProtocolConfig} from "./mocks/MockProtocolConfig.sol";
 import {MorphoCredit} from "../../../src/MorphoCredit.sol";
 import {MarketParams, Id} from "../../../src/interfaces/IMorpho.sol";
 import {MarketParamsLib} from "../../../src/libraries/MarketParamsLib.sol";
+import {ProtocolConfigLib} from "../../../src/libraries/ProtocolConfigLib.sol";
 
 contract sUSD3Test is Setup {
     using MarketParamsLib for MarketParams;
@@ -27,6 +28,7 @@ contract sUSD3Test is Setup {
     // Test users
     address public alice = makeAddr("alice");
     address public bob = makeAddr("bob");
+    address public facility = makeAddr("facility");
 
     function setUp() public override {
         super.setUp();
@@ -77,6 +79,24 @@ contract sUSD3Test is Setup {
         vm.label(address(susd3Strategy), "sUSD3");
         vm.label(alice, "alice");
         vm.label(bob, "bob");
+        vm.label(facility, "facility");
+    }
+
+    function _setCommittedLiquidity(uint256 amount) internal {
+        testProtocolConfig.setConfig(ProtocolConfigLib.COMMITTED_LIQUIDITY, amount);
+    }
+
+    function _setCommittedLiquidityFacility(address facility_) internal {
+        testProtocolConfig.setConfig(ProtocolConfigLib.COMMITTED_LIQUIDITY_FACILITY, uint256(uint160(facility_)));
+    }
+
+    function _setMinBackingRatio(uint256 ratio) internal {
+        testProtocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, ratio);
+    }
+
+    function _drawCommittedLiquidity(uint256 amount) internal {
+        vm.prank(facility);
+        usd3.drawCommittedLiquidity(amount);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -352,6 +372,51 @@ contract sUSD3Test is Setup {
 
         // The exact limit depends on share price conversion, but it should be much less than the initial max
         assertLt(remainingLimit, maxDeposit / 5); // Less than 20% of initial max
+    }
+
+    function test_committedLiquidityIncreasesSubordinatedDebtCap() public {
+        setMorphoDebtCap(0);
+        _setCommittedLiquidity(2_000e6);
+
+        assertEq(susd3Strategy.getSubordinatedDebtCapInUSDC(), 300e6, "full commitment should set cap exposure");
+        assertApproxEqAbs(susd3Strategy.availableDepositLimit(bob), 300e6, 2, "deposit cap should use commitment");
+    }
+
+    function test_committedLiquidityDrawnPreservesActualExposureWhenCommitmentLowered() public {
+        setMorphoDebtCap(0);
+        _setCommittedLiquidity(2_000e6);
+        _setCommittedLiquidityFacility(facility);
+
+        _drawCommittedLiquidity(1_000e6);
+        _setCommittedLiquidity(500e6);
+
+        assertEq(usd3.committedLiquidityDrawn(), 1_000e6, "setup should leave drawn exposure");
+        assertEq(susd3Strategy.getSubordinatedDebtCapInUSDC(), 150e6, "cap should not drop below drawn exposure");
+    }
+
+    function test_committedLiquidityDrawnCountsTowardSusd3WithdrawFloor() public {
+        _setCommittedLiquidity(2_000e6);
+        _setCommittedLiquidityFacility(facility);
+        _setMinBackingRatio(10_000);
+
+        vm.startPrank(bob);
+        ERC20(address(usd3)).approve(address(susd3Strategy), 1_500e6);
+        uint256 shares = susd3Strategy.deposit(1_500e6, bob);
+        vm.stopPrank();
+
+        _drawCommittedLiquidity(1_000e6);
+
+        skip(90 days + 1);
+        vm.prank(bob);
+        susd3Strategy.startCooldown(shares);
+        skip(7 days + 1);
+
+        uint256 withdrawLimit = susd3Strategy.availableWithdrawLimit(bob);
+        assertApproxEqAbs(withdrawLimit, 500e6, 2, "floor should reserve backing for drawn liquidity");
+
+        vm.prank(bob);
+        vm.expectRevert("ERC4626: redeem more than max");
+        susd3Strategy.redeem(shares, bob, bob);
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

Adds a revolving committed-liquidity facility to USD3: a configured external address can draw USDC against a configured commitment size, repayments reopen the line, and management can write down drawn principal as a loss.

- Two new `ProtocolConfig` keys:
  - `COMMITTED_LIQUIDITY` — commitment size in USDC.
  - `COMMITTED_LIQUIDITY_FACILITY` — authorized facility address (stored as `uint160`-cast `uint256`).
- New USD3 state `committedLiquidityDrawn` tracks outstanding drawn principal. Storage gap reduced 40 → 39 to absorb the new slot.
- `_harvestAndReport` adds `committedLiquidityDrawn` to total assets, so share price is preserved across draws and repays.
- `availableWithdrawLimit` reserves only the **undrawn** portion of the commitment from senior withdrawals; drawn principal is treated as a receivable rather than withheld idle cash.
- Draws are gated by `TokenizedStrategy.isShutdown()` and `ProtocolConfig.IS_PAUSED`; the facility path bypasses the senior commitment-time lock because the flow is protocol-side, not LP-side.

## Entry points

- `drawCommittedLiquidity(assets)` — facility-only; checks commitment cap, unwinds Morpho if needed for liquidity, transfers USDC, increments drawn.
- `repayCommittedLiquidity(assets)` — permissionless; `type(uint256).max` repays full outstanding; repaid principal reopens revolving capacity.
- `writeDownCommittedLiquidity(assets)` — management-only; reduces drawn principal so the next `report()` realizes the NAV drop through the existing `_postReportHook` (sUSD3 absorbs first).

## Views and events

- Views: `committedLiquidity()`, `committedLiquidityFacility()`, `availableCommittedLiquidity()`, `maxCommittedLiquidityDraw()`.
- Events: `CommittedLiquidityDrawn`, `CommittedLiquidityRepaid`, `CommittedLiquidityWrittenDown`.
- Internal helper `_liquidAssets()` (idle + redeemable waUSDC, accounting for waUSDC pause) shared between `availableWithdrawLimit`, `drawCommittedLiquidity`, and `maxCommittedLiquidityDraw`.

## Files

- `src/libraries/ProtocolConfigLib.sol` — new `COMMITTED_LIQUIDITY` and `COMMITTED_LIQUIDITY_FACILITY` keys.
- `src/usd3/USD3.sol` — state, views, entry points, events, `_liquidAssets` helper, withdraw-limit and total-assets updates.
- `src/usd3/interfaces/IUSD3.sol` — mirror new events, views, and entry points.
- `test/forge/usd3/USD3CommittedLiquidity.t.sol` — facility auth; draw against idle and via Morpho unwind; reverts for commitment cap, liquidity, shutdown, pause; commitment-time bypass; undrawn-only withdraw math; repay paths (max sentinel, third-party, overpayment, revolving redraw); PPS preservation across `report` after draw; write-down loss realization with sUSD3 absorption.
- `test/forge/usd3/Invariants.t.sol` — model includes drawn principal in totalAssets; new invariant asserts `availableWithdrawLimit(actor) <= liquidAssets - availableCommittedLiquidity()`.

## Test plan

- [ ] `yarn build:forge`
- [ ] `yarn run test:forge --match-path 'test/forge/usd3/USD3CommittedLiquidity.t.sol' -vvv`
- [ ] `yarn run test:forge --match-path 'test/forge/usd3/**/*.t.sol'`
- [ ] `yarn test:forge:invariant:usd3`