### PR TITLE
feat(usd3): nominal sUSD3 backing floor

### DIFF
--- a/src/libraries/ProtocolConfigLib.sol
+++ b/src/libraries/ProtocolConfigLib.sol
@@ -28,6 +28,7 @@ library ProtocolConfigLib {
     bytes32 internal constant TRANCHE_RATIO = keccak256("TRANCHE_RATIO");
     bytes32 internal constant TRANCHE_SHARE_VARIANT = keccak256("TRANCHE_SHARE_VARIANT");
     bytes32 internal constant MIN_SUSD3_BACKING_RATIO = keccak256("MIN_SUSD3_BACKING_RATIO");
+    bytes32 internal constant NOMINAL_SUBORDINATION_FLOOR = keccak256("NOMINAL_SUBORDINATION_FLOOR");
 
     // Timing Keys
     bytes32 internal constant SUSD3_LOCK_DURATION = keccak256("SUSD3_LOCK_DURATION");

--- a/src/libraries/ProtocolConfigLib.sol
+++ b/src/libraries/ProtocolConfigLib.sol
@@ -28,7 +28,7 @@ library ProtocolConfigLib {
     bytes32 internal constant TRANCHE_RATIO = keccak256("TRANCHE_RATIO");
     bytes32 internal constant TRANCHE_SHARE_VARIANT = keccak256("TRANCHE_SHARE_VARIANT");
     bytes32 internal constant MIN_SUSD3_BACKING_RATIO = keccak256("MIN_SUSD3_BACKING_RATIO");
-    bytes32 internal constant NOMINAL_SUBORDINATION_FLOOR = keccak256("NOMINAL_SUBORDINATION_FLOOR");
+    bytes32 internal constant SUSD3_NOMINAL_BACKING_FLOOR = keccak256("SUSD3_NOMINAL_BACKING_FLOOR");
 
     // Timing Keys
     bytes32 internal constant SUSD3_LOCK_DURATION = keccak256("SUSD3_LOCK_DURATION");

--- a/src/usd3/sUSD3.sol
+++ b/src/usd3/sUSD3.sol
@@ -421,12 +421,12 @@ contract sUSD3 is BaseHooksUpgradeable {
     }
 
     /**
-     * @notice Get the nominal subordination floor from ProtocolConfig
-     * @return Nominal subordination floor, expressed in USDC
+     * @notice Get the nominal backing floor from ProtocolConfig
+     * @return Nominal backing floor, expressed in USDC
      */
-    function nominalSubordinationFloor() public view returns (uint256) {
+    function nominalBackingFloor() public view returns (uint256) {
         IProtocolConfig config = IProtocolConfig(IMorphoCredit(morphoCredit).protocolConfig());
-        return config.config(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR);
+        return config.config(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR);
     }
 
     /**
@@ -463,11 +463,11 @@ contract sUSD3 is BaseHooksUpgradeable {
 
     /**
      * @notice Calculate minimum sUSD3 backing required for current market debt
-     * @dev Returns the greater of the ratio-based floor and nominal subordination floor
+     * @dev Returns the greater of the ratio-based floor and nominal backing floor
      * @return Minimum backing amount required, expressed in USDC
      */
     function getSubordinatedDebtFloorInUSDC() public view returns (uint256) {
-        uint256 nominalFloor = nominalSubordinationFloor();
+        uint256 nominalFloor = nominalBackingFloor();
         uint256 backingRatio = minBackingRatio();
 
         uint256 ratioFloor;

--- a/src/usd3/sUSD3.sol
+++ b/src/usd3/sUSD3.sol
@@ -422,6 +422,7 @@ contract sUSD3 is BaseHooksUpgradeable {
 
     /**
      * @notice Get the nominal backing floor from ProtocolConfig
+     * @dev If set above achievable sUSD3 backing capacity, withdrawals can remain blocked.
      * @return Nominal backing floor, expressed in USDC
      */
     function nominalBackingFloor() public view returns (uint256) {
@@ -474,11 +475,9 @@ contract sUSD3 is BaseHooksUpgradeable {
         if (backingRatio > 0) {
             USD3 usd3 = USD3(address(asset));
 
-            // Get actual borrowed amount
             (,, uint256 totalBorrowAssetsWaUSDC,) = usd3.getMarketLiquidity();
             uint256 debtUSDC = usd3.WAUSDC().convertToAssets(totalBorrowAssetsWaUSDC);
 
-            // Calculate minimum required backing
             ratioFloor = (debtUSDC * backingRatio) / MAX_BPS;
         }
 

--- a/src/usd3/sUSD3.sol
+++ b/src/usd3/sUSD3.sol
@@ -421,6 +421,15 @@ contract sUSD3 is BaseHooksUpgradeable {
     }
 
     /**
+     * @notice Get the nominal subordination floor from ProtocolConfig
+     * @return Nominal subordination floor, expressed in USDC
+     */
+    function nominalSubordinationFloor() public view returns (uint256) {
+        IProtocolConfig config = IProtocolConfig(IMorphoCredit(morphoCredit).protocolConfig());
+        return config.config(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR);
+    }
+
+    /**
      * @notice Calculate maximum sUSD3 deposits allowed based on debt and subordination ratio
      * @dev Returns the cap amount for subordinated debt based on actual or potential market debt
      * @return Maximum subordinated debt cap, expressed in USDC
@@ -454,24 +463,26 @@ contract sUSD3 is BaseHooksUpgradeable {
 
     /**
      * @notice Calculate minimum sUSD3 backing required for current market debt
-     * @dev Returns the floor amount of sUSD3 assets needed based on MIN_SUSD3_BACKING_RATIO
+     * @dev Returns the greater of the ratio-based floor and nominal subordination floor
      * @return Minimum backing amount required, expressed in USDC
      */
     function getSubordinatedDebtFloorInUSDC() public view returns (uint256) {
-        // Get minimum backing ratio
+        uint256 nominalFloor = nominalSubordinationFloor();
         uint256 backingRatio = minBackingRatio();
 
-        // If backing ratio is 0, no minimum backing required
-        if (backingRatio == 0) return 0;
+        uint256 ratioFloor;
+        if (backingRatio > 0) {
+            USD3 usd3 = USD3(address(asset));
 
-        USD3 usd3 = USD3(address(asset));
+            // Get actual borrowed amount
+            (,, uint256 totalBorrowAssetsWaUSDC,) = usd3.getMarketLiquidity();
+            uint256 debtUSDC = usd3.WAUSDC().convertToAssets(totalBorrowAssetsWaUSDC);
 
-        // Get actual borrowed amount
-        (,, uint256 totalBorrowAssetsWaUSDC,) = usd3.getMarketLiquidity();
-        uint256 debtUSDC = usd3.WAUSDC().convertToAssets(totalBorrowAssetsWaUSDC);
+            // Calculate minimum required backing
+            ratioFloor = (debtUSDC * backingRatio) / MAX_BPS;
+        }
 
-        // Calculate minimum required backing
-        return (debtUSDC * backingRatio) / MAX_BPS;
+        return Math.max(ratioFloor, nominalFloor);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
+++ b/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
@@ -176,6 +176,53 @@ contract DebtFloorComprehensiveTest is Setup {
         assertLt(withdrawLimit2, bobAssets, "Withdrawal should be limited after backing ratio change");
     }
 
+    function test_debtFloor_zeroBackingRatio_usesNominalSubordinationFloor() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 100_000e6);
+
+        vm.prank(alice);
+        strategy.deposit(DEPOSIT_AMOUNT, alice);
+
+        setMaxOnCredit(8000);
+        createMarketDebt(borrower, 500_000e6);
+
+        assertEq(susd3Strategy.nominalSubordinationFloor(), 100_000e6, "nominal floor mismatch");
+        assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 100_000e6, "should use nominal floor");
+    }
+
+    function test_debtFloor_zeroDebt_usesNominalSubordinationFloor() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 5000);
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 75_000e6);
+
+        assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 75_000e6, "should use nominal floor without debt");
+    }
+
+    function test_debtFloor_nominalFloorDominatesRatioFloor() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 1000); // 10%
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 50_000e6);
+
+        vm.prank(alice);
+        strategy.deposit(DEPOSIT_AMOUNT, alice);
+
+        setMaxOnCredit(8000);
+        createMarketDebt(borrower, 100_000e6); // 10K ratio floor
+
+        assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 50_000e6, "nominal floor should dominate");
+    }
+
+    function test_debtFloor_ratioFloorDominatesNominalFloor() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 5000); // 50%
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 10_000e6);
+
+        vm.prank(alice);
+        strategy.deposit(DEPOSIT_AMOUNT, alice);
+
+        setMaxOnCredit(8000);
+        createMarketDebt(borrower, 100_000e6); // 50K ratio floor
+
+        assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 50_000e6, "ratio floor should dominate");
+    }
+
     /*//////////////////////////////////////////////////////////////
                     BOUNDARY CONDITION TESTING
     //////////////////////////////////////////////////////////////*/
