### PR TITLE
feat(usd3): allow zero sUSD3 lock duration

### DIFF
--- a/src/usd3/README.md
+++ b/src/usd3/README.md
@@ -28,7 +28,7 @@ USD3 and sUSD3 are tokenized yield strategies built on Yearn V3's architecture f
 #### sUSD3 Strategy
 
 - Accepts USD3 tokens to provide subordinate capital
-- Configurable lock period for stability (via ProtocolConfig, default 90 days)
+- Configurable lock period for stability (via ProtocolConfig; 0 disables new locks)
 - Configurable cooldown period (via ProtocolConfig, default 7 days) + withdrawal window (local, default 2 days)
 - Partial cooldown support for better UX
 - First-loss absorption protects USD3 holders
@@ -270,7 +270,7 @@ Centrally managed parameters (with defaults):
 
 - **sUSD3 Parameters**:
   - Subordination ratio (default 15%)
-  - Lock duration (default 90 days)
+  - Lock duration (0 disables new locks)
   - Cooldown period (default 7 days)
   - Interest distribution share
 

--- a/src/usd3/sUSD3.sol
+++ b/src/usd3/sUSD3.sol
@@ -141,11 +141,12 @@ contract sUSD3 is BaseHooksUpgradeable {
             msg.sender == receiver || depositorWhitelist[msg.sender], "sUSD3: Only self or whitelisted deposits allowed"
         );
 
-        // Always extend lock period for valid deposits
+        // Extend lock period for valid deposits when configured.
         if (assets > 0 || shares > 0) {
-            // Read lock duration from ProtocolConfig
             uint256 duration = lockDuration();
-            lockedUntil[receiver] = block.timestamp + duration;
+            if (duration > 0) {
+                lockedUntil[receiver] = block.timestamp + duration;
+            }
         }
     }
 