@@ -398,6 +445,90 @@ contract DebtFloorComprehensiveTest is Setup {
             0.05e18, // 5% tolerance for interest accrual
             "Floor should reflect new backing ratio"
         );
+    }
+
+    function test_debtFloor_nominalFloorLimitsWithdrawalsToExcessAboveFloor() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 100_000e6);
+
+        vm.prank(alice);
+        strategy.deposit(DEPOSIT_AMOUNT, alice);
+
+        vm.prank(bob);
+        strategy.deposit(500_000e6, bob);
+
+        setMaxOnCredit(8000);
+        createMarketDebt(borrower, 500_000e6);
+
+        vm.prank(bob);
+        strategy.approve(address(susd3Strategy), 250_000e6);
+
+        vm.prank(bob);
+        uint256 bobSUSD3Shares = susd3Strategy.deposit(250_000e6, bob);
+
+        skip(91 days);
+        vm.prank(bob);
+        susd3Strategy.startCooldown(bobSUSD3Shares);
+        skip(8 days);
+
+        uint256 holdingsUSDC =
+            ITokenizedStrategy(address(usd3Strategy)).convertToAssets(strategy.balanceOf(address(susd3Strategy)));
+        uint256 expectedLimit = ITokenizedStrategy(address(usd3Strategy)).convertToShares(holdingsUSDC - 100_000e6);
+
+        assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 100_000e6, "nominal floor mismatch");
+        assertApproxEqAbs(
+            susd3Strategy.availableWithdrawLimit(bob), expectedLimit, 2, "withdraw limit should preserve floor"
+        );
+    }
+
+    function test_debtFloor_nominalFloorChangeDuringCooldown() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 50_000e6);
+
+        vm.prank(alice);
+        strategy.deposit(DEPOSIT_AMOUNT, alice);
+
+        vm.prank(bob);
+        strategy.deposit(500_000e6, bob);
+
+        setMaxOnCredit(8000);
+        createMarketDebt(borrower, 500_000e6);
+
+        vm.prank(bob);
+        strategy.approve(address(susd3Strategy), 250_000e6);
+
+        vm.prank(bob);
+        uint256 bobSUSD3Shares = susd3Strategy.deposit(250_000e6, bob);
+
+        skip(91 days);
+        vm.prank(bob);
+        susd3Strategy.startCooldown(bobSUSD3Shares);
+        skip(8 days);
+
+        uint256 withdrawLimitBefore = susd3Strategy.availableWithdrawLimit(bob);
+
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 150_000e6);
+
+        uint256 withdrawLimitAfter = susd3Strategy.availableWithdrawLimit(bob);
+        uint256 holdingsUSDC =
+            ITokenizedStrategy(address(usd3Strategy)).convertToAssets(strategy.balanceOf(address(susd3Strategy)));
+        uint256 expectedLimit = ITokenizedStrategy(address(usd3Strategy)).convertToShares(holdingsUSDC - 150_000e6);
+
+        assertLt(withdrawLimitAfter, withdrawLimitBefore, "higher nominal floor should reduce withdrawal limit");
+        assertApproxEqAbs(withdrawLimitAfter, expectedLimit, 2, "withdraw limit should use updated nominal floor");
+    }
+
+    function test_debtFloor_nominalFloorDoesNotChangeDepositLimit() public {
+        protocolConfig.setConfig(ProtocolConfigLib.DEBT_CAP, 500_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.TRANCHE_RATIO, 1500); // 15%
+
+        uint256 depositLimitBefore = susd3Strategy.availableDepositLimit(alice);
+
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 1_000_000e6);
+
+        uint256 depositLimitAfter = susd3Strategy.availableDepositLimit(alice);
+
+        assertEq(depositLimitAfter, depositLimitBefore, "nominal floor should not affect deposit cap");
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
+++ b/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
@@ -481,6 +481,31 @@ contract DebtFloorComprehensiveTest is Setup {
         );
     }
 
+    function test_debtFloor_nominalFloorBlocksWithdrawalAtExactFloor() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 100_000e6);
+
+        vm.prank(bob);
+        strategy.deposit(100_000e6, bob);
+
+        vm.prank(bob);
+        strategy.approve(address(susd3Strategy), 100_000e6);
+
+        vm.prank(bob);
+        uint256 bobSUSD3Shares = susd3Strategy.deposit(100_000e6, bob);
+
+        skip(91 days);
+        vm.prank(bob);
+        susd3Strategy.startCooldown(bobSUSD3Shares);
+        skip(8 days);
+
+        uint256 holdingsUSDC =
+            ITokenizedStrategy(address(usd3Strategy)).convertToAssets(strategy.balanceOf(address(susd3Strategy)));
+
+        assertEq(holdingsUSDC, 100_000e6, "holdings should equal nominal floor");
+        assertEq(susd3Strategy.availableWithdrawLimit(bob), 0, "withdrawal should be blocked at exact floor");
+    }
+
     function test_debtFloor_nominalFloorChangeDuringCooldown() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
         protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 50_000e6);

--- a/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
+++ b/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
@@ -176,9 +176,9 @@ contract DebtFloorComprehensiveTest is Setup {
         assertLt(withdrawLimit2, bobAssets, "Withdrawal should be limited after backing ratio change");
     }
 