@@ -363,9 +364,7 @@ contract sUSD3 is BaseHooksUpgradeable {
      */
     function lockDuration() public view returns (uint256) {
         IProtocolConfig config = IProtocolConfig(IMorphoCredit(morphoCredit).protocolConfig());
-
-        uint256 duration = config.getSusd3LockDuration();
-        return duration > 0 ? duration : 90 days; // Default to 90 days if not set
+        return config.getSusd3LockDuration();
     }
 
     /**

--- a/test/forge/usd3/coverage/sUSD3Coverage.t.sol
+++ b/test/forge/usd3/coverage/sUSD3Coverage.t.sol
@@ -256,10 +256,10 @@ contract sUSD3Coverage is Setup {
         uint256 newDuration = susd3Strategy.lockDuration();
         assertEq(newDuration, 60 days, "Should return updated duration");
 
-        // Test zero fallback
+        // Test zero duration
         protocolConfig.setConfig(SUSD3_LOCK_DURATION, 0);
         uint256 zeroDuration = susd3Strategy.lockDuration();
-        assertEq(zeroDuration, 90 days, "Should fallback to 90 days when 0");
+        assertEq(zeroDuration, 0, "Should return zero when configured");
     }
 
     /**

--- a/test/forge/usd3/sUSD3.t.sol
+++ b/test/forge/usd3/sUSD3.t.sol
@@ -380,6 +380,96 @@ contract sUSD3Test is Setup {
         assertEq(susd3Strategy.withdrawalWindow(), 3 days);
     }
 
+    function test_lockDurationReturnsZeroWhenConfigZero() public {
+        address morphoAddress = address(usd3.morphoCredit());
+        address protocolConfigAddress = MorphoCredit(morphoAddress).protocolConfig();
+        MockProtocolConfig protocolConfig = MockProtocolConfig(protocolConfigAddress);
+
+        bytes32 SUSD3_LOCK_DURATION = keccak256("SUSD3_LOCK_DURATION");
+        protocolConfig.setConfig(SUSD3_LOCK_DURATION, 0);
+
+        assertEq(susd3Strategy.lockDuration(), 0);
+    }
+
+    function test_zeroLockAllowsImmediateTransfer() public {
+        address morphoAddress = address(usd3.morphoCredit());
+        address protocolConfigAddress = MorphoCredit(morphoAddress).protocolConfig();
+        MockProtocolConfig protocolConfig = MockProtocolConfig(protocolConfigAddress);
+
+        bytes32 SUSD3_LOCK_DURATION = keccak256("SUSD3_LOCK_DURATION");
+        protocolConfig.setConfig(SUSD3_LOCK_DURATION, 0);
+
+        uint256 depositAmount = 100e6;
+        vm.startPrank(alice);
+        ERC20(address(usd3)).approve(address(susd3Strategy), depositAmount);
+        uint256 shares = susd3Strategy.deposit(depositAmount, alice);
+        ERC20(address(susd3Strategy)).transfer(bob, shares);
+        vm.stopPrank();
+
+        assertEq(ERC20(address(susd3Strategy)).balanceOf(bob), shares);
+    }
+
+    function test_zeroLockAllowsImmediateCooldown() public {
+        address morphoAddress = address(usd3.morphoCredit());
+        address protocolConfigAddress = MorphoCredit(morphoAddress).protocolConfig();
+        MockProtocolConfig protocolConfig = MockProtocolConfig(protocolConfigAddress);
+
+        bytes32 SUSD3_LOCK_DURATION = keccak256("SUSD3_LOCK_DURATION");
+        protocolConfig.setConfig(SUSD3_LOCK_DURATION, 0);
+
+        uint256 depositAmount = 100e6;
+        vm.startPrank(alice);
+        ERC20(address(usd3)).approve(address(susd3Strategy), depositAmount);
+        uint256 shares = susd3Strategy.deposit(depositAmount, alice);
+        susd3Strategy.startCooldown(shares);
+        vm.stopPrank();
+
+        (uint256 cooldownEnd, uint256 windowEnd, uint256 cooldownShares) = susd3Strategy.getCooldownStatus(alice);
+        assertEq(cooldownEnd, block.timestamp + 7 days);
+        assertEq(windowEnd, block.timestamp + 7 days + 2 days);
+        assertEq(cooldownShares, shares);
+    }
+
+    function test_zeroLockSkipsStorageWrite() public {
+        address morphoAddress = address(usd3.morphoCredit());
+        address protocolConfigAddress = MorphoCredit(morphoAddress).protocolConfig();
+        MockProtocolConfig protocolConfig = MockProtocolConfig(protocolConfigAddress);
+
+        bytes32 SUSD3_LOCK_DURATION = keccak256("SUSD3_LOCK_DURATION");
+        protocolConfig.setConfig(SUSD3_LOCK_DURATION, 0);
+
+        uint256 depositAmount = 100e6;
+        vm.startPrank(alice);
+        ERC20(address(usd3)).approve(address(susd3Strategy), depositAmount);
+        susd3Strategy.deposit(depositAmount, alice);
+        vm.stopPrank();
+
+        assertEq(susd3Strategy.lockedUntil(alice), 0);
+    }
+
+    function test_zeroLockPreservesPriorLock() public {
+        address morphoAddress = address(usd3.morphoCredit());
+        address protocolConfigAddress = MorphoCredit(morphoAddress).protocolConfig();
+        MockProtocolConfig protocolConfig = MockProtocolConfig(protocolConfigAddress);
+
+        uint256 firstDeposit = 100e6;
+        vm.startPrank(alice);
+        ERC20(address(usd3)).approve(address(susd3Strategy), type(uint256).max);
+        susd3Strategy.deposit(firstDeposit, alice);
+
+        uint256 originalLock = susd3Strategy.lockedUntil(alice);
+        vm.stopPrank();
+
+        bytes32 SUSD3_LOCK_DURATION = keccak256("SUSD3_LOCK_DURATION");
+        protocolConfig.setConfig(SUSD3_LOCK_DURATION, 0);
+
+        vm.startPrank(alice);
+        susd3Strategy.deposit(100e6, alice);
+        vm.stopPrank();
+
+        assertEq(susd3Strategy.lockedUntil(alice), originalLock);
+    }
+
     function test_setParameters_invalidValues() public {
         // Get protocol config
         address morphoAddress = address(usd3.morphoCredit());


### PR DESCRIPTION
## Summary

- `sUSD3.lockDuration()` now returns `ProtocolConfig.getSusd3LockDuration()` directly, removing the silent `0 -> 90 days` fallback. This mirrors how `cooldownDuration()` already treats `0` as disabled.
- `_preDepositHook` skips the `lockedUntil` storage write when `duration == 0`: fresh depositors stay at `lockedUntil = 0` (passes all gate checks same-block), and returning depositors keep their prior nonzero lock instead of having it overwritten to `block.timestamp`.
- Docs in `src/usd3/README.md` updated to reflect that lock duration is fully config-driven.

## Behavior notes

- Environments that still want a 90-day lock must explicitly set `SUSD3_LOCK_DURATION = 90 days` in `ProtocolConfig`. Test mocks (`MockProtocolConfig`) keep that default, so the existing default-lock test paths are unchanged.
- Cooldown is unaffected — `SUSD3_COOLDOWN_PERIOD` is independent of the lock setting.
- No ABI or storage layout changes.

## Test plan

- [x] `yarn run test:forge --match-path 'test/forge/usd3/sUSD3.t.sol' -vvv` — 29/29 pass, including 5 new tests:
  - `test_lockDurationReturnsZeroWhenConfigZero`
  - `test_zeroLockAllowsImmediateTransfer`
  - `test_zeroLockAllowsImmediateCooldown`
  - `test_zeroLockSkipsStorageWrite`
  - `test_zeroLockPreservesPriorLock`
- [x] `yarn run test:forge --match-path 'test/forge/usd3/coverage/sUSD3Coverage.t.sol' -vvv` — 9/9 pass (updated `test_lockDurationFunction` zero assertion).
- [x] `yarn run test:forge --match-path 'test/forge/usd3/security/**' -vvv` — 83/83 pass across 8 suites; mock-default 90-day regression path intact.
- [x] `forge fmt --check` on the four touched files: clean.