-    function test_debtFloor_zeroBackingRatio_usesNominalSubordinationFloor() public {
+    function test_debtFloor_zeroBackingRatio_usesNominalBackingFloor() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 100_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 100_000e6);
 
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -186,20 +186,20 @@ contract DebtFloorComprehensiveTest is Setup {
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 500_000e6);
 
-        assertEq(susd3Strategy.nominalSubordinationFloor(), 100_000e6, "nominal floor mismatch");
+        assertEq(susd3Strategy.nominalBackingFloor(), 100_000e6, "nominal floor mismatch");
         assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 100_000e6, "should use nominal floor");
     }
 
-    function test_debtFloor_zeroDebt_usesNominalSubordinationFloor() public {
+    function test_debtFloor_zeroDebt_usesNominalBackingFloor() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 5000);
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 75_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 75_000e6);
 
         assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 75_000e6, "should use nominal floor without debt");
     }
 
     function test_debtFloor_nominalFloorDominatesRatioFloor() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 1000); // 10%
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 50_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 50_000e6);
 
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -212,7 +212,7 @@ contract DebtFloorComprehensiveTest is Setup {
 
     function test_debtFloor_ratioFloorDominatesNominalFloor() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 5000); // 50%
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 10_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 10_000e6);
 
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -449,7 +449,7 @@ contract DebtFloorComprehensiveTest is Setup {
 
     function test_debtFloor_nominalFloorLimitsWithdrawalsToExcessAboveFloor() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 100_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 100_000e6);
 
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -483,7 +483,7 @@ contract DebtFloorComprehensiveTest is Setup {
 
     function test_debtFloor_nominalFloorChangeDuringCooldown() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 50_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 50_000e6);
 
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -507,7 +507,7 @@ contract DebtFloorComprehensiveTest is Setup {
 
         uint256 withdrawLimitBefore = susd3Strategy.availableWithdrawLimit(bob);
 
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 150_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 150_000e6);
 
         uint256 withdrawLimitAfter = susd3Strategy.availableWithdrawLimit(bob);
         uint256 holdingsUSDC =
@@ -524,7 +524,7 @@ contract DebtFloorComprehensiveTest is Setup {
 
         uint256 depositLimitBefore = susd3Strategy.availableDepositLimit(alice);
 
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 1_000_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 1_000_000e6);
 
         uint256 depositLimitAfter = susd3Strategy.availableDepositLimit(alice);
 

--- a/test/forge/usd3/invariants/DebtFloorInvariants.t.sol
+++ b/test/forge/usd3/invariants/DebtFloorInvariants.t.sol
@@ -7,6 +7,7 @@ import {USD3} from "../../../../src/usd3/USD3.sol";
 import {sUSD3} from "../../../../src/usd3/sUSD3.sol";
 import {MorphoCredit} from "../../../../src/MorphoCredit.sol";
 import {MockProtocolConfig} from "../mocks/MockProtocolConfig.sol";
+import {ProtocolConfigLib} from "../../../../src/libraries/ProtocolConfigLib.sol";
 import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
 import {
     TransparentUpgradeableProxy
@@ -46,7 +47,8 @@ contract DebtFloorInvariantsTest is StdInvariant, Setup {
         // Configure floor/cap environment.
         setMaxOnCredit(8000);
         setMorphoDebtCap(20_000_000e6);
-        protocolConfig.setConfig(keccak256("MIN_SUSD3_BACKING_RATIO"), 3000); // 30%
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 3000); // 30%
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 400_000e6);
 
         // Seed liquidity and debt.
         address alice = makeAddr("debt-floor-alice");
@@ -99,7 +101,9 @@ contract DebtFloorInvariantsTest is StdInvariant, Setup {
         (,, uint256 totalBorrowAssetsWaUSDC,) = usd3Strategy.getMarketLiquidity();
         uint256 debtUsdc = usd3Strategy.WAUSDC().convertToAssets(totalBorrowAssetsWaUSDC);
         uint256 backingRatio = susd3Strategy.minBackingRatio();
-        uint256 expectedFloor = (debtUsdc * backingRatio) / 10_000;
+        uint256 ratioFloor = (debtUsdc * backingRatio) / 10_000;
+        uint256 nominalFloor = susd3Strategy.nominalSubordinationFloor();
+        uint256 expectedFloor = ratioFloor > nominalFloor ? ratioFloor : nominalFloor;
 
         assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), expectedFloor, "debt floor formula mismatch");
     }

--- a/test/forge/usd3/invariants/DebtFloorInvariants.t.sol
+++ b/test/forge/usd3/invariants/DebtFloorInvariants.t.sol
@@ -48,7 +48,7 @@ contract DebtFloorInvariantsTest is StdInvariant, Setup {
         setMaxOnCredit(8000);
         setMorphoDebtCap(20_000_000e6);
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 3000); // 30%
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 400_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 400_000e6);
 
         // Seed liquidity and debt.
         address alice = makeAddr("debt-floor-alice");
@@ -102,7 +102,7 @@ contract DebtFloorInvariantsTest is StdInvariant, Setup {
         uint256 debtUsdc = usd3Strategy.WAUSDC().convertToAssets(totalBorrowAssetsWaUSDC);
         uint256 backingRatio = susd3Strategy.minBackingRatio();
         uint256 ratioFloor = (debtUsdc * backingRatio) / 10_000;
-        uint256 nominalFloor = susd3Strategy.nominalSubordinationFloor();
+        uint256 nominalFloor = susd3Strategy.nominalBackingFloor();
         uint256 expectedFloor = ratioFloor > nominalFloor ? ratioFloor : nominalFloor;
 
         assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), expectedFloor, "debt floor formula mismatch");


### PR DESCRIPTION
## Summary

Introduces a governance-controlled nominal floor on the sUSD3 subordinated-debt backing requirement. The previous floor was purely a percentage of outstanding debt, so when market debt was low (or zero) the floor collapsed and sUSD3 holders could fully withdraw, leaving the senior tranche without a baseline equity buffer.

The effective floor on sUSD3 holdings is now:

```
max(debtUSDC * MIN_SUSD3_BACKING_RATIO / 10_000, SUSD3_NOMINAL_BACKING_FLOOR)
```

### Changes

- New `SUSD3_NOMINAL_BACKING_FLOOR` key in `ProtocolConfigLib`, denominated in USDC base units (6 decimals). No `IProtocolConfig` ABI change — consumers read it via the existing `config(bytes32)` getter, matching the `MIN_SUSD3_BACKING_RATIO` precedent.
- New `sUSD3.nominalBackingFloor()` view exposes the value.
- `sUSD3.getSubordinatedDebtFloorInUSDC()` returns the greater of the ratio-based floor and the nominal floor. The function is the single point of truth — `availableWithdrawLimit` already routes through it.
- `availableDepositLimit` is intentionally unchanged. `TRANCHE_RATIO` remains the sole sUSD3 deposit cap.

Governance trust: setting `SUSD3_NOMINAL_BACKING_FLOOR` above the achievable sUSD3 deposit capacity can leave existing holders unable to withdraw. This is documented at the read site and matches the trust model for other ProtocolConfig knobs.

## Test plan

- [x] `yarn run test:forge --match-path 'test/forge/usd3/integration/DebtFloorComprehensive.t.sol'` — 8 new cases covering: nominal-dominates, ratio-dominates, zero-ratio + non-zero-nominal, zero-debt + non-zero-nominal, withdrawal limited to excess above floor, nominal change during cooldown, withdrawal blocked at exact floor, deposit-limit isolation
- [x] `yarn run test:forge --match-path 'test/forge/usd3/invariants/DebtFloorInvariants.t.sol'` — formula assertion updated to `max(ratioFloor, nominalFloor)`; handler seeds the nominal floor so both regimes are exercised during fuzz
- [x] `yarn run test:forge --match-path 'test/forge/usd3/integration/DebtCapAndBacking.t.sol'` regression
- [ ] `yarn test:forge:invariant:usd3` in CI