### PR TITLE
audit scope v1.2: usd3/sUSD3 subordination, tend config, zero-lock

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -144,40 +144,8 @@ jobs:
       - name: Warm Solc Cache
         run: yarn -s build:forge
 
-      - name: Run USD3 Invariants (fast, expect known failure only)
-        shell: bash
-        run: |
-          set -o pipefail
-          LOG_FILE=usd3-invariant-fast.log
-
-          set +e
-          yarn -s test:forge:invariant:usd3 2>&1 | tee "$LOG_FILE"
-          TEST_EXIT=${PIPESTATUS[0]}
-          set -e
-
-          if [ "$TEST_EXIT" -eq 0 ]; then
-            echo "Expected known USD3 invariant failure did not occur."
-            echo "If the underlying bug is fixed, remove this expected-failure gate."
-            exit 1
-          fi
-
-          total_failures=$(grep -Eo "Encountered a total of [0-9]+ failing tests" "$LOG_FILE" | tail -n1 | grep -Eo "[0-9]+" || true)
-          if [ -z "$total_failures" ] || [ "$total_failures" -ne 1 ]; then
-            echo "Expected exactly 1 failing test, got: ${total_failures:-unknown}"
-            exit 1
-          fi
-
-          grep -q "Encountered 1 failing test in test/forge/usd3/Invariants.t.sol:InvariantsTest" "$LOG_FILE" || {
-            echo "Unexpected failing suite. Expected only USD3 InvariantsTest failure."
-            exit 1
-          }
-
-          grep -q "invariant_lossReportsDoNotIncreasePpsWithLockedShares()" "$LOG_FILE" || {
-            echo "Expected failing invariant not found in output."
-            exit 1
-          }
-
-          echo "Observed only the expected USD3 invariant failure."
+      - name: Run USD3 Invariants (fast)
+        run: yarn -s test:forge:invariant:usd3
         env:
           FOUNDRY_PROFILE: test
           FOUNDRY_INVARIANT_RUNS: 32
@@ -202,40 +170,8 @@ jobs:
       - name: Warm Solc Cache
         run: yarn -s build:forge
 
-      - name: Run USD3 Invariants (deep, expect known failure only)
-        shell: bash
-        run: |
-          set -o pipefail
-          LOG_FILE=usd3-invariant-deep.log
-
-          set +e
-          yarn -s test:forge:invariant:usd3:deep 2>&1 | tee "$LOG_FILE"
-          TEST_EXIT=${PIPESTATUS[0]}
-          set -e
-
-          if [ "$TEST_EXIT" -eq 0 ]; then
-            echo "Expected known USD3 invariant failure did not occur."
-            echo "If the underlying bug is fixed, remove this expected-failure gate."
-            exit 1
-          fi
-
-          total_failures=$(grep -Eo "Encountered a total of [0-9]+ failing tests" "$LOG_FILE" | tail -n1 | grep -Eo "[0-9]+" || true)
-          if [ -z "$total_failures" ] || [ "$total_failures" -ne 1 ]; then
-            echo "Expected exactly 1 failing test, got: ${total_failures:-unknown}"
-            exit 1
-          fi
-
-          grep -q "Encountered 1 failing test in test/forge/usd3/Invariants.t.sol:InvariantsTest" "$LOG_FILE" || {
-            echo "Unexpected failing suite. Expected only USD3 InvariantsTest failure."
-            exit 1
-          }
-
-          grep -q "invariant_lossReportsDoNotIncreasePpsWithLockedShares()" "$LOG_FILE" || {
-            echo "Expected failing invariant not found in output."
-            exit 1
-          }
-
-          echo "Observed only the expected USD3 invariant failure."
+      - name: Run USD3 Invariants (deep)
+        run: yarn -s test:forge:invariant:usd3:deep
         env:
           FOUNDRY_PROFILE: test
           FOUNDRY_INVARIANT_RUNS: 256

--- a/src/libraries/ProtocolConfigLib.sol
+++ b/src/libraries/ProtocolConfigLib.sol
@@ -38,6 +38,9 @@ library ProtocolConfigLib {
     // Supply Cap Keys
     bytes32 internal constant USD3_SUPPLY_CAP = keccak256("USD3_SUPPLY_CAP");
 
+    // Tend Keys
+    bytes32 internal constant TEND_DRIFT_THRESHOLD = keccak256("TEND_DRIFT_THRESHOLD");
+
     // Markdown Keys
     bytes32 internal constant FULL_MARKDOWN_DURATION = keccak256("FULL_MARKDOWN_DURATION");
 }

--- a/src/libraries/ProtocolConfigLib.sol
+++ b/src/libraries/ProtocolConfigLib.sol
@@ -28,6 +28,7 @@ library ProtocolConfigLib {
     bytes32 internal constant TRANCHE_RATIO = keccak256("TRANCHE_RATIO");
     bytes32 internal constant TRANCHE_SHARE_VARIANT = keccak256("TRANCHE_SHARE_VARIANT");
     bytes32 internal constant MIN_SUSD3_BACKING_RATIO = keccak256("MIN_SUSD3_BACKING_RATIO");
+    bytes32 internal constant NOMINAL_SUBORDINATION_FLOOR = keccak256("NOMINAL_SUBORDINATION_FLOOR");
 
     // Timing Keys
     bytes32 internal constant SUSD3_LOCK_DURATION = keccak256("SUSD3_LOCK_DURATION");

--- a/src/libraries/ProtocolConfigLib.sol
+++ b/src/libraries/ProtocolConfigLib.sol
@@ -28,7 +28,7 @@ library ProtocolConfigLib {
     bytes32 internal constant TRANCHE_RATIO = keccak256("TRANCHE_RATIO");
     bytes32 internal constant TRANCHE_SHARE_VARIANT = keccak256("TRANCHE_SHARE_VARIANT");
     bytes32 internal constant MIN_SUSD3_BACKING_RATIO = keccak256("MIN_SUSD3_BACKING_RATIO");
-    bytes32 internal constant NOMINAL_SUBORDINATION_FLOOR = keccak256("NOMINAL_SUBORDINATION_FLOOR");
+    bytes32 internal constant SUSD3_NOMINAL_BACKING_FLOOR = keccak256("SUSD3_NOMINAL_BACKING_FLOOR");
 
     // Timing Keys
     bytes32 internal constant SUSD3_LOCK_DURATION = keccak256("SUSD3_LOCK_DURATION");

--- a/src/mocks/ProxyImports.sol
+++ b/src/mocks/ProxyImports.sol
@@ -6,7 +6,5 @@ import {
 } from "lib/openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "lib/openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
-// Dummy contract to force Hardhat to generate types for OpenZeppelin proxy contracts
-contract ProxyImports {
-    // Empty contract - exists only to ensure proxy contract ABIs are included in compilation
-}
+// Dummy contract to force Hardhat to generate types for OpenZeppelin proxy contracts.
+contract ProxyImports {}

--- a/src/usd3/README.md
+++ b/src/usd3/README.md
@@ -28,7 +28,7 @@ USD3 and sUSD3 are tokenized yield strategies built on Yearn V3's architecture f
 #### sUSD3 Strategy
 
 - Accepts USD3 tokens to provide subordinate capital
-- Configurable lock period for stability (via ProtocolConfig, default 90 days)
+- Configurable lock period for stability (via ProtocolConfig; 0 disables new locks)
 - Configurable cooldown period (via ProtocolConfig, default 7 days) + withdrawal window (local, default 2 days)
 - Partial cooldown support for better UX
 - First-loss absorption protects USD3 holders
@@ -270,7 +270,7 @@ Centrally managed parameters (with defaults):
 
 - **sUSD3 Parameters**:
   - Subordination ratio (default 15%)
-  - Lock duration (default 90 days)
+  - Lock duration (0 disables new locks)
   - Cooldown period (default 7 days)
   - Interest distribution share
 

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -11,7 +11,6 @@ import {SharesMathLib} from "../libraries/SharesMathLib.sol";
 import {IERC4626} from "../../lib/openzeppelin/contracts/interfaces/IERC4626.sol";
 import {Pausable} from "../../lib/openzeppelin/contracts/utils/Pausable.sol";
 import {TokenizedStrategyStorageLib, ERC20} from "@periphery/libraries/TokenizedStrategyStorageLib.sol";
-import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
 import {IProtocolConfig} from "../interfaces/IProtocolConfig.sol";
 import {ProtocolConfigLib} from "../libraries/ProtocolConfigLib.sol";
 
@@ -501,12 +500,11 @@ contract USD3 is BaseHooksUpgradeable {
 
         _preReportHook();
         (profit, loss) = _reportInternal();
-
-        _postReportHookWithPre(profit, loss, preAssets, preSupply);
+        _postReportHook(profit, loss, preAssets, preSupply);
     }
 
     /// @dev Post-report hook to handle loss absorption by burning sUSD3's shares
-    function _postReportHookWithPre(uint256 _profit, uint256 loss, uint256 preAssets, uint256 preSupply) internal {
+    function _postReportHook(uint256 _profit, uint256 loss, uint256 preAssets, uint256 preSupply) internal {
         if (loss == 0 || sUSD3 == address(0)) return;
 
         // Get sUSD3's current USD3 balance

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -11,6 +11,7 @@ import {SharesMathLib} from "../libraries/SharesMathLib.sol";
 import {IERC4626} from "../../lib/openzeppelin/contracts/interfaces/IERC4626.sol";
 import {Pausable} from "../../lib/openzeppelin/contracts/utils/Pausable.sol";
 import {TokenizedStrategyStorageLib, ERC20} from "@periphery/libraries/TokenizedStrategyStorageLib.sol";
+import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
 import {IProtocolConfig} from "../interfaces/IProtocolConfig.sol";
 import {ProtocolConfigLib} from "../libraries/ProtocolConfigLib.sol";
 
@@ -489,31 +490,48 @@ contract USD3 is BaseHooksUpgradeable {
         }
     }
 
+    /**
+     * @notice Report profit and loss with pre-report context for accurate loss absorption
+     * @return profit Amount of profit generated
+     * @return loss Amount of loss incurred
+     */
+    function report() external override returns (uint256 profit, uint256 loss) {
+        uint256 preSupply = TokenizedStrategy.totalSupply();
+        uint256 preAssets = TokenizedStrategy.totalAssets();
+
+        _preReportHook();
+        (profit, loss) = _reportInternal();
+
+        _postReportHookWithPre(profit, loss, preAssets, preSupply);
+    }
+
     /// @dev Post-report hook to handle loss absorption by burning sUSD3's shares
-    function _postReportHook(uint256 profit, uint256 loss) internal override {
-        if (loss > 0 && sUSD3 != address(0)) {
-            // Get sUSD3's current USD3 balance
-            uint256 susd3Balance = TokenizedStrategy.balanceOf(sUSD3);
+    function _postReportHookWithPre(uint256 _profit, uint256 loss, uint256 preAssets, uint256 preSupply) internal {
+        if (loss == 0 || sUSD3 == address(0)) return;
 
-            if (susd3Balance > 0) {
-                // Calculate how many shares are needed to cover the loss
-                // IMPORTANT: We must use pre-report values to calculate the correct share amount
-                // The report has already reduced totalAssets, so we add the loss back
-                uint256 totalSupply = TokenizedStrategy.totalSupply();
-                uint256 totalAssets = TokenizedStrategy.totalAssets();
+        // Get sUSD3's current USD3 balance
+        uint256 susd3Balance = TokenizedStrategy.balanceOf(sUSD3);
+        if (susd3Balance == 0) return;
 
-                // Calculate shares to burn using pre-loss exchange rate
-                uint256 sharesToBurn = loss.mulDiv(totalSupply, totalAssets + loss, Math.Rounding.Floor);
+        if (preAssets == 0 || preSupply == 0) return;
 
-                // Cap at sUSD3's actual balance - they can't lose more than they have
-                if (sharesToBurn > susd3Balance) {
-                    sharesToBurn = susd3Balance;
-                }
+        // Total shares required to cover the loss at the pre-report PPS
+        uint256 totalBurnNeeded = loss.mulDiv(preSupply, preAssets, Math.Rounding.Floor);
 
-                if (sharesToBurn > 0) {
-                    _burnSharesFromSusd3(sharesToBurn);
-                }
-            }
+        // Internal burn from locked shares is reflected in the post-report totalSupply
+        uint256 postSupply = TokenizedStrategy.totalSupply();
+        uint256 lockedBurn = preSupply > postSupply ? preSupply - postSupply : 0;
+
+        // Burn only the remaining shares from sUSD3
+        uint256 sharesToBurn = totalBurnNeeded > lockedBurn ? totalBurnNeeded - lockedBurn : 0;
+
+        // Cap at sUSD3's actual balance - they can't lose more than they have
+        if (sharesToBurn > susd3Balance) {
+            sharesToBurn = susd3Balance;
+        }
+
+        if (sharesToBurn > 0) {
+            _burnSharesFromSusd3(sharesToBurn);
         }
     }
 

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -346,7 +346,7 @@ contract USD3 is BaseHooksUpgradeable {
 
     /// @dev Rebalances between idle and deployed funds to maintain maxOnCredit ratio
     /// @param _totalIdle Current idle funds available
-    function _tend(uint256 _totalIdle) internal virtual override {
+    function _tend(uint256 _totalIdle) internal override {
         if (TokenizedStrategy.isShutdown()) {
             return;
         }
@@ -356,6 +356,14 @@ contract USD3 is BaseHooksUpgradeable {
             WAUSDC.deposit(_totalIdle, address(this));
         }
 
+        _applyDeployCap(true);
+    }
+
+    /// @dev Rebalances deployed waUSDC toward the effective deployment cap.
+    /// Withdraws excess from MorphoCredit when over the cap; otherwise tops up
+    /// deployment from local waUSDC only when supplying is permitted.
+    /// @param allowSupply Whether deploying additional local waUSDC is allowed
+    function _applyDeployCap(bool allowSupply) private {
         // Calculate based on waUSDC amounts
         uint256 deployedWaUSDC = suppliedWaUSDC();
         uint256 localWaUSDC = balanceOfWaUSDC();
@@ -367,7 +375,7 @@ contract USD3 is BaseHooksUpgradeable {
             // Withdraw excess from MorphoCredit
             uint256 waUSDCToWithdraw = deployedWaUSDC - targetDeployedWaUSDC;
             _withdrawFromMorpho(waUSDCToWithdraw);
-        } else if (targetDeployedWaUSDC > deployedWaUSDC && localWaUSDC > 0) {
+        } else if (allowSupply && targetDeployedWaUSDC > deployedWaUSDC && localWaUSDC > 0) {
             // Deploy more if we have local waUSDC
             uint256 waUSDCToDeploy = Math.min(localWaUSDC, targetDeployedWaUSDC - deployedWaUSDC);
             _supplyToMorpho(waUSDCToDeploy);
@@ -390,7 +398,7 @@ contract USD3 is BaseHooksUpgradeable {
         IProtocolConfig config = _protocolConfig();
         uint256 driftBps = config.config(ProtocolConfigLib.TEND_DRIFT_THRESHOLD);
         if (driftBps == 0) driftBps = 10;
-        require(driftBps < 10_000, "Invalid drift threshold");
+        require(driftBps < 10_000);
         uint256 threshold = (target * driftBps) / 10_000;
 
         if (deployed > target) {
@@ -503,7 +511,7 @@ contract USD3 is BaseHooksUpgradeable {
             return 0;
         }
 
-        uint256 cap = supplyCap();
+        uint256 cap = _protocolConfig().config(ProtocolConfigLib.USD3_SUPPLY_CAP);
         if (cap == 0) {
             return 0;
         }
@@ -536,16 +544,13 @@ contract USD3 is BaseHooksUpgradeable {
         // Enforce minimum deposit only for first-time depositors
         uint256 currentBalance = TokenizedStrategy.balanceOf(receiver);
         if (currentBalance == 0) {
-            require(assets >= minDeposit, "Below minimum deposit");
+            require(assets >= minDeposit, "<min");
         }
 
         // Prevent commitment bypass and griefing attacks
         if (minCommitmentTime() > 0) {
             // Only allow self-deposits or whitelisted depositors
-            require(
-                msg.sender == receiver || depositorWhitelist[msg.sender],
-                "USD3: Only self or whitelisted deposits allowed"
-            );
+            require(msg.sender == receiver || depositorWhitelist[msg.sender], "!allowed");
 
             // Always extend commitment for valid deposits
             depositTimestamp[receiver] = block.timestamp;
@@ -624,10 +629,17 @@ contract USD3 is BaseHooksUpgradeable {
 
         // Check commitment period
         uint256 commitmentEnd = depositTimestamp[from] + minCommitmentTime();
-        require(
-            block.timestamp >= commitmentEnd || depositTimestamp[from] == 0,
-            "USD3: Cannot transfer during commitment period"
-        );
+        require(block.timestamp >= commitmentEnd || depositTimestamp[from] == 0, "!transfer");
+    }
+
+    /// @dev Post-transfer hook that rebalances deployment after sUSD3 unstakes.
+    /// When sUSD3 transfers out USD3 shares its subordination backing shrinks, so the
+    /// deployment cap is re-applied (withdraw-only) to pull any excess back from MorphoCredit.
+    /// Skipped during shutdown.
+    /// @param from Address transferring shares
+    /// @param amount Amount of shares being transferred
+    function _postTransferHook(address from, address, uint256 amount, bool success) internal override {
+        if (success && amount > 0 && from == sUSD3 && !TokenizedStrategy.isShutdown()) _applyDeployCap(false);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -696,15 +708,6 @@ contract USD3 is BaseHooksUpgradeable {
     }
 
     /**
-     * @notice Get the effective deployment cap accounting for both maxOnCredit and sUSD3 subordination
-     * @return Maximum waUSDC that should be deployed to MorphoCredit
-     */
-    function effectiveDeployCapWaUSDC() external view returns (uint256) {
-        uint256 totalWaUSDC = suppliedWaUSDC() + balanceOfWaUSDC();
-        return _effectiveDeployCapWaUSDC(totalWaUSDC);
-    }
-
-    /**
      * @notice Get the maximum percentage of funds to deploy to credit markets from ProtocolConfig
      * @return Maximum deployment ratio in basis points (10000 = 100%)
      * @dev Returns the value from ProtocolConfig directly. If not configured in ProtocolConfig,
@@ -722,15 +725,6 @@ contract USD3 is BaseHooksUpgradeable {
     function minCommitmentTime() public view returns (uint256) {
         IProtocolConfig config = _protocolConfig();
         return config.getUsd3CommitmentTime();
-    }
-
-    /**
-     * @notice Get the supply cap from ProtocolConfig
-     * @return Supply cap in asset units
-     */
-    function supplyCap() public view returns (uint256) {
-        IProtocolConfig config = _protocolConfig();
-        return config.config(ProtocolConfigLib.USD3_SUPPLY_CAP);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -14,6 +14,14 @@ import {TokenizedStrategyStorageLib, ERC20} from "@periphery/libraries/Tokenized
 import {IProtocolConfig} from "../interfaces/IProtocolConfig.sol";
 import {ProtocolConfigLib} from "../libraries/ProtocolConfigLib.sol";
 
+interface IAavePool {
+    function getVirtualUnderlyingBalance(address asset) external view returns (uint128);
+}
+
+interface IWaUSDC is IERC4626 {
+    function POOL() external view returns (IAavePool);
+}
+
 /**
  * @title USD3
  * @author 3Jane Protocol
@@ -54,7 +62,7 @@ contract USD3 is BaseHooksUpgradeable {
     /*//////////////////////////////////////////////////////////////
                         CONSTANTS
     //////////////////////////////////////////////////////////////*/
-    IERC4626 public constant WAUSDC = IERC4626(0xD4fa2D31b7968E448877f69A96DE69f5de8cD23E);
+    IWaUSDC public constant WAUSDC = IWaUSDC(0xD4fa2D31b7968E448877f69A96DE69f5de8cD23E);
 
     /*//////////////////////////////////////////////////////////////
                         STORAGE - MORPHO PARAMETERS
@@ -159,15 +167,15 @@ contract USD3 is BaseHooksUpgradeable {
         IERC20(usdc).forceApprove(address(WAUSDC), type(uint256).max);
     }
 
-    /**
-     * @notice Legacy restart hook for the completed v3 emergency restart.
-     * @dev This reinitializer was consumed in production during the controlled
-     *      ProxyAdmin.upgradeAndCall restart flow and is retained only for
-     *      deployed implementation compatibility.
-     */
-    function restartStrategy() external reinitializer(3) {
-        TokenizedStrategyStorageLib.getStrategyStorage().shutdown = false;
-    }
+    // /**
+    //  * @notice Legacy restart hook for the completed v3 emergency restart.
+    //  * @dev This reinitializer was consumed in production during the controlled
+    //  *      ProxyAdmin.upgradeAndCall restart flow and is retained only for
+    //  *      deployed implementation compatibility.
+    //  */
+    // function restartStrategy() external reinitializer(3) {
+    //     TokenizedStrategyStorageLib.getStrategyStorage().shutdown = false;
+    // }
 
     /*//////////////////////////////////////////////////////////////
                         EXTERNAL VIEW FUNCTIONS
@@ -317,7 +325,7 @@ contract USD3 is BaseHooksUpgradeable {
             }
         }
 
-        uint256 waUSDCToUnwrap = Math.min(localWaUSDC, waUSDCNeeded);
+        uint256 waUSDCToUnwrap = Math.min(Math.min(localWaUSDC, waUSDCNeeded), WAUSDC.maxRedeem(address(this)));
 
         if (waUSDCToUnwrap > 0) {
             WAUSDC.redeem(waUSDCToUnwrap, address(this), address(this));
@@ -446,6 +454,10 @@ contract USD3 is BaseHooksUpgradeable {
         return amountWithdrawn;
     }
 
+    function _waUSDCGlobalRedeemable() internal view returns (uint256) {
+        return WAUSDC.convertToShares(WAUSDC.POOL().getVirtualUnderlyingBalance(WAUSDC.asset()));
+    }
+
     /*//////////////////////////////////////////////////////////////
                     PUBLIC VIEW FUNCTIONS (OVERRIDES)
     //////////////////////////////////////////////////////////////*/
@@ -468,10 +480,17 @@ contract USD3 is BaseHooksUpgradeable {
         if (Pausable(address(WAUSDC)).paused()) {
             availableWaUSDC = 0;
         } else {
-            uint256 localWaUSDC = Math.min(balanceOfWaUSDC(), WAUSDC.maxRedeem(address(this)));
+            uint256 localWaUSDC = balanceOfWaUSDC();
             uint256 morphoWaUSDC = Math.min(waUSDCMax, waUSDCLiquidity);
-            morphoWaUSDC = Math.min(morphoWaUSDC, WAUSDC.maxRedeem(address(morphoCredit)));
-            availableWaUSDC = localWaUSDC + morphoWaUSDC;
+            uint256 totalRedeemableWaUSDC = localWaUSDC + morphoWaUSDC;
+
+            if (totalRedeemableWaUSDC > 0) {
+                if (WAUSDC.maxRedeem(address(this)) == 0 && WAUSDC.maxRedeem(address(morphoCredit)) == 0) {
+                    availableWaUSDC = 0;
+                } else {
+                    availableWaUSDC = Math.min(totalRedeemableWaUSDC, _waUSDCGlobalRedeemable());
+                }
+            }
         }
 
         uint256 availableLiquidity = idleAsset + WAUSDC.convertToAssets(availableWaUSDC);
@@ -820,7 +839,7 @@ contract USD3 is BaseHooksUpgradeable {
 
         // Read the tranche share variant (yield share to sUSD3 in basis points)
         uint256 trancheShare = config.getTrancheShareVariant();
-        require(trancheShare <= 10_000, "Invalid tranche share");
+        require(trancheShare <= 10_000);
 
         // Get the storage slot for performanceFee using the library
         bytes32 targetSlot = TokenizedStrategyStorageLib.profitConfigSlot();

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -339,8 +339,6 @@ contract USD3 is BaseHooksUpgradeable {
 
         morphoCredit.accrueInterest(params);
 
-        _tend(asset.balanceOf(address(this)));
-
         uint256 totalWaUSDC = suppliedWaUSDC() + balanceOfWaUSDC();
 
         return WAUSDC.convertToAssets(totalWaUSDC) + asset.balanceOf(address(this));
@@ -576,37 +574,38 @@ contract USD3 is BaseHooksUpgradeable {
 
         _preReportHook();
         (profit, loss) = _reportInternal();
-        _postReportHook(profit, loss, preAssets, preSupply);
+        _postReportHook(loss, preAssets, preSupply);
     }
 
-    /// @dev Post-report hook to handle loss absorption by burning sUSD3's shares
-    function _postReportHook(uint256 _profit, uint256 loss, uint256 preAssets, uint256 preSupply) internal {
-        if (loss == 0 || sUSD3 == address(0)) return;
+    /// @dev Handles loss absorption and post-report rebalancing.
+    function _postReportHook(uint256 loss, uint256 preAssets, uint256 preSupply) internal {
+        if (loss > 0 && sUSD3 != address(0) && preAssets > 0 && preSupply > 0) {
+            // Get sUSD3's current USD3 balance
+            uint256 susd3Balance = TokenizedStrategy.balanceOf(sUSD3);
 
-        // Get sUSD3's current USD3 balance
-        uint256 susd3Balance = TokenizedStrategy.balanceOf(sUSD3);
-        if (susd3Balance == 0) return;
+            if (susd3Balance > 0) {
+                // Total shares required to cover the loss at the pre-report PPS
+                uint256 totalBurnNeeded = loss.mulDiv(preSupply, preAssets, Math.Rounding.Floor);
 
-        if (preAssets == 0 || preSupply == 0) return;
+                // Internal burn from locked shares is reflected in the post-report totalSupply
+                uint256 postSupply = TokenizedStrategy.totalSupply();
+                uint256 lockedBurn = preSupply > postSupply ? preSupply - postSupply : 0;
 
-        // Total shares required to cover the loss at the pre-report PPS
-        uint256 totalBurnNeeded = loss.mulDiv(preSupply, preAssets, Math.Rounding.Floor);
+                // Burn only the remaining shares from sUSD3
+                uint256 sharesToBurn = totalBurnNeeded > lockedBurn ? totalBurnNeeded - lockedBurn : 0;
 
-        // Internal burn from locked shares is reflected in the post-report totalSupply
-        uint256 postSupply = TokenizedStrategy.totalSupply();
-        uint256 lockedBurn = preSupply > postSupply ? preSupply - postSupply : 0;
+                // Cap at sUSD3's actual balance - they can't lose more than they have
+                if (sharesToBurn > susd3Balance) {
+                    sharesToBurn = susd3Balance;
+                }
 
-        // Burn only the remaining shares from sUSD3
-        uint256 sharesToBurn = totalBurnNeeded > lockedBurn ? totalBurnNeeded - lockedBurn : 0;
-
-        // Cap at sUSD3's actual balance - they can't lose more than they have
-        if (sharesToBurn > susd3Balance) {
-            sharesToBurn = susd3Balance;
+                if (sharesToBurn > 0) {
+                    _burnSharesFromSusd3(sharesToBurn);
+                }
+            }
         }
 
-        if (sharesToBurn > 0) {
-            _burnSharesFromSusd3(sharesToBurn);
-        }
+        _tend(asset.balanceOf(address(this)));
     }
 
     /**

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -221,6 +221,10 @@ contract USD3 is BaseHooksUpgradeable {
         waUSDCMax = shares.toAssetsDown(totalSupplyAssets, totalShares);
     }
 
+    function _protocolConfig() internal view returns (IProtocolConfig) {
+        return IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
+    }
+
     /*//////////////////////////////////////////////////////////////
                     INTERNAL STRATEGY FUNCTIONS
     //////////////////////////////////////////////////////////////*/
@@ -230,7 +234,7 @@ contract USD3 is BaseHooksUpgradeable {
     function _subordinationDeployCapWaUSDC() internal view returns (uint256) {
         if (sUSD3 == address(0)) return type(uint256).max;
 
-        IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
+        IProtocolConfig config = _protocolConfig();
         uint256 backingRatio = config.config(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO);
         if (backingRatio == 0) return type(uint256).max;
 
@@ -375,7 +379,7 @@ contract USD3 is BaseHooksUpgradeable {
 
         if (target == 0) return deployed > 0;
 
-        IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
+        IProtocolConfig config = _protocolConfig();
         uint256 driftBps = config.config(ProtocolConfigLib.TEND_DRIFT_THRESHOLD);
         if (driftBps == 0) driftBps = 10;
         require(driftBps < 10_000, "Invalid drift threshold");
@@ -698,7 +702,7 @@ contract USD3 is BaseHooksUpgradeable {
      *      it returns 0, effectively preventing deployment until explicitly configured.
      */
     function maxOnCredit() public view returns (uint256) {
-        IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
+        IProtocolConfig config = _protocolConfig();
         return config.getMaxOnCredit();
     }
 
@@ -707,7 +711,7 @@ contract USD3 is BaseHooksUpgradeable {
      * @return Minimum commitment time in seconds
      */
     function minCommitmentTime() public view returns (uint256) {
-        IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
+        IProtocolConfig config = _protocolConfig();
         return config.getUsd3CommitmentTime();
     }
 
@@ -716,7 +720,7 @@ contract USD3 is BaseHooksUpgradeable {
      * @return Supply cap in asset units
      */
     function supplyCap() public view returns (uint256) {
-        IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
+        IProtocolConfig config = _protocolConfig();
         return config.config(ProtocolConfigLib.USD3_SUPPLY_CAP);
     }
 
@@ -801,7 +805,7 @@ contract USD3 is BaseHooksUpgradeable {
      */
     function syncTrancheShare() external onlyKeepers {
         // Get the protocol config through MorphoCredit
-        IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
+        IProtocolConfig config = _protocolConfig();
 
         // Read the tranche share variant (yield share to sUSD3 in basis points)
         uint256 trancheShare = config.getTrancheShareVariant();

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -339,9 +339,7 @@ contract USD3 is BaseHooksUpgradeable {
 
         morphoCredit.accrueInterest(params);
 
-        uint256 totalWaUSDC = suppliedWaUSDC() + balanceOfWaUSDC();
-
-        return WAUSDC.convertToAssets(totalWaUSDC) + asset.balanceOf(address(this));
+        return nav();
     }
 
     /// @dev Rebalances between idle and deployed funds to maintain maxOnCredit ratio
@@ -458,6 +456,10 @@ contract USD3 is BaseHooksUpgradeable {
     function availableWithdrawLimit(address _owner) public view override returns (uint256) {
         // Get available liquidity first
         uint256 idleAsset = asset.balanceOf(address(this));
+
+        if (nav() + 2 < TokenizedStrategy.totalAssets()) {
+            return 0;
+        }
 
         (, uint256 waUSDCMax, uint256 waUSDCLiquidity) = getPosition();
 
@@ -707,6 +709,12 @@ contract USD3 is BaseHooksUpgradeable {
         return morphoCredit.expectedSupplyAssets(_marketParams, address(this));
     }
 
+    /// @dev Net asset value of the strategy in USDC terms
+    /// @return Sum of deployed and local waUSDC converted to assets, plus idle USDC held by the strategy
+    function nav() public view returns (uint256) {
+        return WAUSDC.convertToAssets(suppliedWaUSDC() + balanceOfWaUSDC()) + asset.balanceOf(address(this));
+    }
+
     /**
      * @notice Get the maximum percentage of funds to deploy to credit markets from ProtocolConfig
      * @return Maximum deployment ratio in basis points (10000 = 100%)
@@ -737,8 +745,8 @@ contract USD3 is BaseHooksUpgradeable {
      * @dev Only callable by management. After calling, also set performance fee recipient.
      */
     function setSUSD3(address _sUSD3) external onlyManagement {
-        require(sUSD3 == address(0), "sUSD3 already set");
-        require(_sUSD3 != address(0), "Invalid address");
+        require(sUSD3 == address(0));
+        require(_sUSD3 != address(0));
 
         sUSD3 = _sUSD3;
         emit SUSD3StrategyUpdated(address(0), _sUSD3);

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -160,8 +160,10 @@ contract USD3 is BaseHooksUpgradeable {
     }
 
     /**
-     * @notice Restart the strategy after an emergency shutdown.
-     * @dev Intended to be consumed atomically through ProxyAdmin.upgradeAndCall during the v3 restart upgrade.
+     * @notice Legacy restart hook for the completed v3 emergency restart.
+     * @dev This reinitializer was consumed in production during the controlled
+     *      ProxyAdmin.upgradeAndCall restart flow and is retained only for
+     *      deployed implementation compatibility.
      */
     function restartStrategy() external reinitializer(3) {
         TokenizedStrategyStorageLib.getStrategyStorage().shutdown = false;

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -216,7 +216,37 @@ contract USD3 is BaseHooksUpgradeable {
                     INTERNAL STRATEGY FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
-    /// @dev Deploy funds to MorphoCredit market respecting maxOnCredit ratio
+    /// @dev Maximum waUSDC deployment allowed by sUSD3 backing alone.
+    /// Returns type(uint256).max when no subordination constraint applies.
+    function _subordinationDeployCapWaUSDC() internal view returns (uint256) {
+        if (sUSD3 == address(0)) return type(uint256).max;
+
+        IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
+        uint256 backingRatio = config.config(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO);
+        if (backingRatio == 0) return type(uint256).max;
+
+        uint256 sUSD3Shares = TokenizedStrategy.balanceOf(sUSD3);
+        uint256 _totalSupply = TokenizedStrategy.totalSupply();
+        uint256 _totalAssets = TokenizedStrategy.totalAssets();
+
+        if (_totalSupply == 0 || _totalAssets == 0 || sUSD3Shares == 0) return 0;
+
+        // Conservative (floor-rounded) USD3 share-to-USDC conversion,
+        // same accounting model as sUSD3.sol availableDepositLimit/availableWithdrawLimit
+        uint256 sUSD3ValueUSDC = sUSD3Shares.mulDiv(_totalAssets, _totalSupply, Math.Rounding.Floor);
+        uint256 maxDebtUSDC = (sUSD3ValueUSDC * 10_000) / backingRatio;
+
+        return WAUSDC.convertToShares(maxDebtUSDC);
+    }
+
+    /// @dev Effective deployment cap: min(maxOnCredit-based cap, subordination cap)
+    function _effectiveDeployCapWaUSDC(uint256 totalWaUSDC) internal view returns (uint256) {
+        uint256 maxOnCreditCap = (totalWaUSDC * maxOnCredit()) / 10_000;
+        uint256 subCap = _subordinationDeployCapWaUSDC();
+        return Math.min(maxOnCreditCap, subCap);
+    }
+
+    /// @dev Deploy funds to MorphoCredit market respecting maxOnCredit ratio and subordination cap
     /// @param _amount Amount of asset to deploy
     function _deployFunds(uint256 _amount) internal override {
         if (_amount == 0) return;
@@ -235,8 +265,7 @@ contract USD3 is BaseHooksUpgradeable {
         uint256 localWaUSDC = balanceOfWaUSDC();
         uint256 totalWaUSDC = deployedWaUSDC + localWaUSDC;
 
-        // Calculate max that should be deployed to MorphoCredit
-        uint256 maxDeployableWaUSDC = (totalWaUSDC * maxOnCreditRatio) / 10_000;
+        uint256 maxDeployableWaUSDC = _effectiveDeployCapWaUSDC(totalWaUSDC);
 
         if (maxDeployableWaUSDC <= deployedWaUSDC) {
             // Already at or above max, keep all new waUSDC local
@@ -315,7 +344,7 @@ contract USD3 is BaseHooksUpgradeable {
         uint256 localWaUSDC = balanceOfWaUSDC();
         uint256 totalWaUSDC = deployedWaUSDC + localWaUSDC;
 
-        uint256 targetDeployedWaUSDC = (totalWaUSDC * maxOnCredit()) / 10_000;
+        uint256 targetDeployedWaUSDC = _effectiveDeployCapWaUSDC(totalWaUSDC);
 
         if (deployedWaUSDC > targetDeployedWaUSDC) {
             // Withdraw excess from MorphoCredit
@@ -326,6 +355,24 @@ contract USD3 is BaseHooksUpgradeable {
             uint256 waUSDCToDeploy = Math.min(localWaUSDC, targetDeployedWaUSDC - deployedWaUSDC);
             _supplyToMorpho(waUSDCToDeploy);
         }
+    }
+
+    /// @dev Signal keepers when deployment drifts from the effective cap
+    function _tendTrigger() internal view override returns (bool) {
+        uint256 deployed = suppliedWaUSDC();
+        uint256 localWaUSDC = balanceOfWaUSDC();
+        uint256 totalWaUSDC = deployed + localWaUSDC;
+        uint256 target = _effectiveDeployCapWaUSDC(totalWaUSDC);
+
+        if (target == 0) return deployed > 0;
+
+        if (deployed > target) {
+            return (deployed - target) > target / 1000;
+        }
+        if (target > deployed && localWaUSDC > 0) {
+            return (target - deployed) > target / 1000;
+        }
+        return false;
     }
 
     /// @dev Helper function to supply waUSDC to MorphoCredit
@@ -602,6 +649,15 @@ contract USD3 is BaseHooksUpgradeable {
      */
     function suppliedWaUSDC() public view returns (uint256) {
         return morphoCredit.expectedSupplyAssets(_marketParams, address(this));
+    }
+
+    /**
+     * @notice Get the effective deployment cap accounting for both maxOnCredit and sUSD3 subordination
+     * @return Maximum waUSDC that should be deployed to MorphoCredit
+     */
+    function effectiveDeployCapWaUSDC() external view returns (uint256) {
+        uint256 totalWaUSDC = suppliedWaUSDC() + balanceOfWaUSDC();
+        return _effectiveDeployCapWaUSDC(totalWaUSDC);
     }
 
     /**

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -366,11 +366,17 @@ contract USD3 is BaseHooksUpgradeable {
 
         if (target == 0) return deployed > 0;
 
+        IProtocolConfig config = IProtocolConfig(IMorphoCredit(address(morphoCredit)).protocolConfig());
+        uint256 driftBps = config.config(ProtocolConfigLib.TEND_DRIFT_THRESHOLD);
+        if (driftBps == 0) driftBps = 10;
+        require(driftBps < 10_000, "Invalid drift threshold");
+        uint256 threshold = (target * driftBps) / 10_000;
+
         if (deployed > target) {
-            return (deployed - target) > target / 1000;
+            return (deployed - target) > threshold;
         }
         if (target > deployed && localWaUSDC > 0) {
-            return (target - deployed) > target / 1000;
+            return (target - deployed) > threshold;
         }
         return false;
     }

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -347,6 +347,10 @@ contract USD3 is BaseHooksUpgradeable {
     /// @dev Rebalances between idle and deployed funds to maintain maxOnCredit ratio
     /// @param _totalIdle Current idle funds available
     function _tend(uint256 _totalIdle) internal virtual override {
+        if (TokenizedStrategy.isShutdown()) {
+            return;
+        }
+
         // First wrap any idle USDC to waUSDC
         if (_totalIdle > 0) {
             WAUSDC.deposit(_totalIdle, address(this));
@@ -372,6 +376,10 @@ contract USD3 is BaseHooksUpgradeable {
 
     /// @dev Signal keepers when deployment drifts from the effective cap
     function _tendTrigger() internal view override returns (bool) {
+        if (TokenizedStrategy.isShutdown()) {
+            return false;
+        }
+
         uint256 deployed = suppliedWaUSDC();
         uint256 localWaUSDC = balanceOfWaUSDC();
         uint256 totalWaUSDC = deployed + localWaUSDC;

--- a/src/usd3/base/BaseHooksUpgradeable.sol
+++ b/src/usd3/base/BaseHooksUpgradeable.sol
@@ -158,8 +158,15 @@ abstract contract BaseHooksUpgradeable is BaseStrategyUpgradeable, Hooks {
      */
     function report() external virtual returns (uint256 profit, uint256 loss) {
         _preReportHook();
+        (profit, loss) = _reportInternal();
+        _postReportHook(profit, loss);
+    }
+
+    /**
+     * @dev Internal report execution hook to centralize delegatecall logic.
+     */
+    function _reportInternal() internal returns (uint256 profit, uint256 loss) {
         (profit, loss) =
             abi.decode(_delegateCall(abi.encodeCall(ITokenizedStrategy(address(this)).report, ())), (uint256, uint256));
-        _postReportHook(profit, loss);
     }
 }

--- a/src/usd3/interfaces/IUSD3.sol
+++ b/src/usd3/interfaces/IUSD3.sol
@@ -22,6 +22,7 @@ interface IUSD3 is IStrategy {
     function morphoCredit() external view returns (IMorpho);
     function marketId() external view returns (Id);
     function marketParams() external view returns (MarketParams memory);
+    function nav() external view returns (uint256);
     function symbol() external pure returns (string memory);
 
     // Configuration parameters

--- a/src/usd3/sUSD3.sol
+++ b/src/usd3/sUSD3.sol
@@ -421,12 +421,12 @@ contract sUSD3 is BaseHooksUpgradeable {
     }
 
     /**
-     * @notice Get the nominal subordination floor from ProtocolConfig
-     * @return Nominal subordination floor, expressed in USDC
+     * @notice Get the nominal backing floor from ProtocolConfig
+     * @return Nominal backing floor, expressed in USDC
      */
-    function nominalSubordinationFloor() public view returns (uint256) {
+    function nominalBackingFloor() public view returns (uint256) {
         IProtocolConfig config = IProtocolConfig(IMorphoCredit(morphoCredit).protocolConfig());
-        return config.config(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR);
+        return config.config(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR);
     }
 
     /**
@@ -463,11 +463,11 @@ contract sUSD3 is BaseHooksUpgradeable {
 
     /**
      * @notice Calculate minimum sUSD3 backing required for current market debt
-     * @dev Returns the greater of the ratio-based floor and nominal subordination floor
+     * @dev Returns the greater of the ratio-based floor and nominal backing floor
      * @return Minimum backing amount required, expressed in USDC
      */
     function getSubordinatedDebtFloorInUSDC() public view returns (uint256) {
-        uint256 nominalFloor = nominalSubordinationFloor();
+        uint256 nominalFloor = nominalBackingFloor();
         uint256 backingRatio = minBackingRatio();
 
         uint256 ratioFloor;

--- a/src/usd3/sUSD3.sol
+++ b/src/usd3/sUSD3.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.18;
 
-import {BaseHooksUpgradeable, IERC20, IMorphoCredit, IProtocolConfig, Math, SafeERC20, USD3} from "./USD3.sol";
+import {BaseHooksUpgradeable, IERC20, IMorphoCredit, IProtocolConfig, Math, USD3} from "./USD3.sol";
 import {IStrategy} from "@tokenized-strategy/interfaces/IStrategy.sol";
 import {ProtocolConfigLib} from "../libraries/ProtocolConfigLib.sol";
 
@@ -276,10 +276,22 @@ contract sUSD3 is BaseHooksUpgradeable {
     /// @param _owner Address to check limit for
     /// @return Maximum withdrawal amount allowed in assets
     function availableWithdrawLimit(address _owner) public view override returns (uint256) {
+        uint256 currentUSD3Holdings = asset.balanceOf(address(this));
+
+        // Block withdraws if sUSD3 has unrealized losses
+        if (currentUSD3Holdings + 2 < TokenizedStrategy.totalAssets()) {
+            return 0;
+        }
+
+        // Block withdraws if USD3 has unrealized losses
+        if (USD3(address(asset)).nav() + 2 < IStrategy(address(asset)).totalAssets()) {
+            return 0;
+        }
+
         // During shutdown, bypass all checks and return available assets
         if (TokenizedStrategy.isShutdown()) {
             // Return all available USD3 (entire balance since sUSD3 holds USD3 directly)
-            return asset.balanceOf(address(this));
+            return currentUSD3Holdings;
         }
 
         // Check initial lock period
@@ -320,7 +332,6 @@ contract sUSD3 is BaseHooksUpgradeable {
             return userWithdrawLimit;
         }
 
-        uint256 currentUSD3Holdings = asset.balanceOf(address(this));
         uint256 currentAssetsUSDC = IStrategy(address(asset)).convertToAssets(currentUSD3Holdings);
 
         if (currentAssetsUSDC <= subordinatedDebtFloorUSDC) {

--- a/src/usd3/sUSD3.sol
+++ b/src/usd3/sUSD3.sol
@@ -141,11 +141,12 @@ contract sUSD3 is BaseHooksUpgradeable {
             msg.sender == receiver || depositorWhitelist[msg.sender], "sUSD3: Only self or whitelisted deposits allowed"
         );
 
-        // Always extend lock period for valid deposits
+        // Extend lock period for valid deposits when configured.
         if (assets > 0 || shares > 0) {
-            // Read lock duration from ProtocolConfig
             uint256 duration = lockDuration();
-            lockedUntil[receiver] = block.timestamp + duration;
+            if (duration > 0) {
+                lockedUntil[receiver] = block.timestamp + duration;
+            }
         }
     }
 
@@ -363,9 +364,7 @@ contract sUSD3 is BaseHooksUpgradeable {
      */
     function lockDuration() public view returns (uint256) {
         IProtocolConfig config = IProtocolConfig(IMorphoCredit(morphoCredit).protocolConfig());
-
-        uint256 duration = config.getSusd3LockDuration();
-        return duration > 0 ? duration : 90 days; // Default to 90 days if not set
+        return config.getSusd3LockDuration();
     }
 
     /**

--- a/src/usd3/sUSD3.sol
+++ b/src/usd3/sUSD3.sol
@@ -422,6 +422,7 @@ contract sUSD3 is BaseHooksUpgradeable {
 
     /**
      * @notice Get the nominal backing floor from ProtocolConfig
+     * @dev If set above achievable sUSD3 backing capacity, withdrawals can remain blocked.
      * @return Nominal backing floor, expressed in USDC
      */
     function nominalBackingFloor() public view returns (uint256) {
@@ -474,11 +475,9 @@ contract sUSD3 is BaseHooksUpgradeable {
         if (backingRatio > 0) {
             USD3 usd3 = USD3(address(asset));
 
-            // Get actual borrowed amount
             (,, uint256 totalBorrowAssetsWaUSDC,) = usd3.getMarketLiquidity();
             uint256 debtUSDC = usd3.WAUSDC().convertToAssets(totalBorrowAssetsWaUSDC);
 
-            // Calculate minimum required backing
             ratioFloor = (debtUSDC * backingRatio) / MAX_BPS;
         }
 

--- a/src/usd3/sUSD3.sol
+++ b/src/usd3/sUSD3.sol
@@ -421,6 +421,15 @@ contract sUSD3 is BaseHooksUpgradeable {
     }
 
     /**
+     * @notice Get the nominal subordination floor from ProtocolConfig
+     * @return Nominal subordination floor, expressed in USDC
+     */
+    function nominalSubordinationFloor() public view returns (uint256) {
+        IProtocolConfig config = IProtocolConfig(IMorphoCredit(morphoCredit).protocolConfig());
+        return config.config(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR);
+    }
+
+    /**
      * @notice Calculate maximum sUSD3 deposits allowed based on debt and subordination ratio
      * @dev Returns the cap amount for subordinated debt based on actual or potential market debt
      * @return Maximum subordinated debt cap, expressed in USDC
@@ -454,24 +463,26 @@ contract sUSD3 is BaseHooksUpgradeable {
 
     /**
      * @notice Calculate minimum sUSD3 backing required for current market debt
-     * @dev Returns the floor amount of sUSD3 assets needed based on MIN_SUSD3_BACKING_RATIO
+     * @dev Returns the greater of the ratio-based floor and nominal subordination floor
      * @return Minimum backing amount required, expressed in USDC
      */
     function getSubordinatedDebtFloorInUSDC() public view returns (uint256) {
-        // Get minimum backing ratio
+        uint256 nominalFloor = nominalSubordinationFloor();
         uint256 backingRatio = minBackingRatio();
 
-        // If backing ratio is 0, no minimum backing required
-        if (backingRatio == 0) return 0;
+        uint256 ratioFloor;
+        if (backingRatio > 0) {
+            USD3 usd3 = USD3(address(asset));
 
-        USD3 usd3 = USD3(address(asset));
+            // Get actual borrowed amount
+            (,, uint256 totalBorrowAssetsWaUSDC,) = usd3.getMarketLiquidity();
+            uint256 debtUSDC = usd3.WAUSDC().convertToAssets(totalBorrowAssetsWaUSDC);
 
-        // Get actual borrowed amount
-        (,, uint256 totalBorrowAssetsWaUSDC,) = usd3.getMarketLiquidity();
-        uint256 debtUSDC = usd3.WAUSDC().convertToAssets(totalBorrowAssetsWaUSDC);
+            // Calculate minimum required backing
+            ratioFloor = (debtUSDC * backingRatio) / MAX_BPS;
+        }
 
-        // Calculate minimum required backing
-        return (debtUSDC * backingRatio) / MAX_BPS;
+        return Math.max(ratioFloor, nominalFloor);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/forge/usd3/AccessControl.t.sol
+++ b/test/forge/usd3/AccessControl.t.sol
@@ -71,7 +71,7 @@ contract AccessControlTest is Setup {
 
         // Even management cannot set it again (one-time only)
         vm.prank(management);
-        vm.expectRevert("sUSD3 already set");
+        vm.expectRevert();
         usd3Strategy.setSUSD3(newSusd3);
 
         // Verify the original is still set
@@ -90,7 +90,7 @@ contract AccessControlTest is Setup {
 
         // Even management cannot change it once set
         vm.prank(management);
-        vm.expectRevert("sUSD3 already set");
+        vm.expectRevert();
         usd3Strategy.setSUSD3(newSusd3);
 
         // Verify it hasn't changed

--- a/test/forge/usd3/InterestDistribution.t.sol
+++ b/test/forge/usd3/InterestDistribution.t.sol
@@ -554,7 +554,7 @@ contract InterestDistribution is Setup {
 
         // Try to sync - should revert
         vm.prank(keeper);
-        vm.expectRevert("Invalid tranche share");
+        vm.expectRevert();
         usd3Strategy.syncTrancheShare();
     }
 

--- a/test/forge/usd3/Operation.t.sol
+++ b/test/forge/usd3/Operation.t.sol
@@ -85,7 +85,7 @@ contract OperationTest is Setup {
         // Alice tries to deposit below minimum as first deposit - should fail
         vm.startPrank(alice);
         underlyingAsset.approve(address(usd3Strategy), type(uint256).max);
-        vm.expectRevert("Below minimum deposit");
+        vm.expectRevert(bytes("<min"));
         usd3Strategy.deposit(50e6, alice);
 
         // Alice deposits at minimum - should work
@@ -100,7 +100,7 @@ contract OperationTest is Setup {
         // Bob tries to deposit below minimum as first deposit - should fail
         vm.startPrank(bob);
         underlyingAsset.approve(address(usd3Strategy), type(uint256).max);
-        vm.expectRevert("Below minimum deposit");
+        vm.expectRevert(bytes("<min"));
         usd3Strategy.deposit(50e6, bob);
 
         // Bob deposits at minimum - should work

--- a/test/forge/usd3/Operation.t.sol
+++ b/test/forge/usd3/Operation.t.sol
@@ -413,7 +413,7 @@ contract OperationTest is Setup {
 
         // Should revert with invalid share
         vm.prank(keeper);
-        vm.expectRevert("Invalid tranche share");
+        vm.expectRevert();
         usd3Strategy.syncTrancheShare();
     }
 
@@ -686,7 +686,7 @@ contract OperationTest is Setup {
 
         // syncTrancheShare should revert on invalid value
         vm.prank(keeper);
-        vm.expectRevert("Invalid tranche share");
+        vm.expectRevert();
         usd3Strategy.syncTrancheShare();
 
         // Normal operations should continue

--- a/test/forge/usd3/Shutdown.t.sol
+++ b/test/forge/usd3/Shutdown.t.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.8.18;
 
 import "forge-std/console2.sol";
 import {Setup, ERC20, IUSD3} from "./utils/Setup.sol";
+import {USD3} from "../../../src/usd3/USD3.sol";
 
 contract ShutdownTest is Setup {
     function setUp() public virtual override {
@@ -78,6 +79,68 @@ contract ShutdownTest is Setup {
         } else {
             assertGe(asset.balanceOf(user), balanceBefore + _amount, "!final balance");
         }
+    }
+
+    function test_reportDoesNotRedeployFreedFundsAfterShutdown() public {
+        uint256 amount = 100_000e6;
+        USD3 usd3Strategy = USD3(address(strategy));
+
+        mintAndDepositIntoStrategy(strategy, user, amount);
+        assertGt(usd3Strategy.suppliedWaUSDC(), 0, "funds should start deployed");
+
+        vm.prank(emergencyAdmin);
+        strategy.shutdownStrategy();
+
+        vm.prank(emergencyAdmin);
+        strategy.emergencyWithdraw(amount);
+
+        uint256 idleBeforeReport = asset.balanceOf(address(strategy));
+        assertEq(usd3Strategy.suppliedWaUSDC(), 0, "emergency withdraw should free Morpho supply");
+        assertEq(usd3Strategy.balanceOfWaUSDC(), 0, "freed waUSDC should be unwrapped");
+        assertGt(idleBeforeReport, 0, "strategy should hold idle USDC");
+
+        vm.prank(keeper);
+        strategy.report();
+
+        assertEq(usd3Strategy.suppliedWaUSDC(), 0, "report should not redeploy during shutdown");
+        assertEq(usd3Strategy.balanceOfWaUSDC(), 0, "report should not wrap idle USDC during shutdown");
+        assertEq(asset.balanceOf(address(strategy)), idleBeforeReport, "idle USDC should remain idle");
+    }
+
+    function test_tendDoesNotRebalanceAfterShutdown() public {
+        uint256 amount = 100_000e6;
+        USD3 usd3Strategy = USD3(address(strategy));
+
+        mintAndDepositIntoStrategy(strategy, user, amount);
+        uint256 deployedBeforeShutdown = usd3Strategy.suppliedWaUSDC();
+        assertGt(deployedBeforeShutdown, 0, "funds should start deployed");
+
+        setMaxOnCredit(5000);
+
+        vm.prank(emergencyAdmin);
+        strategy.shutdownStrategy();
+
+        vm.prank(keeper);
+        strategy.tend();
+
+        assertEq(usd3Strategy.suppliedWaUSDC(), deployedBeforeShutdown, "tend should be a no-op during shutdown");
+        assertEq(usd3Strategy.balanceOfWaUSDC(), 0, "tend should not pull funds during shutdown");
+    }
+
+    function test_tendTriggerFalseAfterShutdown() public {
+        uint256 amount = 100_000e6;
+
+        mintAndDepositIntoStrategy(strategy, user, amount);
+        setMaxOnCredit(5000);
+
+        (bool shouldTendBeforeShutdown,) = strategy.tendTrigger();
+        assertTrue(shouldTendBeforeShutdown, "deployment drift should trigger tend before shutdown");
+
+        vm.prank(emergencyAdmin);
+        strategy.shutdownStrategy();
+
+        (bool shouldTendAfterShutdown,) = strategy.tendTrigger();
+        assertFalse(shouldTendAfterShutdown, "shutdown should suppress tend trigger");
     }
 
     // TODO: Add tests for any emergency function added.

--- a/test/forge/usd3/USD3SupplyCap.t.sol
+++ b/test/forge/usd3/USD3SupplyCap.t.sol
@@ -80,7 +80,7 @@ contract USD3SupplyCapTest is Setup {
 
     function test_supplyCap_unlimitedByDefault() public {
         // Default cap is unlimited (type(uint256).max)
-        assertEq(usd3Strategy.supplyCap(), type(uint256).max, "Default cap should be unlimited");
+        assertEq(protocolConfig.config(USD3_SUPPLY_CAP), type(uint256).max, "Default cap should be unlimited");
         uint256 expectedLimit = usd3Strategy.WAUSDC().maxDeposit(address(usd3Strategy));
         assertEq(usd3Strategy.availableDepositLimit(alice), expectedLimit, "Should allow unlimited deposits");
 
@@ -107,7 +107,7 @@ contract USD3SupplyCapTest is Setup {
         // Set a supply cap
         _setSupplyCap(TEST_CAP);
 
-        assertEq(usd3Strategy.supplyCap(), TEST_CAP, "Cap should be set");
+        assertEq(protocolConfig.config(USD3_SUPPLY_CAP), TEST_CAP, "Cap should be set");
         assertEq(usd3Strategy.availableDepositLimit(alice), TEST_CAP, "Available should equal cap initially");
 
         // Deposit half the cap

--- a/test/forge/usd3/Whitelist.t.sol
+++ b/test/forge/usd3/Whitelist.t.sol
@@ -250,7 +250,7 @@ contract WhitelistTest is Setup {
 
         // Alice (whitelisted) cannot deposit below minimum for first deposit
         vm.prank(alice);
-        vm.expectRevert("Below minimum deposit");
+        vm.expectRevert(bytes("<min"));
         strategy.deposit(25e6, alice);
 
         // Alice can deposit at or above minimum

--- a/test/forge/usd3/coverage/BaseStrategyCoverage.t.sol
+++ b/test/forge/usd3/coverage/BaseStrategyCoverage.t.sol
@@ -466,7 +466,7 @@ contract BaseStrategyCoverage is Setup {
 
         // Even management cannot change it once set (one-time only)
         vm.prank(management);
-        vm.expectRevert("sUSD3 already set");
+        vm.expectRevert();
         usd3Strategy.setSUSD3(newSusd3);
 
         // Test onlyKeepers (syncTrancheShare)

--- a/test/forge/usd3/coverage/USD3Coverage.t.sol
+++ b/test/forge/usd3/coverage/USD3Coverage.t.sol
@@ -106,7 +106,7 @@ contract USD3Coverage is Setup {
 
         // Test that sUSD3 cannot be changed once set (it's already set in setUp)
         vm.prank(management);
-        vm.expectRevert("sUSD3 already set");
+        vm.expectRevert();
         usd3Strategy.setSUSD3(address(0));
 
         // Verify original is still set
@@ -255,7 +255,7 @@ contract USD3Coverage is Setup {
 
         // Management cannot set it again (one-time only)
         vm.prank(management);
-        vm.expectRevert("sUSD3 already set");
+        vm.expectRevert();
         usd3Strategy.setSUSD3(newSusd3);
 
         // Verify the original is still set
@@ -277,7 +277,7 @@ contract USD3Coverage is Setup {
 
         // Cannot set again even with management
         vm.prank(management);
-        vm.expectRevert("sUSD3 already set");
+        vm.expectRevert();
         usd3Strategy.setSUSD3(firstSusd3);
 
         // Verify original is still set
@@ -285,12 +285,12 @@ contract USD3Coverage is Setup {
 
         // Cannot set to address(0) either
         vm.prank(management);
-        vm.expectRevert("sUSD3 already set");
+        vm.expectRevert();
         usd3Strategy.setSUSD3(address(0));
 
         // Cannot set to same address either
         vm.prank(management);
-        vm.expectRevert("sUSD3 already set");
+        vm.expectRevert();
         usd3Strategy.setSUSD3(currentSusd3);
     }
 

--- a/test/forge/usd3/coverage/USD3Coverage.t.sol
+++ b/test/forge/usd3/coverage/USD3Coverage.t.sol
@@ -129,7 +129,7 @@ contract USD3Coverage is Setup {
 
         // Try to sync - should revert
         vm.prank(keeper);
-        vm.expectRevert("Invalid tranche share");
+        vm.expectRevert();
         usd3Strategy.syncTrancheShare();
 
         // Verify current ratio hasn't changed

--- a/test/forge/usd3/coverage/sUSD3Coverage.t.sol
+++ b/test/forge/usd3/coverage/sUSD3Coverage.t.sol
@@ -256,10 +256,10 @@ contract sUSD3Coverage is Setup {
         uint256 newDuration = susd3Strategy.lockDuration();
         assertEq(newDuration, 60 days, "Should return updated duration");
 
-        // Test zero fallback
+        // Test zero duration
         protocolConfig.setConfig(SUSD3_LOCK_DURATION, 0);
         uint256 zeroDuration = susd3Strategy.lockDuration();
-        assertEq(zeroDuration, 90 days, "Should fallback to 90 days when 0");
+        assertEq(zeroDuration, 0, "Should return zero when configured");
     }
 
     /**

--- a/test/forge/usd3/edge/CommitmentEdgeCases.t.sol
+++ b/test/forge/usd3/edge/CommitmentEdgeCases.t.sol
@@ -313,7 +313,7 @@ contract CommitmentEdgeCasesTest is Setup {
 
         // Alice CANNOT transfer shares during commitment period
         vm.prank(alice);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         ERC20(address(usd3Strategy)).transfer(bob, shares);
 
         // Fast forward 3 more days (7 days from Alice's deposit - commitment complete)
@@ -406,7 +406,7 @@ contract CommitmentEdgeCasesTest is Setup {
 
         // Alice CANNOT transfer shares during commitment period
         vm.prank(alice);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         ERC20(address(usd3Strategy)).transfer(bob, aliceShares);
 
         // Skip commitment period
@@ -456,7 +456,7 @@ contract CommitmentEdgeCasesTest is Setup {
             underlyingAsset.approve(address(usd3Strategy), 200e6);
 
             // All must meet minimum for first deposit
-            vm.expectRevert("Below minimum deposit");
+            vm.expectRevert(bytes("<min"));
             usd3Strategy.deposit(50e6, users[i]);
 
             // Deposit at minimum

--- a/test/forge/usd3/integration/DebtCapAndBacking.t.sol
+++ b/test/forge/usd3/integration/DebtCapAndBacking.t.sol
@@ -179,9 +179,6 @@ contract DebtCapAndBackingTest is Setup {
     //////////////////////////////////////////////////////////////*/
 
     function test_backingRequirement_preventsWithdrawals() public {
-        // Set minimum backing ratio
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, MIN_BACKING_RATIO);
-
         // Alice deposits to USD3
         vm.prank(alice);
         uint256 aliceShares = strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -193,6 +190,9 @@ contract DebtCapAndBackingTest is Setup {
         // Create debt first to enable sUSD3 deposits (debt-based subordination)
         setMaxOnCredit(8000);
         createMarketDebt(borrower, DEPOSIT_AMOUNT / 2); // 500K debt
+
+        // Set minimum backing ratio AFTER debt creation to avoid blocking deployment
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, MIN_BACKING_RATIO);
 
         // Now Bob can deposit USD3 to sUSD3 (after debt exists)
         uint256 bobUSD3 = strategy.balanceOf(bob);
@@ -235,9 +235,6 @@ contract DebtCapAndBackingTest is Setup {
     }
 
     function test_backingRequirement_allowsPartialWithdrawals() public {
-        // Set minimum backing ratio to 25%
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 2500);
-
         // Alice deposits to USD3
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -249,6 +246,9 @@ contract DebtCapAndBackingTest is Setup {
         // Create debt first to enable sUSD3 deposits
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 200_000e6); // 200K debt needs 50K backing at 25%
+
+        // Set minimum backing ratio AFTER debt creation to avoid blocking deployment
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 2500);
 
         // Now Bob can deposit USD3 to sUSD3 (after debt exists)
         uint256 bobUSD3 = strategy.balanceOf(bob);
@@ -316,9 +316,6 @@ contract DebtCapAndBackingTest is Setup {
     }
 
     function test_emergencyShutdownBypassesChecks() public {
-        // Set strict backing requirement
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 10000); // 100%
-
         // Setup positions
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -329,6 +326,9 @@ contract DebtCapAndBackingTest is Setup {
         // Create debt first to enable sUSD3 deposits
         setMaxOnCredit(8000);
         createMarketDebt(borrower, DEPOSIT_AMOUNT / 2);
+
+        // Set strict backing requirement AFTER debt creation to avoid blocking deployment
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 10000); // 100%
 
         // Now Bob can deposit USD3 to sUSD3 (after debt exists)
         uint256 bobUSD3 = strategy.balanceOf(bob);

--- a/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
+++ b/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
@@ -181,9 +181,6 @@ contract DebtFloorComprehensiveTest is Setup {
     //////////////////////////////////////////////////////////////*/
 
     function test_debtFloor_withdrawalAtExactFloor() public {
-        // Set backing ratio to 25%
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 2500);
-
         // Setup positions
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -194,6 +191,9 @@ contract DebtFloorComprehensiveTest is Setup {
         // Create specific debt amount
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 200_000e6); // 200K debt needs 50K backing at 25%
+
+        // Set backing ratio AFTER debt creation to avoid blocking deployment
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 2500);
 
         // Bob deposits to sUSD3
         uint256 bobUSD3 = strategy.balanceOf(bob);
@@ -244,9 +244,6 @@ contract DebtFloorComprehensiveTest is Setup {
     }
 
     function test_debtFloor_withdrawalOneCentAboveFloor() public {
-        // Set backing ratio to 30%
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 3000);
-
         // Setup positions
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -257,6 +254,9 @@ contract DebtFloorComprehensiveTest is Setup {
         // Create debt
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 100_000e6); // 100K debt needs 30K backing
+
+        // Set backing ratio AFTER debt creation
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 3000);
 
         // Bob deposits specific amount to sUSD3 (slightly above floor requirement)
         vm.prank(bob);
@@ -304,9 +304,6 @@ contract DebtFloorComprehensiveTest is Setup {
     //////////////////////////////////////////////////////////////*/
 
     function test_debtFloor_debtIncreaseDuringCooldown() public {
-        // Set backing ratio
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 4000); // 40%
-
         // Setup initial positions
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT * 2, alice);
@@ -317,6 +314,9 @@ contract DebtFloorComprehensiveTest is Setup {
         // Create initial debt
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 100_000e6); // 100K initial debt
+
+        // Set backing ratio AFTER debt creation
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 4000); // 40%
 
         // Bob deposits to sUSD3
         vm.prank(bob);
@@ -335,8 +335,10 @@ contract DebtFloorComprehensiveTest is Setup {
         uint256 withdrawLimit1 = susd3Strategy.availableWithdrawLimit(bob);
         assertGt(withdrawLimit1, 0, "Should have some withdrawal available initially");
 
-        // Increase debt during cooldown window
+        // Temporarily disable backing constraint to allow second borrow's report() to deploy
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
         createMarketDebt(borrower2, 150_000e6); // Additional 150K debt
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 4000);
 
         // Check withdrawal limit after debt increase
         uint256 withdrawLimit2 = susd3Strategy.availableWithdrawLimit(bob);
@@ -353,9 +355,6 @@ contract DebtFloorComprehensiveTest is Setup {
     }
 
     function test_debtFloor_backingRatioChangeDuringCooldown() public {
-        // Start with 20% backing ratio
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 2000);
-
         // Setup positions and debt
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -365,6 +364,9 @@ contract DebtFloorComprehensiveTest is Setup {
 
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 200_000e6);
+
+        // Start with 20% backing ratio (set AFTER debt creation)
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 2000);
 
         // Bob deposits to sUSD3
         vm.prank(bob);
@@ -405,9 +407,6 @@ contract DebtFloorComprehensiveTest is Setup {
     //////////////////////////////////////////////////////////////*/
 
     function test_debtFloor_simultaneousWithdrawalsNearFloor() public {
-        // Set backing ratio
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 3000); // 30%
-
         // Setup positions
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -421,6 +420,9 @@ contract DebtFloorComprehensiveTest is Setup {
         // Create debt
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 300_000e6); // 300K debt needs 90K backing
+
+        // Set backing ratio AFTER debt creation
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 3000); // 30%
 
         // Bob and Charlie both deposit to sUSD3
         vm.prank(bob);
@@ -469,9 +471,6 @@ contract DebtFloorComprehensiveTest is Setup {
     //////////////////////////////////////////////////////////////*/
 
     function test_debtFloor_recoveryFromBelowFloor() public {
-        // Set backing ratio
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 5000); // 50%
-
         // Setup positions
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -482,6 +481,9 @@ contract DebtFloorComprehensiveTest is Setup {
         // Create debt
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 400_000e6); // 400K debt needs 200K backing
+
+        // Set backing ratio AFTER debt creation
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 5000); // 50%
 
         // Bob deposits less than floor requirement
         vm.prank(bob);

--- a/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
+++ b/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
@@ -176,6 +176,53 @@ contract DebtFloorComprehensiveTest is Setup {
         assertLt(withdrawLimit2, bobAssets, "Withdrawal should be limited after backing ratio change");
     }
 
+    function test_debtFloor_zeroBackingRatio_usesNominalSubordinationFloor() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 100_000e6);
+
+        vm.prank(alice);
+        strategy.deposit(DEPOSIT_AMOUNT, alice);
+
+        setMaxOnCredit(8000);
+        createMarketDebt(borrower, 500_000e6);
+
+        assertEq(susd3Strategy.nominalSubordinationFloor(), 100_000e6, "nominal floor mismatch");
+        assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 100_000e6, "should use nominal floor");
+    }
+
+    function test_debtFloor_zeroDebt_usesNominalSubordinationFloor() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 5000);
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 75_000e6);
+
+        assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 75_000e6, "should use nominal floor without debt");
+    }
+
+    function test_debtFloor_nominalFloorDominatesRatioFloor() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 1000); // 10%
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 50_000e6);
+
+        vm.prank(alice);
+        strategy.deposit(DEPOSIT_AMOUNT, alice);
+
+        setMaxOnCredit(8000);
+        createMarketDebt(borrower, 100_000e6); // 10K ratio floor
+
+        assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 50_000e6, "nominal floor should dominate");
+    }
+
+    function test_debtFloor_ratioFloorDominatesNominalFloor() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 5000); // 50%
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 10_000e6);
+
+        vm.prank(alice);
+        strategy.deposit(DEPOSIT_AMOUNT, alice);
+
+        setMaxOnCredit(8000);
+        createMarketDebt(borrower, 100_000e6); // 50K ratio floor
+
+        assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 50_000e6, "ratio floor should dominate");
+    }
+
     /*//////////////////////////////////////////////////////////////
                     BOUNDARY CONDITION TESTING
     //////////////////////////////////////////////////////////////*/
@@ -398,6 +445,90 @@ contract DebtFloorComprehensiveTest is Setup {
             0.05e18, // 5% tolerance for interest accrual
             "Floor should reflect new backing ratio"
         );
+    }
+
+    function test_debtFloor_nominalFloorLimitsWithdrawalsToExcessAboveFloor() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 100_000e6);
+
+        vm.prank(alice);
+        strategy.deposit(DEPOSIT_AMOUNT, alice);
+
+        vm.prank(bob);
+        strategy.deposit(500_000e6, bob);
+
+        setMaxOnCredit(8000);
+        createMarketDebt(borrower, 500_000e6);
+
+        vm.prank(bob);
+        strategy.approve(address(susd3Strategy), 250_000e6);
+
+        vm.prank(bob);
+        uint256 bobSUSD3Shares = susd3Strategy.deposit(250_000e6, bob);
+
+        skip(91 days);
+        vm.prank(bob);
+        susd3Strategy.startCooldown(bobSUSD3Shares);
+        skip(8 days);
+
+        uint256 holdingsUSDC =
+            ITokenizedStrategy(address(usd3Strategy)).convertToAssets(strategy.balanceOf(address(susd3Strategy)));
+        uint256 expectedLimit = ITokenizedStrategy(address(usd3Strategy)).convertToShares(holdingsUSDC - 100_000e6);
+
+        assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 100_000e6, "nominal floor mismatch");
+        assertApproxEqAbs(
+            susd3Strategy.availableWithdrawLimit(bob), expectedLimit, 2, "withdraw limit should preserve floor"
+        );
+    }
+
+    function test_debtFloor_nominalFloorChangeDuringCooldown() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 50_000e6);
+
+        vm.prank(alice);
+        strategy.deposit(DEPOSIT_AMOUNT, alice);
+
+        vm.prank(bob);
+        strategy.deposit(500_000e6, bob);
+
+        setMaxOnCredit(8000);
+        createMarketDebt(borrower, 500_000e6);
+
+        vm.prank(bob);
+        strategy.approve(address(susd3Strategy), 250_000e6);
+
+        vm.prank(bob);
+        uint256 bobSUSD3Shares = susd3Strategy.deposit(250_000e6, bob);
+
+        skip(91 days);
+        vm.prank(bob);
+        susd3Strategy.startCooldown(bobSUSD3Shares);
+        skip(8 days);
+
+        uint256 withdrawLimitBefore = susd3Strategy.availableWithdrawLimit(bob);
+
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 150_000e6);
+
+        uint256 withdrawLimitAfter = susd3Strategy.availableWithdrawLimit(bob);
+        uint256 holdingsUSDC =
+            ITokenizedStrategy(address(usd3Strategy)).convertToAssets(strategy.balanceOf(address(susd3Strategy)));
+        uint256 expectedLimit = ITokenizedStrategy(address(usd3Strategy)).convertToShares(holdingsUSDC - 150_000e6);
+
+        assertLt(withdrawLimitAfter, withdrawLimitBefore, "higher nominal floor should reduce withdrawal limit");
+        assertApproxEqAbs(withdrawLimitAfter, expectedLimit, 2, "withdraw limit should use updated nominal floor");
+    }
+
+    function test_debtFloor_nominalFloorDoesNotChangeDepositLimit() public {
+        protocolConfig.setConfig(ProtocolConfigLib.DEBT_CAP, 500_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.TRANCHE_RATIO, 1500); // 15%
+
+        uint256 depositLimitBefore = susd3Strategy.availableDepositLimit(alice);
+
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 1_000_000e6);
+
+        uint256 depositLimitAfter = susd3Strategy.availableDepositLimit(alice);
+
+        assertEq(depositLimitAfter, depositLimitBefore, "nominal floor should not affect deposit cap");
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
+++ b/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
@@ -481,6 +481,31 @@ contract DebtFloorComprehensiveTest is Setup {
         );
     }
 
+    function test_debtFloor_nominalFloorBlocksWithdrawalAtExactFloor() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 100_000e6);
+
+        vm.prank(bob);
+        strategy.deposit(100_000e6, bob);
+
+        vm.prank(bob);
+        strategy.approve(address(susd3Strategy), 100_000e6);
+
+        vm.prank(bob);
+        uint256 bobSUSD3Shares = susd3Strategy.deposit(100_000e6, bob);
+
+        skip(91 days);
+        vm.prank(bob);
+        susd3Strategy.startCooldown(bobSUSD3Shares);
+        skip(8 days);
+
+        uint256 holdingsUSDC =
+            ITokenizedStrategy(address(usd3Strategy)).convertToAssets(strategy.balanceOf(address(susd3Strategy)));
+
+        assertEq(holdingsUSDC, 100_000e6, "holdings should equal nominal floor");
+        assertEq(susd3Strategy.availableWithdrawLimit(bob), 0, "withdrawal should be blocked at exact floor");
+    }
+
     function test_debtFloor_nominalFloorChangeDuringCooldown() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
         protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 50_000e6);

--- a/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
+++ b/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
@@ -176,9 +176,9 @@ contract DebtFloorComprehensiveTest is Setup {
         assertLt(withdrawLimit2, bobAssets, "Withdrawal should be limited after backing ratio change");
     }
 
-    function test_debtFloor_zeroBackingRatio_usesNominalSubordinationFloor() public {
+    function test_debtFloor_zeroBackingRatio_usesNominalBackingFloor() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 100_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 100_000e6);
 
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -186,20 +186,20 @@ contract DebtFloorComprehensiveTest is Setup {
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 500_000e6);
 
-        assertEq(susd3Strategy.nominalSubordinationFloor(), 100_000e6, "nominal floor mismatch");
+        assertEq(susd3Strategy.nominalBackingFloor(), 100_000e6, "nominal floor mismatch");
         assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 100_000e6, "should use nominal floor");
     }
 
-    function test_debtFloor_zeroDebt_usesNominalSubordinationFloor() public {
+    function test_debtFloor_zeroDebt_usesNominalBackingFloor() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 5000);
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 75_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 75_000e6);
 
         assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 75_000e6, "should use nominal floor without debt");
     }
 
     function test_debtFloor_nominalFloorDominatesRatioFloor() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 1000); // 10%
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 50_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 50_000e6);
 
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -212,7 +212,7 @@ contract DebtFloorComprehensiveTest is Setup {
 
     function test_debtFloor_ratioFloorDominatesNominalFloor() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 5000); // 50%
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 10_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 10_000e6);
 
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -449,7 +449,7 @@ contract DebtFloorComprehensiveTest is Setup {
 
     function test_debtFloor_nominalFloorLimitsWithdrawalsToExcessAboveFloor() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 100_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 100_000e6);
 
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -483,7 +483,7 @@ contract DebtFloorComprehensiveTest is Setup {
 
     function test_debtFloor_nominalFloorChangeDuringCooldown() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 50_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 50_000e6);
 
         vm.prank(alice);
         strategy.deposit(DEPOSIT_AMOUNT, alice);
@@ -507,7 +507,7 @@ contract DebtFloorComprehensiveTest is Setup {
 
         uint256 withdrawLimitBefore = susd3Strategy.availableWithdrawLimit(bob);
 
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 150_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 150_000e6);
 
         uint256 withdrawLimitAfter = susd3Strategy.availableWithdrawLimit(bob);
         uint256 holdingsUSDC =
@@ -524,7 +524,7 @@ contract DebtFloorComprehensiveTest is Setup {
 
         uint256 depositLimitBefore = susd3Strategy.availableDepositLimit(alice);
 
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 1_000_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 1_000_000e6);
 
         uint256 depositLimitAfter = susd3Strategy.availableDepositLimit(alice);
 

--- a/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
+++ b/test/forge/usd3/integration/DebtFloorComprehensive.t.sol
@@ -198,7 +198,6 @@ contract DebtFloorComprehensiveTest is Setup {
     }
 
     function test_debtFloor_nominalFloorDominatesRatioFloor() public {
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 1000); // 10%
         protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 50_000e6);
 
         vm.prank(alice);
@@ -206,12 +205,12 @@ contract DebtFloorComprehensiveTest is Setup {
 
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 100_000e6); // 10K ratio floor
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 1000); // 10%
 
         assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 50_000e6, "nominal floor should dominate");
     }
 
     function test_debtFloor_ratioFloorDominatesNominalFloor() public {
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 5000); // 50%
         protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 10_000e6);
 
         vm.prank(alice);
@@ -219,6 +218,7 @@ contract DebtFloorComprehensiveTest is Setup {
 
         setMaxOnCredit(8000);
         createMarketDebt(borrower, 100_000e6); // 50K ratio floor
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 5000); // 50%
 
         assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), 50_000e6, "ratio floor should dominate");
     }

--- a/test/forge/usd3/integration/ShutdownIntegration.t.sol
+++ b/test/forge/usd3/integration/ShutdownIntegration.t.sol
@@ -232,7 +232,7 @@ contract ShutdownIntegrationTest is Setup {
         // Bob tries to deposit below minimum (whitelisted)
         vm.startPrank(bob);
         underlyingAsset.approve(address(usd3Strategy), 50e6);
-        vm.expectRevert("Below minimum deposit");
+        vm.expectRevert(bytes("<min"));
         usd3Strategy.deposit(50e6, bob);
         vm.stopPrank();
 
@@ -319,7 +319,7 @@ contract ShutdownIntegrationTest is Setup {
 
         if (finalShares == 0) {
             // After full withdrawal, minimum applies again
-            vm.expectRevert("Below minimum deposit");
+            vm.expectRevert(bytes("<min"));
             usd3Strategy.deposit(50e6, alice);
 
             // Must meet minimum for new cycle

--- a/test/forge/usd3/integration/SubordinationDeployCap.t.sol
+++ b/test/forge/usd3/integration/SubordinationDeployCap.t.sol
@@ -174,6 +174,66 @@ contract SubordinationDeployCapTest is Setup {
         );
     }
 
+    function test_reportRestoresBackingCapAfterLossAbsorption() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        setMaxOnCredit(10_000);
+
+        vm.prank(alice);
+        strategy.deposit(1_000_000e6, alice);
+
+        vm.prank(bob);
+        strategy.deposit(500_000e6, bob);
+        _depositToSUSD3(bob, strategy.balanceOf(bob));
+
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 10_000);
+
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        uint256 suppliedBeforeLoss = usd3Strategy.suppliedWaUSDC();
+        uint256 capBeforeLoss = usd3Strategy.effectiveDeployCapWaUSDC();
+        uint256 susd3BalanceBeforeLoss = strategy.balanceOf(address(susd3Strategy));
+        uint256 localWaUSDC = usd3Strategy.balanceOfWaUSDC();
+        uint256 lossWaUSDC = 400_000e6;
+
+        assertApproxEqAbs(suppliedBeforeLoss, capBeforeLoss, 2, "pre-loss deployment should sit at cap");
+        assertGe(localWaUSDC, lossWaUSDC, "test requires enough local waUSDC to remove");
+
+        vm.prank(address(usd3Strategy));
+        waUSDC.transfer(address(0xdead), lossWaUSDC);
+
+        vm.prank(keeper);
+        (, uint256 loss) = ITokenizedStrategy(address(strategy)).report();
+
+        uint256 suppliedAfterReport = usd3Strategy.suppliedWaUSDC();
+        uint256 capAfterReport = usd3Strategy.effectiveDeployCapWaUSDC();
+        uint256 susd3BalanceAfterReport = strategy.balanceOf(address(susd3Strategy));
+
+        assertGt(loss, 0, "report should realize the local waUSDC loss");
+        assertLt(susd3BalanceAfterReport, susd3BalanceBeforeLoss, "sUSD3 should absorb the loss");
+        assertLe(suppliedAfterReport, capAfterReport + 2, "report should finish within post-burn cap");
+        assertLt(suppliedAfterReport, suppliedBeforeLoss, "report should pull excess Morpho supply");
+    }
+
+    function test_reportStillDeploysLocalWaUSDCWhenNoLoss() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        setMaxOnCredit(0);
+
+        vm.prank(alice);
+        strategy.deposit(100_000e6, alice);
+
+        assertEq(usd3Strategy.suppliedWaUSDC(), 0, "maxOnCredit=0 should keep funds local");
+        assertGt(usd3Strategy.balanceOfWaUSDC(), 0, "deposit should wrap into local waUSDC");
+
+        setMaxOnCredit(10_000);
+
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).report();
+
+        assertGt(usd3Strategy.suppliedWaUSDC(), 0, "report should still rebalance after accounting");
+        assertEq(usd3Strategy.balanceOfWaUSDC(), 0, "report should deploy local waUSDC");
+    }
+
     /*//////////////////////////////////////////////////////////////
                     DEPLOYMENT CAP TESTS
     //////////////////////////////////////////////////////////////*/

--- a/test/forge/usd3/integration/SubordinationDeployCap.t.sol
+++ b/test/forge/usd3/integration/SubordinationDeployCap.t.sol
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.18;
+
+import "forge-std/Test.sol";
+import {Setup} from "../utils/Setup.sol";
+import {USD3} from "../../../../src/usd3/USD3.sol";
+import {sUSD3} from "../../../../src/usd3/sUSD3.sol";
+import {MorphoCredit} from "../../../../src/MorphoCredit.sol";
+import {IMorpho, Id, MarketParams} from "../../../../src/interfaces/IMorpho.sol";
+import {MockProtocolConfig} from "../mocks/MockProtocolConfig.sol";
+import {ProtocolConfigLib} from "../../../../src/libraries/ProtocolConfigLib.sol";
+import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
+import {ErrorsLib} from "../../../../src/libraries/ErrorsLib.sol";
+import {
+    TransparentUpgradeableProxy
+} from "../../../../lib/openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "../../../../lib/openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+contract SubordinationDeployCapTest is Setup {
+    USD3 public usd3Strategy;
+    sUSD3 public susd3Strategy;
+    MockProtocolConfig public protocolConfig;
+
+    address public alice = makeAddr("alice");
+    address public bob = makeAddr("bob");
+    address public borrower = makeAddr("borrower");
+
+    uint256 public constant DEPOSIT_AMOUNT = 1_000_000e6;
+
+    function setUp() public override {
+        super.setUp();
+
+        usd3Strategy = USD3(address(strategy));
+
+        address morphoAddress = address(usd3Strategy.morphoCredit());
+        protocolConfig = MockProtocolConfig(MorphoCredit(morphoAddress).protocolConfig());
+
+        // Deploy and link sUSD3
+        sUSD3 susd3Implementation = new sUSD3();
+        ProxyAdmin susd3ProxyAdmin = new ProxyAdmin(management);
+        TransparentUpgradeableProxy susd3Proxy = new TransparentUpgradeableProxy(
+            address(susd3Implementation),
+            address(susd3ProxyAdmin),
+            abi.encodeCall(sUSD3.initialize, (address(usd3Strategy), management, keeper))
+        );
+        susd3Strategy = sUSD3(address(susd3Proxy));
+
+        vm.prank(management);
+        usd3Strategy.setSUSD3(address(susd3Strategy));
+
+        deal(address(underlyingAsset), alice, DEPOSIT_AMOUNT * 20);
+        deal(address(underlyingAsset), bob, DEPOSIT_AMOUNT * 20);
+
+        vm.prank(alice);
+        asset.approve(address(strategy), type(uint256).max);
+        vm.prank(bob);
+        asset.approve(address(strategy), type(uint256).max);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    function _depositToSUSD3(address user, uint256 usd3Amount) internal returns (uint256) {
+        vm.prank(user);
+        strategy.approve(address(susd3Strategy), usd3Amount);
+        vm.prank(user);
+        return susd3Strategy.deposit(usd3Amount, user);
+    }
+
+    /// @dev Creates initial debt and sUSD3 backing WITHOUT the backing ratio constraint.
+    /// Sets MIN_SUSD3_BACKING_RATIO after setup so the subordination cap can be tested.
+    function _bootstrapDebtAndBacking(
+        uint256 usd3DepositAmount,
+        uint256 debtAmount,
+        uint256 susd3DepositAmount,
+        uint256 backingRatio
+    ) internal {
+        // Ensure TRANCHE_RATIO is set for sUSD3 deposit limits
+        protocolConfig.setConfig(ProtocolConfigLib.TRANCHE_RATIO, 10_000);
+        // No backing constraint during bootstrap
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        setMaxOnCredit(10_000);
+
+        // Deposit USDC into USD3
+        vm.prank(alice);
+        strategy.deposit(usd3DepositAmount, alice);
+
+        // Create debt (this calls report() internally, deploys to Morpho, then borrows)
+        createMarketDebt(borrower, debtAmount);
+
+        // Now deposit into sUSD3 (needs debt to exist for deposit limit > 0)
+        if (susd3DepositAmount > 0) {
+            vm.prank(bob);
+            strategy.deposit(susd3DepositAmount, bob);
+
+            uint256 bobUSD3 = strategy.balanceOf(bob);
+            uint256 depositLimit = susd3Strategy.availableDepositLimit(bob);
+            uint256 toDeposit = bobUSD3 > depositLimit ? depositLimit : bobUSD3;
+            if (toDeposit > 0) {
+                _depositToSUSD3(bob, toDeposit);
+            }
+        }
+
+        // NOW enable the backing ratio constraint
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, backingRatio);
+    }
+
+    function _setupBorrower(uint256 creditAmount) internal {
+        Id marketId = usd3Strategy.marketId();
+        MarketParams memory marketParams = usd3Strategy.marketParams();
+        IMorpho morpho = usd3Strategy.morphoCredit();
+
+        address[] memory borrowers_ = new address[](0);
+        uint256[] memory repaymentBps = new uint256[](0);
+        uint256[] memory endingBalances = new uint256[](0);
+
+        vm.prank(marketParams.creditLine);
+        MorphoCredit(address(morpho))
+            .closeCycleAndPostObligations(marketId, block.timestamp, borrowers_, repaymentBps, endingBalances);
+
+        vm.prank(marketParams.creditLine);
+        MorphoCredit(address(morpho)).setCreditLine(marketId, borrower, creditAmount, 0);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    BUG REGRESSION TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_bugRegression_borrowHeadroomBoundedByBacking() public {
+        // 10M USDC deposited, 500K debt, ~800K sUSD3 backing, 10M debt cap
+        _bootstrapDebtAndBacking(10_000_000e6, 500_000e6, 800_000e6, 10_000);
+        setMorphoDebtCap(10_000_000e6);
+
+        // Tend to enforce subordination cap
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        uint256 suppliedAfterTend = usd3Strategy.suppliedWaUSDC();
+        uint256 cap = usd3Strategy.effectiveDeployCapWaUSDC();
+
+        assertLe(suppliedAfterTend, cap + 1, "Deployment should respect subordination cap");
+
+        // The deployed amount should be bounded by sUSD3 backing, NOT the 10M debt cap
+        uint256 sUSD3ValueUSDC =
+            ITokenizedStrategy(address(susd3Strategy)).convertToAssets(strategy.balanceOf(address(susd3Strategy)));
+        assertLe(
+            waUSDC.convertToAssets(suppliedAfterTend),
+            sUSD3ValueUSDC + 1e6,
+            "Deployment should be bounded by sUSD3 backing, not debt cap"
+        );
+    }
+
+    function test_bugRegression_liveShape() public {
+        // Mirror production: ~7.7M debt, ~7.8M sUSD3 backing, 10M cap
+        _bootstrapDebtAndBacking(10_000_000e6, 7_700_000e6, 7_800_000e6, 10_000);
+        setMorphoDebtCap(10_000_000e6);
+
+        // Tend
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        uint256 sUSD3ValueUSDC =
+            ITokenizedStrategy(address(susd3Strategy)).convertToAssets(strategy.balanceOf(address(susd3Strategy)));
+
+        (,, uint256 totalBorrowAssets, uint256 liquidity) = usd3Strategy.getMarketLiquidity();
+        uint256 borrowHeadroom = waUSDC.convertToAssets(liquidity);
+        uint256 debtUSDC = waUSDC.convertToAssets(totalBorrowAssets);
+
+        // Borrow headroom should be bounded by backing headroom
+        uint256 maxNewBorrows = sUSD3ValueUSDC > debtUSDC ? sUSD3ValueUSDC - debtUSDC : 0;
+        assertLe(
+            borrowHeadroom, maxNewBorrows + 2e6, "Borrow headroom should be bounded by backing headroom, not debt cap"
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    DEPLOYMENT CAP TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_deploymentCappedByBacking() public {
+        // 200K debt, 300K sUSD3 backing: after tend, deployment bounded by 300K cap
+        _bootstrapDebtAndBacking(2_000_000e6, 200_000e6, 300_000e6, 10_000);
+
+        // Tend to enforce cap
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        uint256 supplied = usd3Strategy.suppliedWaUSDC();
+        uint256 sUSD3ValueUSDC =
+            ITokenizedStrategy(address(susd3Strategy)).convertToAssets(strategy.balanceOf(address(susd3Strategy)));
+
+        assertLe(waUSDC.convertToAssets(supplied), sUSD3ValueUSDC + 1e6, "Deployment should not exceed sUSD3 backing");
+    }
+
+    function test_tendWithdrawsWhenBackingDrops() public {
+        _bootstrapDebtAndBacking(2_000_000e6, 500_000e6, 1_000_000e6, 10_000);
+
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+        uint256 suppliedBefore = usd3Strategy.suppliedWaUSDC();
+
+        // Simulate sUSD3 backing drop by burning half its USD3 balance
+        uint256 susd3USD3Balance = strategy.balanceOf(address(susd3Strategy));
+        deal(address(strategy), address(susd3Strategy), susd3USD3Balance / 2);
+
+        // Tend should pull back deployment
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+        uint256 suppliedAfter = usd3Strategy.suppliedWaUSDC();
+
+        assertLt(suppliedAfter, suppliedBefore, "Deployment should decrease after backing drop");
+    }
+
+    function test_tendRedeploysWhenBackingRises() public {
+        _bootstrapDebtAndBacking(2_000_000e6, 200_000e6, 200_000e6, 10_000);
+
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+        uint256 suppliedBefore = usd3Strategy.suppliedWaUSDC();
+
+        // Increase sUSD3 backing by dealing more USD3 tokens
+        uint256 susd3USD3Balance = strategy.balanceOf(address(susd3Strategy));
+        deal(address(strategy), address(susd3Strategy), susd3USD3Balance * 3);
+
+        // Tend should redeploy idle funds
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+        uint256 suppliedAfter = usd3Strategy.suppliedWaUSDC();
+
+        assertGe(suppliedAfter, suppliedBefore, "Deployment should increase after backing rise");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    TEND TRIGGER TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_tendTrigger_trueWhenOverDeployed() public {
+        _bootstrapDebtAndBacking(2_000_000e6, 500_000e6, 500_000e6, 10_000);
+
+        // Tend to reach equilibrium
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        // Drop sUSD3 backing significantly
+        uint256 susd3USD3Balance = strategy.balanceOf(address(susd3Strategy));
+        deal(address(strategy), address(susd3Strategy), susd3USD3Balance / 4);
+
+        (bool shouldTend,) = usd3Strategy.tendTrigger();
+        assertTrue(shouldTend, "Should trigger tend when over-deployed vs backing");
+    }
+
+    function test_tendTrigger_trueWhenUnderDeployedWithIdleFunds() public {
+        _bootstrapDebtAndBacking(1_000_000e6, 200_000e6, 200_000e6, 10_000);
+
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        // Increase sUSD3 backing significantly
+        uint256 susd3USD3Balance = strategy.balanceOf(address(susd3Strategy));
+        deal(address(strategy), address(susd3Strategy), susd3USD3Balance * 5);
+
+        (bool shouldTend,) = usd3Strategy.tendTrigger();
+        assertTrue(shouldTend, "Should trigger tend when under-deployed with headroom");
+    }
+
+    function test_tendTrigger_falseWithinThreshold() public {
+        _bootstrapDebtAndBacking(1_000_000e6, 200_000e6, 500_000e6, 10_000);
+
+        // Tend to reach equilibrium
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        (bool shouldTend,) = usd3Strategy.tendTrigger();
+        assertFalse(shouldTend, "Should not trigger tend at equilibrium");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    PASSTHROUGH / EDGE CASE TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_maxOnCreditStricterThanBacking() public {
+        _bootstrapDebtAndBacking(2_000_000e6, 500_000e6, 1_000_000e6, 10_000);
+        setMaxOnCredit(3000); // 30% — much stricter than subordination cap
+
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        uint256 supplied = usd3Strategy.suppliedWaUSDC();
+        uint256 total = supplied + usd3Strategy.balanceOfWaUSDC();
+        uint256 maxOnCreditTarget = (total * 3000) / 10_000;
+
+        assertLe(supplied, maxOnCreditTarget + 1, "maxOnCredit should dominate when stricter");
+    }
+
+    function test_backingRatioZeroPassthrough() public {
+        // MIN_SUSD3_BACKING_RATIO = 0 means no subordination constraint
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        setMaxOnCredit(8000);
+
+        vm.prank(alice);
+        strategy.deposit(2_000_000e6, alice);
+
+        vm.prank(keeper);
+        strategy.report();
+
+        uint256 supplied = usd3Strategy.suppliedWaUSDC();
+        uint256 total = supplied + usd3Strategy.balanceOfWaUSDC();
+        uint256 expected = (total * 8000) / 10_000;
+
+        assertApproxEqAbs(supplied, expected, 2, "Should deploy per maxOnCredit when backingRatio=0");
+    }
+
+    function test_noDeploymentWhenSUSD3Empty() public {
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 10_000);
+        setMaxOnCredit(10_000);
+
+        // sUSD3 is linked but holds nothing
+        vm.prank(alice);
+        strategy.deposit(1_000_000e6, alice);
+
+        vm.prank(keeper);
+        strategy.report();
+
+        uint256 supplied = usd3Strategy.suppliedWaUSDC();
+        assertEq(supplied, 0, "Should not deploy when sUSD3 has no backing");
+    }
+
+    function test_effectiveCapIsMin() public {
+        _bootstrapDebtAndBacking(1_000_000e6, 200_000e6, 300_000e6, 10_000);
+        setMaxOnCredit(5000); // 50%
+
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        uint256 cap = usd3Strategy.effectiveDeployCapWaUSDC();
+        uint256 supplied = usd3Strategy.suppliedWaUSDC();
+        uint256 total = supplied + usd3Strategy.balanceOfWaUSDC();
+
+        uint256 maxOnCreditCap = (total * 5000) / 10_000;
+        uint256 sUSD3ValueUSDC =
+            ITokenizedStrategy(address(susd3Strategy)).convertToAssets(strategy.balanceOf(address(susd3Strategy)));
+        uint256 subCap = waUSDC.convertToShares(sUSD3ValueUSDC);
+
+        uint256 expectedCap = maxOnCreditCap < subCap ? maxOnCreditCap : subCap;
+        assertApproxEqAbs(cap, expectedCap, 2, "Effective cap should be min(maxOnCredit, subordination)");
+    }
+}

--- a/test/forge/usd3/integration/SubordinationDeployCap.t.sol
+++ b/test/forge/usd3/integration/SubordinationDeployCap.t.sol
@@ -219,9 +219,14 @@ contract SubordinationDeployCapTest is Setup {
         ITokenizedStrategy(address(strategy)).tend();
         uint256 suppliedBefore = usd3Strategy.suppliedWaUSDC();
 
-        // Increase sUSD3 backing by dealing more USD3 tokens
-        uint256 susd3USD3Balance = strategy.balanceOf(address(susd3Strategy));
-        deal(address(strategy), address(susd3Strategy), susd3USD3Balance * 3);
+        // Increase sUSD3 backing via actual deposit flow (preserves ERC20 invariants)
+        address charlie = makeAddr("charlie");
+        deal(address(underlyingAsset), charlie, 400_000e6);
+        vm.prank(charlie);
+        asset.approve(address(strategy), type(uint256).max);
+        vm.prank(charlie);
+        strategy.deposit(400_000e6, charlie);
+        _depositToSUSD3(charlie, strategy.balanceOf(charlie));
 
         // Tend should redeploy idle funds
         vm.prank(keeper);
@@ -256,9 +261,14 @@ contract SubordinationDeployCapTest is Setup {
         vm.prank(keeper);
         ITokenizedStrategy(address(strategy)).tend();
 
-        // Increase sUSD3 backing significantly
-        uint256 susd3USD3Balance = strategy.balanceOf(address(susd3Strategy));
-        deal(address(strategy), address(susd3Strategy), susd3USD3Balance * 5);
+        // Increase sUSD3 backing via actual deposit flow (preserves ERC20 invariants)
+        address charlie = makeAddr("charlie");
+        deal(address(underlyingAsset), charlie, 800_000e6);
+        vm.prank(charlie);
+        asset.approve(address(strategy), type(uint256).max);
+        vm.prank(charlie);
+        strategy.deposit(800_000e6, charlie);
+        _depositToSUSD3(charlie, strategy.balanceOf(charlie));
 
         (bool shouldTend,) = usd3Strategy.tendTrigger();
         assertTrue(shouldTend, "Should trigger tend when under-deployed with headroom");
@@ -273,6 +283,46 @@ contract SubordinationDeployCapTest is Setup {
 
         (bool shouldTend,) = usd3Strategy.tendTrigger();
         assertFalse(shouldTend, "Should not trigger tend at equilibrium");
+    }
+
+    function test_tendTrigger_configurableDriftThreshold() public {
+        _bootstrapDebtAndBacking(2_000_000e6, 500_000e6, 500_000e6, 10_000);
+
+        // Tend to reach equilibrium
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+
+        // Drop sUSD3 backing slightly (~5%) to create moderate drift
+        uint256 susd3USD3Balance = strategy.balanceOf(address(susd3Strategy));
+        deal(address(strategy), address(susd3Strategy), (susd3USD3Balance * 95) / 100);
+
+        // With default 10 bps (0.1%), ~5% drift should trigger
+        (bool shouldTendDefault,) = usd3Strategy.tendTrigger();
+        assertTrue(shouldTendDefault, "Should trigger with default 0.1% threshold");
+
+        // Set large threshold (50%) — ~5% drift should NOT trigger
+        protocolConfig.setConfig(ProtocolConfigLib.TEND_DRIFT_THRESHOLD, 5000);
+        (bool shouldTendLarge,) = usd3Strategy.tendTrigger();
+        assertFalse(shouldTendLarge, "Should not trigger with 50% threshold");
+
+        // Set small threshold (1 bp = 0.01%) — should trigger again
+        protocolConfig.setConfig(ProtocolConfigLib.TEND_DRIFT_THRESHOLD, 1);
+        (bool shouldTendSmall,) = usd3Strategy.tendTrigger();
+        assertTrue(shouldTendSmall, "Should trigger with 0.01% threshold");
+    }
+
+    function test_tendTrigger_revertsWhenDriftThresholdTooHigh() public {
+        _bootstrapDebtAndBacking(1_000_000e6, 200_000e6, 500_000e6, 10_000);
+
+        // 100% threshold should revert
+        protocolConfig.setConfig(ProtocolConfigLib.TEND_DRIFT_THRESHOLD, 10_000);
+        vm.expectRevert("Invalid drift threshold");
+        usd3Strategy.tendTrigger();
+
+        // Above 100% should also revert
+        protocolConfig.setConfig(ProtocolConfigLib.TEND_DRIFT_THRESHOLD, 15_000);
+        vm.expectRevert("Invalid drift threshold");
+        usd3Strategy.tendTrigger();
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/forge/usd3/integration/SubordinationDeployCap.t.sol
+++ b/test/forge/usd3/integration/SubordinationDeployCap.t.sol
@@ -68,6 +68,22 @@ contract SubordinationDeployCapTest is Setup {
         return susd3Strategy.deposit(usd3Amount, user);
     }
 
+    function _effectiveDeployCapWaUSDC() internal view returns (uint256) {
+        uint256 totalWaUSDC = usd3Strategy.suppliedWaUSDC() + usd3Strategy.balanceOfWaUSDC();
+        uint256 maxOnCreditCap = (totalWaUSDC * usd3Strategy.maxOnCredit()) / 10_000;
+        uint256 backingRatio = protocolConfig.config(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO);
+        if (backingRatio == 0) return maxOnCreditCap;
+
+        uint256 susd3Shares = strategy.balanceOf(address(susd3Strategy));
+        uint256 totalSupply = strategy.totalSupply();
+        uint256 totalAssets = strategy.totalAssets();
+        if (susd3Shares == 0 || totalSupply == 0 || totalAssets == 0) return 0;
+
+        uint256 sUSD3ValueUSDC = (susd3Shares * totalAssets) / totalSupply;
+        uint256 subCap = waUSDC.convertToShares((sUSD3ValueUSDC * 10_000) / backingRatio);
+        return maxOnCreditCap < subCap ? maxOnCreditCap : subCap;
+    }
+
     /// @dev Creates initial debt and sUSD3 backing WITHOUT the backing ratio constraint.
     /// Sets MIN_SUSD3_BACKING_RATIO after setup so the subordination cap can be tested.
     function _bootstrapDebtAndBacking(
@@ -123,6 +139,29 @@ contract SubordinationDeployCapTest is Setup {
         MorphoCredit(address(morpho)).setCreditLine(marketId, borrower, creditAmount, 0);
     }
 
+    function _setupSUSD3ExitRebalanceScenario() internal {
+        protocolConfig.setConfig(ProtocolConfigLib.TRANCHE_RATIO, 10_000);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_LOCK_DURATION, 0);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_COOLDOWN_PERIOD, 0);
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        setMaxOnCredit(10_000);
+        setMorphoDebtCap(10_000_000e6);
+
+        vm.prank(alice);
+        strategy.deposit(10_000_000e6, alice);
+
+        createMarketDebt(borrower, 1_000_000e6);
+
+        vm.prank(bob);
+        strategy.deposit(2_000_000e6, bob);
+        _depositToSUSD3(bob, strategy.balanceOf(bob));
+
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 10_000);
+
+        vm.prank(keeper);
+        ITokenizedStrategy(address(strategy)).tend();
+    }
+
     /*//////////////////////////////////////////////////////////////
                     BUG REGRESSION TESTS
     //////////////////////////////////////////////////////////////*/
@@ -137,7 +176,7 @@ contract SubordinationDeployCapTest is Setup {
         ITokenizedStrategy(address(strategy)).tend();
 
         uint256 suppliedAfterTend = usd3Strategy.suppliedWaUSDC();
-        uint256 cap = usd3Strategy.effectiveDeployCapWaUSDC();
+        uint256 cap = _effectiveDeployCapWaUSDC();
 
         assertLe(suppliedAfterTend, cap + 1, "Deployment should respect subordination cap");
 
@@ -174,6 +213,91 @@ contract SubordinationDeployCapTest is Setup {
         );
     }
 
+    function test_susd3WithdrawRebalancesUsd3ToPostExitCap() public {
+        _setupSUSD3ExitRebalanceScenario();
+
+        uint256 suppliedBefore = usd3Strategy.suppliedWaUSDC();
+        uint256 capBefore = _effectiveDeployCapWaUSDC();
+        (,, uint256 debtBefore,) = usd3Strategy.getMarketLiquidity();
+        uint256 withdrawLimit = susd3Strategy.availableWithdrawLimit(bob);
+
+        assertApproxEqAbs(suppliedBefore, capBefore, 2, "pre-withdraw deployment should sit at cap");
+        assertGt(suppliedBefore, debtBefore, "scenario should have unborrowed deployed liquidity");
+        assertGt(withdrawLimit, 0, "sUSD3 should have debt-floor withdrawal capacity");
+
+        vm.prank(bob);
+        susd3Strategy.withdraw(withdrawLimit, bob, bob);
+
+        uint256 suppliedAfter = usd3Strategy.suppliedWaUSDC();
+        uint256 capAfter = _effectiveDeployCapWaUSDC();
+
+        assertLt(suppliedAfter, suppliedBefore, "withdraw should pull excess USD3 supply");
+        assertLe(suppliedAfter, capAfter + 2, "withdraw should finish within post-exit cap");
+        assertApproxEqAbs(suppliedAfter, debtBefore, 2, "only borrowed liquidity should remain supplied");
+    }
+
+    function test_susd3WithdrawRemovesBorrowableOverCapLiquidity() public {
+        _setupSUSD3ExitRebalanceScenario();
+
+        uint256 withdrawLimit = susd3Strategy.availableWithdrawLimit(bob);
+
+        vm.prank(bob);
+        susd3Strategy.withdraw(withdrawLimit, bob, bob);
+
+        (,,, uint256 liquidityAfter) = usd3Strategy.getMarketLiquidity();
+        assertLe(liquidityAfter, 2, "over-cap liquidity should be pulled before another tx can borrow");
+
+        MarketParams memory marketParams = usd3Strategy.marketParams();
+        vm.expectRevert(ErrorsLib.InsufficientLiquidity.selector);
+        vm.prank(borrower);
+        helper.borrow(marketParams, 100_000e6, 0, borrower, borrower);
+    }
+
+    function test_susd3WithdrawDoesNotTendAfterUsd3Shutdown() public {
+        _setupSUSD3ExitRebalanceScenario();
+
+        uint256 suppliedBefore = usd3Strategy.suppliedWaUSDC();
+        uint256 withdrawLimit = susd3Strategy.availableWithdrawLimit(bob);
+
+        vm.prank(emergencyAdmin);
+        strategy.shutdownStrategy();
+
+        vm.prank(bob);
+        susd3Strategy.withdraw(withdrawLimit, bob, bob);
+
+        assertEq(usd3Strategy.suppliedWaUSDC(), suppliedBefore, "USD3 shutdown should bypass transfer-hook tend");
+    }
+
+    function test_susd3WithdrawDoesNotDeployIdleWaUSDCWhenPaused() public {
+        protocolConfig.setConfig(ProtocolConfigLib.TRANCHE_RATIO, 10_000);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_LOCK_DURATION, 0);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_COOLDOWN_PERIOD, 0);
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
+        setMaxOnCredit(0);
+
+        vm.prank(alice);
+        strategy.deposit(1_000_000e6, alice);
+
+        vm.prank(bob);
+        strategy.deposit(100_000e6, bob);
+        _depositToSUSD3(bob, strategy.balanceOf(bob));
+
+        assertEq(usd3Strategy.suppliedWaUSDC(), 0, "setup should be underdeployed");
+        assertGt(usd3Strategy.balanceOfWaUSDC(), 0, "setup should have local waUSDC");
+
+        setMaxOnCredit(10_000);
+        protocolConfig.setConfig(keccak256("IS_PAUSED"), 1);
+
+        uint256 localBefore = usd3Strategy.balanceOfWaUSDC();
+        uint256 shares = ITokenizedStrategy(address(susd3Strategy)).balanceOf(bob);
+
+        vm.prank(bob);
+        susd3Strategy.redeem(shares, bob, bob);
+
+        assertEq(usd3Strategy.suppliedWaUSDC(), 0, "sUSD3 exit hook should not deploy while paused");
+        assertEq(usd3Strategy.balanceOfWaUSDC(), localBefore, "local waUSDC should remain local");
+    }
+
     function test_reportRestoresBackingCapAfterLossAbsorption() public {
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 0);
         setMaxOnCredit(10_000);
@@ -191,7 +315,7 @@ contract SubordinationDeployCapTest is Setup {
         ITokenizedStrategy(address(strategy)).tend();
 
         uint256 suppliedBeforeLoss = usd3Strategy.suppliedWaUSDC();
-        uint256 capBeforeLoss = usd3Strategy.effectiveDeployCapWaUSDC();
+        uint256 capBeforeLoss = _effectiveDeployCapWaUSDC();
         uint256 susd3BalanceBeforeLoss = strategy.balanceOf(address(susd3Strategy));
         uint256 localWaUSDC = usd3Strategy.balanceOfWaUSDC();
         uint256 lossWaUSDC = 400_000e6;
@@ -206,7 +330,7 @@ contract SubordinationDeployCapTest is Setup {
         (, uint256 loss) = ITokenizedStrategy(address(strategy)).report();
 
         uint256 suppliedAfterReport = usd3Strategy.suppliedWaUSDC();
-        uint256 capAfterReport = usd3Strategy.effectiveDeployCapWaUSDC();
+        uint256 capAfterReport = _effectiveDeployCapWaUSDC();
         uint256 susd3BalanceAfterReport = strategy.balanceOf(address(susd3Strategy));
 
         assertGt(loss, 0, "report should realize the local waUSDC loss");
@@ -376,12 +500,12 @@ contract SubordinationDeployCapTest is Setup {
 
         // 100% threshold should revert
         protocolConfig.setConfig(ProtocolConfigLib.TEND_DRIFT_THRESHOLD, 10_000);
-        vm.expectRevert("Invalid drift threshold");
+        vm.expectRevert();
         usd3Strategy.tendTrigger();
 
         // Above 100% should also revert
         protocolConfig.setConfig(ProtocolConfigLib.TEND_DRIFT_THRESHOLD, 15_000);
-        vm.expectRevert("Invalid drift threshold");
+        vm.expectRevert();
         usd3Strategy.tendTrigger();
     }
 
@@ -443,7 +567,7 @@ contract SubordinationDeployCapTest is Setup {
         vm.prank(keeper);
         ITokenizedStrategy(address(strategy)).tend();
 
-        uint256 cap = usd3Strategy.effectiveDeployCapWaUSDC();
+        uint256 cap = _effectiveDeployCapWaUSDC();
         uint256 supplied = usd3Strategy.suppliedWaUSDC();
         uint256 total = supplied + usd3Strategy.balanceOfWaUSDC();
 

--- a/test/forge/usd3/integration/USD3MorphoIntegration.t.sol
+++ b/test/forge/usd3/integration/USD3MorphoIntegration.t.sol
@@ -280,6 +280,64 @@ contract USD3MorphoIntegrationTest is Setup {
         assertEq(withdrawn, availableLimit, "Should withdraw exactly the available liquidity");
     }
 
+    function test_settlementBeforeReportBlocksStaleWithdrawals() public {
+        uint256 supplyAmount = 10000e6;
+        uint256 borrowAmount = 1000e6;
+
+        vm.prank(SUPPLIER);
+        uint256 shares = ITokenizedStrategy(address(usd3Strategy)).deposit(supplyAmount, SUPPLIER);
+
+        _setupBorrowerWithATokenLoan(BORROWER, borrowAmount);
+
+        uint256 storedAssetsBeforeSettlement = ITokenizedStrategy(address(usd3Strategy)).totalAssets();
+        assertEq(storedAssetsBeforeSettlement, supplyAmount, "setup should have stale Yearn accounting baseline");
+
+        vm.prank(marketParams.creditLine);
+        (uint256 writtenOffAssets, uint256 writtenOffShares) =
+            MorphoCredit(address(morpho)).settleAccount(marketParams, BORROWER);
+        assertGt(writtenOffAssets, 0, "settlement should realize a loss");
+        assertGt(writtenOffShares, 0, "settlement should write off borrow shares");
+
+        assertLt(_usd3Nav(), storedAssetsBeforeSettlement, "spot nav should be below stored assets");
+        assertEq(usd3Strategy.availableWithdrawLimit(SUPPLIER), 0, "withdraw limit should be gated until report");
+        assertEq(ITokenizedStrategy(address(usd3Strategy)).maxWithdraw(SUPPLIER), 0, "maxWithdraw should be zero");
+        assertEq(ITokenizedStrategy(address(usd3Strategy)).maxRedeem(SUPPLIER), 0, "maxRedeem should be zero");
+
+        vm.prank(SUPPLIER);
+        vm.expectRevert();
+        ITokenizedStrategy(address(usd3Strategy)).redeem(shares, SUPPLIER, SUPPLIER);
+
+        vm.prank(strategyKeeper);
+        (uint256 profit, uint256 loss) = ITokenizedStrategy(address(usd3Strategy)).report();
+        assertEq(profit, 0, "settlement should not report profit");
+        assertApproxEqAbs(loss, writtenOffAssets, 1, "report should recognize realized settlement loss");
+
+        uint256 storedAssetsAfterReport = ITokenizedStrategy(address(usd3Strategy)).totalAssets();
+        assertApproxEqAbs(storedAssetsAfterReport, _usd3Nav(), 2, "report should refresh stored assets to nav");
+        assertGt(usd3Strategy.availableWithdrawLimit(SUPPLIER), 0, "withdrawals should reopen after report");
+    }
+
+    function test_settlementBeforeReportBlocksStaleWithdrawalsDuringShutdown() public {
+        uint256 supplyAmount = 10000e6;
+        uint256 borrowAmount = 1000e6;
+
+        vm.prank(SUPPLIER);
+        ITokenizedStrategy(address(usd3Strategy)).deposit(supplyAmount, SUPPLIER);
+
+        _setupBorrowerWithATokenLoan(BORROWER, borrowAmount);
+
+        vm.prank(marketParams.creditLine);
+        MorphoCredit(address(morpho)).settleAccount(marketParams, BORROWER);
+
+        assertLt(_usd3Nav(), ITokenizedStrategy(address(usd3Strategy)).totalAssets(), "setup should be stale");
+
+        vm.prank(management);
+        ITokenizedStrategy(address(usd3Strategy)).shutdownStrategy();
+
+        assertEq(usd3Strategy.availableWithdrawLimit(SUPPLIER), 0, "shutdown should not bypass stale nav guard");
+        assertEq(ITokenizedStrategy(address(usd3Strategy)).maxWithdraw(SUPPLIER), 0, "maxWithdraw should be zero");
+    }
+
     function test_multipleDepositors() public {
         address depositor1 = makeAddr("Depositor1");
         address depositor2 = makeAddr("Depositor2");
@@ -350,6 +408,11 @@ contract USD3MorphoIntegrationTest is Setup {
     function _triggerAccrual() internal {
         // Trigger interest accrual in Morpho
         morpho.accrueInterest(marketParams);
+    }
+
+    function _usd3Nav() internal view returns (uint256) {
+        uint256 waUSDCAssets = usd3Strategy.suppliedWaUSDC() + usd3Strategy.balanceOfWaUSDC();
+        return waUSDC.convertToAssets(waUSDCAssets) + asset.balanceOf(address(usd3Strategy));
     }
 
     function _createPastObligation(address borrower, uint256 amount, uint256 endingBalance) internal {

--- a/test/forge/usd3/integration/USD3RestartStrategy.t.sol
+++ b/test/forge/usd3/integration/USD3RestartStrategy.t.sol
@@ -16,6 +16,12 @@ import {
 } from "../../../../lib/openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ProxyAdmin} from "../../../../lib/openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 
+contract USD3Restartable is USD3 {
+    function restartStrategy() external reinitializer(3) {
+        TokenizedStrategyStorageLib.getStrategyStorage().shutdown = false;
+    }
+}
+
 contract USD3RestartStrategyTest is Setup {
     uint256 internal constant NOT_ENTERED = 1;
     uint256 internal constant ENTERED_OFFSET = 160;
@@ -25,7 +31,7 @@ contract USD3RestartStrategyTest is Setup {
     address internal bob = makeAddr("bob");
 
     function test_restartStrategyReopensShutdownStrategyAtomically() public {
-        (USD3 usd3, ProxyAdmin proxyAdmin) = _deployRestartableUSD3();
+        (USD3Restartable usd3, ProxyAdmin proxyAdmin) = _deployRestartableUSD3();
         ITokenizedStrategy tokenized = ITokenizedStrategy(address(usd3));
 
         _deposit(usd3, alice, 1_000e6);
@@ -47,7 +53,7 @@ contract USD3RestartStrategyTest is Setup {
     }
 
     function test_restartStrategyCanOnlyRunOnce() public {
-        (USD3 usd3, ProxyAdmin proxyAdmin) = _deployRestartableUSD3();
+        (USD3Restartable usd3, ProxyAdmin proxyAdmin) = _deployRestartableUSD3();
         ITokenizedStrategy tokenized = ITokenizedStrategy(address(usd3));
 
         _deposit(usd3, alice, 1_000e6);
@@ -62,7 +68,7 @@ contract USD3RestartStrategyTest is Setup {
     }
 
     function test_restartStrategySupportsEmergencyWithdrawRecoveryPath() public {
-        (USD3 usd3, ProxyAdmin proxyAdmin) = _deployRestartableUSD3();
+        (USD3Restartable usd3, ProxyAdmin proxyAdmin) = _deployRestartableUSD3();
         ITokenizedStrategy tokenized = ITokenizedStrategy(address(usd3));
 
         _deposit(usd3, alice, 1_000e6);
@@ -83,8 +89,8 @@ contract USD3RestartStrategyTest is Setup {
         assertApproxEqAbs(withdrawn, 500e6, 1, "redeem should work after restart");
     }
 
-    function _deployRestartableUSD3() internal returns (USD3 usd3, ProxyAdmin proxyAdmin) {
-        USD3 implementation = new USD3();
+    function _deployRestartableUSD3() internal returns (USD3Restartable usd3, ProxyAdmin proxyAdmin) {
+        USD3Restartable implementation = new USD3Restartable();
         USD3 setupStrategy = USD3(address(strategy));
 
         bytes memory initData = abi.encodeWithSelector(
@@ -99,7 +105,7 @@ contract USD3RestartStrategyTest is Setup {
             new TransparentUpgradeableProxy(address(implementation), address(this), initData);
 
         proxyAdmin = ProxyAdmin(address(uint160(uint256(vm.load(address(proxy), ERC1967Utils.ADMIN_SLOT)))));
-        usd3 = USD3(address(proxy));
+        usd3 = USD3Restartable(address(proxy));
 
         usd3.reinitialize();
 
@@ -111,12 +117,12 @@ contract USD3RestartStrategyTest is Setup {
         MorphoCredit(address(morpho)).setUsd3(address(usd3));
     }
 
-    function _upgradeAndRestart(USD3 usd3, ProxyAdmin proxyAdmin) internal {
-        USD3 newImplementation = new USD3();
+    function _upgradeAndRestart(USD3Restartable usd3, ProxyAdmin proxyAdmin) internal {
+        USD3Restartable newImplementation = new USD3Restartable();
         proxyAdmin.upgradeAndCall(
             ITransparentUpgradeableProxy(address(usd3)),
             address(newImplementation),
-            abi.encodeCall(USD3.restartStrategy, ())
+            abi.encodeCall(USD3Restartable.restartStrategy, ())
         );
     }
 

--- a/test/forge/usd3/integration/USD3sUSD3Integration.t.sol
+++ b/test/forge/usd3/integration/USD3sUSD3Integration.t.sol
@@ -307,6 +307,71 @@ contract USD3sUSD3IntegrationTest is Setup {
         assertGt(withdrawn, 0, "Should be able to withdraw after cooldown");
     }
 
+    function test_staleNavBlocksSusd3WithdrawLimit() public {
+        uint256 borrowAmount = 5_000e6;
+
+        vm.startPrank(alice);
+        asset.approve(address(usd3Strategy), LARGE_DEPOSIT);
+        usd3Strategy.deposit(LARGE_DEPOSIT, alice);
+        vm.stopPrank();
+
+        createMarketDebt(charlie, borrowAmount);
+
+        vm.startPrank(bob);
+        asset.approve(address(usd3Strategy), MEDIUM_DEPOSIT);
+        usd3Strategy.deposit(MEDIUM_DEPOSIT, bob);
+
+        uint256 bobDepositAmount = ERC20(address(usd3Strategy)).balanceOf(bob) / 10;
+        ERC20(address(usd3Strategy)).approve(address(susd3Strategy), bobDepositAmount);
+        susd3Strategy.deposit(bobDepositAmount, bob);
+        vm.stopPrank();
+
+        vm.prank(keeper);
+        susd3Strategy.report();
+
+        skip(susd3Strategy.lockDuration() + 1);
+
+        uint256 bobSusd3Shares = ERC20(address(susd3Strategy)).balanceOf(bob);
+        vm.prank(bob);
+        susd3Strategy.startCooldown(bobSusd3Shares);
+
+        skip(susd3Strategy.cooldownDuration() + 1);
+
+        assertGt(susd3Strategy.availableWithdrawLimit(bob), 0, "setup should allow sUSD3 withdrawals");
+
+        uint256 usd3StoredAssets = ITokenizedStrategy(address(usd3Strategy)).totalAssets();
+        MarketParams memory params = usd3Strategy.marketParams();
+        IMorpho morpho = usd3Strategy.morphoCredit();
+        vm.prank(params.creditLine);
+        MorphoCredit(address(morpho)).settleAccount(params, charlie);
+
+        assertLt(usd3Strategy.nav(), usd3StoredAssets, "USD3 nav should be stale before report");
+        assertEq(susd3Strategy.availableWithdrawLimit(bob), 0, "stale USD3 nav should block sUSD3 withdrawals");
+        assertEq(ITokenizedStrategy(address(susd3Strategy)).maxWithdraw(bob), 0, "maxWithdraw should be zero");
+        assertEq(ITokenizedStrategy(address(susd3Strategy)).maxRedeem(bob), 0, "maxRedeem should be zero");
+
+        vm.prank(keeper);
+        (uint256 profit, uint256 loss) = usd3Strategy.report();
+        assertEq(profit, 0, "settlement should not report profit");
+        assertApproxEqAbs(loss, borrowAmount, 1, "report should recognize settled debt");
+
+        uint256 susd3StoredAssets = ITokenizedStrategy(address(susd3Strategy)).totalAssets();
+        uint256 susd3SpotAssets = ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy));
+        assertLt(susd3SpotAssets, susd3StoredAssets, "sUSD3 spot nav should be stale before sUSD3 report");
+        assertEq(susd3Strategy.availableWithdrawLimit(bob), 0, "stale sUSD3 nav should block withdrawals");
+
+        vm.prank(keeper);
+        susd3Strategy.report();
+
+        assertApproxEqAbs(
+            ITokenizedStrategy(address(susd3Strategy)).totalAssets(),
+            ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy)),
+            2,
+            "sUSD3 report should refresh stored assets"
+        );
+        assertGt(susd3Strategy.availableWithdrawLimit(bob), 0, "sUSD3 withdrawals should reopen after report");
+    }
+
     /*//////////////////////////////////////////////////////////////
                     HELPER FUNCTIONS
     //////////////////////////////////////////////////////////////*/

--- a/test/forge/usd3/invariants/DebtFloorInvariants.t.sol
+++ b/test/forge/usd3/invariants/DebtFloorInvariants.t.sol
@@ -7,6 +7,7 @@ import {USD3} from "../../../../src/usd3/USD3.sol";
 import {sUSD3} from "../../../../src/usd3/sUSD3.sol";
 import {MorphoCredit} from "../../../../src/MorphoCredit.sol";
 import {MockProtocolConfig} from "../mocks/MockProtocolConfig.sol";
+import {ProtocolConfigLib} from "../../../../src/libraries/ProtocolConfigLib.sol";
 import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
 import {
     TransparentUpgradeableProxy
@@ -46,7 +47,8 @@ contract DebtFloorInvariantsTest is StdInvariant, Setup {
         // Configure floor/cap environment.
         setMaxOnCredit(8000);
         setMorphoDebtCap(20_000_000e6);
-        protocolConfig.setConfig(keccak256("MIN_SUSD3_BACKING_RATIO"), 3000); // 30%
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 3000); // 30%
+        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 400_000e6);
 
         // Seed liquidity and debt.
         address alice = makeAddr("debt-floor-alice");
@@ -99,7 +101,9 @@ contract DebtFloorInvariantsTest is StdInvariant, Setup {
         (,, uint256 totalBorrowAssetsWaUSDC,) = usd3Strategy.getMarketLiquidity();
         uint256 debtUsdc = usd3Strategy.WAUSDC().convertToAssets(totalBorrowAssetsWaUSDC);
         uint256 backingRatio = susd3Strategy.minBackingRatio();
-        uint256 expectedFloor = (debtUsdc * backingRatio) / 10_000;
+        uint256 ratioFloor = (debtUsdc * backingRatio) / 10_000;
+        uint256 nominalFloor = susd3Strategy.nominalSubordinationFloor();
+        uint256 expectedFloor = ratioFloor > nominalFloor ? ratioFloor : nominalFloor;
 
         assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), expectedFloor, "debt floor formula mismatch");
     }

--- a/test/forge/usd3/invariants/DebtFloorInvariants.t.sol
+++ b/test/forge/usd3/invariants/DebtFloorInvariants.t.sol
@@ -47,8 +47,6 @@ contract DebtFloorInvariantsTest is StdInvariant, Setup {
         // Configure floor/cap environment.
         setMaxOnCredit(8000);
         setMorphoDebtCap(20_000_000e6);
-        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 3000); // 30%
-        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 400_000e6);
 
         // Seed liquidity and debt.
         address alice = makeAddr("debt-floor-alice");
@@ -59,6 +57,8 @@ contract DebtFloorInvariantsTest is StdInvariant, Setup {
         vm.stopPrank();
 
         createMarketDebt(makeAddr("debt-floor-borrower"), 1_000_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 3000); // 30%
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 400_000e6);
 
         vm.startPrank(alice);
         IERC20(address(usd3Strategy)).approve(address(susd3Strategy), 500_000e6);

--- a/test/forge/usd3/invariants/DebtFloorInvariants.t.sol
+++ b/test/forge/usd3/invariants/DebtFloorInvariants.t.sol
@@ -48,7 +48,7 @@ contract DebtFloorInvariantsTest is StdInvariant, Setup {
         setMaxOnCredit(8000);
         setMorphoDebtCap(20_000_000e6);
         protocolConfig.setConfig(ProtocolConfigLib.MIN_SUSD3_BACKING_RATIO, 3000); // 30%
-        protocolConfig.setConfig(ProtocolConfigLib.NOMINAL_SUBORDINATION_FLOOR, 400_000e6);
+        protocolConfig.setConfig(ProtocolConfigLib.SUSD3_NOMINAL_BACKING_FLOOR, 400_000e6);
 
         // Seed liquidity and debt.
         address alice = makeAddr("debt-floor-alice");
@@ -102,7 +102,7 @@ contract DebtFloorInvariantsTest is StdInvariant, Setup {
         uint256 debtUsdc = usd3Strategy.WAUSDC().convertToAssets(totalBorrowAssetsWaUSDC);
         uint256 backingRatio = susd3Strategy.minBackingRatio();
         uint256 ratioFloor = (debtUsdc * backingRatio) / 10_000;
-        uint256 nominalFloor = susd3Strategy.nominalSubordinationFloor();
+        uint256 nominalFloor = susd3Strategy.nominalBackingFloor();
         uint256 expectedFloor = ratioFloor > nominalFloor ? ratioFloor : nominalFloor;
 
         assertEq(susd3Strategy.getSubordinatedDebtFloorInUSDC(), expectedFloor, "debt floor formula mismatch");

--- a/test/forge/usd3/mocks/MockProtocolConfig.sol
+++ b/test/forge/usd3/mocks/MockProtocolConfig.sol
@@ -33,6 +33,7 @@ contract MockProtocolConfig is IProtocolConfig {
     bytes32 private constant MIN_BORROW = keccak256("MIN_BORROW");
     bytes32 private constant IRP = keccak256("IRP");
     bytes32 private constant DEBT_CAP = keccak256("DEBT_CAP");
+    bytes32 private constant TEND_DRIFT_THRESHOLD = keccak256("TEND_DRIFT_THRESHOLD");
 
     constructor() {
         owner = msg.sender;
@@ -51,6 +52,7 @@ contract MockProtocolConfig is IProtocolConfig {
         config[GRACE_PERIOD] = 7 days;
         config[DELINQUENCY_PERIOD] = 30 days;
         config[MIN_BORROW] = 100e6; // 100 USDC minimum
+        config[TEND_DRIFT_THRESHOLD] = 10; // 0.1% default
     }
 
     function initialize(address newOwner) external {

--- a/test/forge/usd3/mocks/MockWaUSDC.sol
+++ b/test/forge/usd3/mocks/MockWaUSDC.sol
@@ -22,6 +22,8 @@ contract MockWaUSDC is ERC20 {
     // Pause state for testing EIP-4626 compliance
     bool private _paused;
 
+    uint128 private _virtualUnderlyingBalance;
+
     constructor(address _usdc) ERC20("Wrapped Aave USDC", "waUSDC") {
         _asset = _usdc;
     }
@@ -41,11 +43,25 @@ contract MockWaUSDC is ERC20 {
         return _paused;
     }
 
+    function POOL() public view returns (MockWaUSDC) {
+        return this;
+    }
+
     /**
      * @dev Set the pause state (for testing)
      */
     function setPaused(bool paused_) external {
         _paused = paused_;
+    }
+
+    function setVirtualUnderlyingBalance(uint128 virtualUnderlyingBalance_) external {
+        _virtualUnderlyingBalance = virtualUnderlyingBalance_;
+    }
+
+    function getVirtualUnderlyingBalance(address asset_) external view returns (uint128) {
+        require(asset_ == _asset, "invalid asset");
+        if (_virtualUnderlyingBalance != 0) return _virtualUnderlyingBalance;
+        return uint128(totalAssets());
     }
 
     /**
@@ -77,6 +93,7 @@ contract MockWaUSDC is ERC20 {
      */
     function withdraw(uint256 assets, address receiver, address owner) public whenNotPaused returns (uint256 shares) {
         shares = previewWithdraw(assets);
+        require(shares <= maxRedeem(owner), "ERC4626: withdraw more than max");
         if (msg.sender != owner) {
             uint256 allowed = allowance(owner, msg.sender);
             if (allowed != type(uint256).max) {
@@ -92,6 +109,7 @@ contract MockWaUSDC is ERC20 {
      * @dev Redeem waUSDC shares for USDC
      */
     function redeem(uint256 shares, address receiver, address owner) public whenNotPaused returns (uint256 assets) {
+        require(shares <= maxRedeem(owner), "ERC4626: redeem more than max");
         assets = previewRedeem(shares);
         if (msg.sender != owner) {
             uint256 allowed = allowance(owner, msg.sender);
@@ -157,12 +175,15 @@ contract MockWaUSDC is ERC20 {
 
     function maxWithdraw(address owner) public view returns (uint256) {
         if (_paused) return 0;
-        return convertToAssets(balanceOf(owner));
+        return convertToAssets(maxRedeem(owner));
     }
 
     function maxRedeem(address owner) public view returns (uint256) {
         if (_paused) return 0;
-        return balanceOf(owner);
+        uint256 underlyingTokenBalanceInShares =
+            convertToShares(_virtualUnderlyingBalance == 0 ? totalAssets() : _virtualUnderlyingBalance);
+        uint256 cachedUserBalance = balanceOf(owner);
+        return underlyingTokenBalanceInShares >= cachedUserBalance ? cachedUserBalance : underlyingTokenBalanceInShares;
     }
 
     /**

--- a/test/forge/usd3/regression/MinDepositBypass.t.sol
+++ b/test/forge/usd3/regression/MinDepositBypass.t.sol
@@ -56,7 +56,7 @@ contract MinDepositBypassTest is Setup {
         asset.approve(address(usd3Strategy), belowMinAmount);
 
         // Should revert for first-time depositor with amount below minimum
-        vm.expectRevert("Below minimum deposit");
+        vm.expectRevert(bytes("<min"));
         usd3Strategy.deposit(belowMinAmount, alice);
         vm.stopPrank();
 
@@ -82,7 +82,7 @@ contract MinDepositBypassTest is Setup {
 
         // This SHOULD revert but doesn't due to the bug
         // The test expects this to revert, so it will FAIL when the bug exists
-        vm.expectRevert("Below minimum deposit");
+        vm.expectRevert(bytes("<min"));
         usd3Strategy.deposit(type(uint256).max, alice);
 
         vm.stopPrank();
@@ -107,7 +107,7 @@ contract MinDepositBypassTest is Setup {
 
         // This SHOULD revert but doesn't due to the bug
         // The test expects this to revert, so it will FAIL when the bug exists
-        vm.expectRevert("Below minimum deposit");
+        vm.expectRevert(bytes("<min"));
         usd3Strategy.mint(type(uint256).max, bob);
 
         vm.stopPrank();
@@ -133,7 +133,7 @@ contract MinDepositBypassTest is Setup {
 
         // Using type(uint256).max should still respect minDeposit
         // This SHOULD revert but doesn't due to the bug
-        vm.expectRevert("Below minimum deposit");
+        vm.expectRevert(bytes("<min"));
         usd3Strategy.deposit(type(uint256).max, charlie);
 
         vm.stopPrank();
@@ -189,7 +189,7 @@ contract MinDepositBypassTest is Setup {
 
         // This SHOULD fail but doesn't due to the bug
         // The test expects this to revert, so it will FAIL when the bug exists
-        vm.expectRevert("Below minimum deposit");
+        vm.expectRevert(bytes("<min"));
         usd3Strategy.deposit(type(uint256).max, attacker);
 
         vm.stopPrank();

--- a/test/forge/usd3/regression/WaUSDCRedemptionCapacity.t.sol
+++ b/test/forge/usd3/regression/WaUSDCRedemptionCapacity.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.18;
+
+import {Setup} from "../utils/Setup.sol";
+import {USD3} from "../../../../src/usd3/USD3.sol";
+
+contract WaUSDCRedemptionCapacityTest is Setup {
+    USD3 public usd3;
+    address public alice = makeAddr("alice");
+
+    function setUp() public override {
+        super.setUp();
+        usd3 = USD3(address(strategy));
+
+        airdrop(asset, alice, 10_000e6);
+        vm.prank(alice);
+        asset.approve(address(strategy), type(uint256).max);
+    }
+
+    function test_availableWithdrawLimit_capsLocalAndMorphoByGlobalRedeemCapacity() public {
+        setMaxOnCredit(5_000);
+
+        vm.prank(alice);
+        strategy.deposit(2_000e6, alice);
+
+        assertEq(usd3.balanceOfWaUSDC(), 1_000e6, "setup local");
+        assertEq(usd3.suppliedWaUSDC(), 1_000e6, "setup morpho");
+
+        waUSDC.setVirtualUnderlyingBalance(1_500e6);
+
+        assertEq(usd3.availableWithdrawLimit(alice), 1_500e6, "withdraw limit");
+
+        vm.prank(alice);
+        uint256 shares = strategy.withdraw(1_500e6, alice, alice);
+
+        assertEq(shares, 1_500e6, "shares burned");
+        assertEq(asset.balanceOf(alice), 9_500e6, "alice balance");
+    }
+
+    function test_availableWithdrawLimit_countsMorphoLiquidityWhenLocalBalanceIsZero() public {
+        setMaxOnCredit(10_000);
+
+        vm.prank(alice);
+        strategy.deposit(1_000e6, alice);
+
+        assertEq(usd3.balanceOfWaUSDC(), 0, "setup local");
+        assertEq(usd3.suppliedWaUSDC(), 1_000e6, "setup morpho");
+
+        waUSDC.setVirtualUnderlyingBalance(1_000e6);
+
+        assertEq(waUSDC.maxRedeem(address(usd3)), 0, "local max redeem");
+        assertEq(usd3.availableWithdrawLimit(alice), 1_000e6, "withdraw limit");
+
+        vm.prank(alice);
+        uint256 shares = strategy.withdraw(1_000e6, alice, alice);
+
+        assertEq(shares, 1_000e6, "shares burned");
+        assertEq(asset.balanceOf(alice), 10_000e6, "alice balance");
+    }
+}

--- a/test/forge/usd3/sUSD3.t.sol
+++ b/test/forge/usd3/sUSD3.t.sol
@@ -380,6 +380,96 @@ contract sUSD3Test is Setup {
         assertEq(susd3Strategy.withdrawalWindow(), 3 days);
     }
 
+    function test_lockDurationReturnsZeroWhenConfigZero() public {
+        address morphoAddress = address(usd3.morphoCredit());
+        address protocolConfigAddress = MorphoCredit(morphoAddress).protocolConfig();
+        MockProtocolConfig protocolConfig = MockProtocolConfig(protocolConfigAddress);
+
+        bytes32 SUSD3_LOCK_DURATION = keccak256("SUSD3_LOCK_DURATION");
+        protocolConfig.setConfig(SUSD3_LOCK_DURATION, 0);
+
+        assertEq(susd3Strategy.lockDuration(), 0);
+    }
+
+    function test_zeroLockAllowsImmediateTransfer() public {
+        address morphoAddress = address(usd3.morphoCredit());
+        address protocolConfigAddress = MorphoCredit(morphoAddress).protocolConfig();
+        MockProtocolConfig protocolConfig = MockProtocolConfig(protocolConfigAddress);
+
+        bytes32 SUSD3_LOCK_DURATION = keccak256("SUSD3_LOCK_DURATION");
+        protocolConfig.setConfig(SUSD3_LOCK_DURATION, 0);
+
+        uint256 depositAmount = 100e6;
+        vm.startPrank(alice);
+        ERC20(address(usd3)).approve(address(susd3Strategy), depositAmount);
+        uint256 shares = susd3Strategy.deposit(depositAmount, alice);
+        ERC20(address(susd3Strategy)).transfer(bob, shares);
+        vm.stopPrank();
+
+        assertEq(ERC20(address(susd3Strategy)).balanceOf(bob), shares);
+    }
+
+    function test_zeroLockAllowsImmediateCooldown() public {
+        address morphoAddress = address(usd3.morphoCredit());
+        address protocolConfigAddress = MorphoCredit(morphoAddress).protocolConfig();
+        MockProtocolConfig protocolConfig = MockProtocolConfig(protocolConfigAddress);
+
+        bytes32 SUSD3_LOCK_DURATION = keccak256("SUSD3_LOCK_DURATION");
+        protocolConfig.setConfig(SUSD3_LOCK_DURATION, 0);
+
+        uint256 depositAmount = 100e6;
+        vm.startPrank(alice);
+        ERC20(address(usd3)).approve(address(susd3Strategy), depositAmount);
+        uint256 shares = susd3Strategy.deposit(depositAmount, alice);
+        susd3Strategy.startCooldown(shares);
+        vm.stopPrank();
+
+        (uint256 cooldownEnd, uint256 windowEnd, uint256 cooldownShares) = susd3Strategy.getCooldownStatus(alice);
+        assertEq(cooldownEnd, block.timestamp + 7 days);
+        assertEq(windowEnd, block.timestamp + 7 days + 2 days);
+        assertEq(cooldownShares, shares);
+    }
+
+    function test_zeroLockSkipsStorageWrite() public {
+        address morphoAddress = address(usd3.morphoCredit());
+        address protocolConfigAddress = MorphoCredit(morphoAddress).protocolConfig();
+        MockProtocolConfig protocolConfig = MockProtocolConfig(protocolConfigAddress);
+
+        bytes32 SUSD3_LOCK_DURATION = keccak256("SUSD3_LOCK_DURATION");
+        protocolConfig.setConfig(SUSD3_LOCK_DURATION, 0);
+
+        uint256 depositAmount = 100e6;
+        vm.startPrank(alice);
+        ERC20(address(usd3)).approve(address(susd3Strategy), depositAmount);
+        susd3Strategy.deposit(depositAmount, alice);
+        vm.stopPrank();
+
+        assertEq(susd3Strategy.lockedUntil(alice), 0);
+    }
+
+    function test_zeroLockPreservesPriorLock() public {
+        address morphoAddress = address(usd3.morphoCredit());
+        address protocolConfigAddress = MorphoCredit(morphoAddress).protocolConfig();
+        MockProtocolConfig protocolConfig = MockProtocolConfig(protocolConfigAddress);
+
+        uint256 firstDeposit = 100e6;
+        vm.startPrank(alice);
+        ERC20(address(usd3)).approve(address(susd3Strategy), type(uint256).max);
+        susd3Strategy.deposit(firstDeposit, alice);
+
+        uint256 originalLock = susd3Strategy.lockedUntil(alice);
+        vm.stopPrank();
+
+        bytes32 SUSD3_LOCK_DURATION = keccak256("SUSD3_LOCK_DURATION");
+        protocolConfig.setConfig(SUSD3_LOCK_DURATION, 0);
+
+        vm.startPrank(alice);
+        susd3Strategy.deposit(100e6, alice);
+        vm.stopPrank();
+
+        assertEq(susd3Strategy.lockedUntil(alice), originalLock);
+    }
+
     function test_setParameters_invalidValues() public {
         // Get protocol config
         address morphoAddress = address(usd3.morphoCredit());

--- a/test/forge/usd3/security/BypassAttempts.t.sol
+++ b/test/forge/usd3/security/BypassAttempts.t.sol
@@ -115,7 +115,7 @@ contract BypassAttempts is Setup {
 
         // Bob CANNOT transfer Alice's shares during commitment
         vm.prank(bob);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transferFrom(alice, bob, aliceShares);
 
         // Verify Alice still has her shares
@@ -425,7 +425,7 @@ contract BypassAttempts is Setup {
 
         // Alice CANNOT transfer shares during commitment period
         vm.prank(alice);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(bob, 500e6);
 
         // Verify shares didn't move
@@ -497,12 +497,12 @@ contract BypassAttempts is Setup {
         // Try to deposit below minimum via deposit() as first deposit
         vm.startPrank(alice);
         asset.approve(address(usd3Strategy), 1000e6);
-        vm.expectRevert("Below minimum deposit");
+        vm.expectRevert(bytes("<min"));
         usd3Strategy.deposit(50e6, alice); // Below 100e6 minimum
 
         // Try to bypass via mint()
         uint256 sharesToMint = ITokenizedStrategy(address(usd3Strategy)).previewDeposit(50e6);
-        vm.expectRevert("Below minimum deposit");
+        vm.expectRevert(bytes("<min"));
         usd3Strategy.mint(sharesToMint, alice);
         vm.stopPrank();
 

--- a/test/forge/usd3/security/ShutdownSecurity.t.sol
+++ b/test/forge/usd3/security/ShutdownSecurity.t.sol
@@ -139,7 +139,7 @@ contract ShutdownSecurityTest is Setup {
         underlyingAsset.approve(address(usd3Strategy), 1000e6);
 
         uint256 bobSharesAttempt = ITokenizedStrategy(address(usd3Strategy)).previewDeposit(50e6); // Below minimum
-        vm.expectRevert("Below minimum deposit");
+        vm.expectRevert(bytes("<min"));
         usd3Strategy.mint(bobSharesAttempt, bob);
 
         // Bob must meet minimum for first deposit even with mint()
@@ -293,7 +293,7 @@ contract ShutdownSecurityTest is Setup {
 
             // Try to deposit below minimum again
             vm.startPrank(attacker);
-            vm.expectRevert("Below minimum deposit");
+            vm.expectRevert(bytes("<min"));
             usd3Strategy.deposit(50e6, attacker);
 
             // Must meet minimum again for first deposit after full withdrawal

--- a/test/forge/usd3/security/TransferRestrictionComplexScenarios.t.sol
+++ b/test/forge/usd3/security/TransferRestrictionComplexScenarios.t.sol
@@ -104,7 +104,7 @@ contract TransferRestrictionComplexScenarios is Setup {
 
         // Alice still cannot transfer
         vm.prank(alice);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(dave, 100e6);
 
         skip(2 days);
@@ -115,11 +115,11 @@ contract TransferRestrictionComplexScenarios is Setup {
 
         // But Bob and Charlie still cannot
         vm.prank(bob);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(dave, 100e6);
 
         vm.prank(charlie);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(dave, 100e6);
     }
 
@@ -139,7 +139,7 @@ contract TransferRestrictionComplexScenarios is Setup {
         // Alice -> Bob -> Charlie -> Alice
 
         vm.prank(alice);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(bob, 100e6);
 
         // Skip commitment
@@ -194,7 +194,7 @@ contract TransferRestrictionComplexScenarios is Setup {
 
         // But Bob cannot participate in the chain
         vm.prank(bob);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(eve, 100e6);
 
         // Verify final distribution
@@ -443,7 +443,7 @@ contract TransferRestrictionComplexScenarios is Setup {
         usd3Strategy.deposit(1000e6, alice);
 
         // Cannot transfer immediately
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(bob, 100e6);
 
         skip(7 days);
@@ -455,7 +455,7 @@ contract TransferRestrictionComplexScenarios is Setup {
         usd3Strategy.deposit(1000e6, alice);
 
         // Cannot transfer again
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(bob, 100e6);
 
         skip(7 days);

--- a/test/forge/usd3/security/TransferRestrictionEdgeCases.t.sol
+++ b/test/forge/usd3/security/TransferRestrictionEdgeCases.t.sol
@@ -101,7 +101,7 @@ contract TransferRestrictionEdgeCases is Setup {
 
         // Transfer should fail
         vm.prank(alice);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(bob, aliceShares / 2);
 
         // One second later should work
@@ -121,7 +121,7 @@ contract TransferRestrictionEdgeCases is Setup {
         // Zero amount transfer during commitment is still blocked by the hook
         // The hook checks commitment before checking amount
         vm.prank(alice);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(bob, 0);
 
         // After commitment, zero transfers work (though they're no-ops)
@@ -148,7 +148,7 @@ contract TransferRestrictionEdgeCases is Setup {
 
         // Bob cannot transfer during commitment even with infinite approval
         vm.prank(bob);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transferFrom(alice, charlie, aliceShares / 2);
 
         // After commitment period
@@ -196,7 +196,7 @@ contract TransferRestrictionEdgeCases is Setup {
         airdrop(asset, address(attacker), 10000e6);
 
         // Attacker tries to deposit and immediately transfer
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         attacker.attack();
     }
 
@@ -216,7 +216,7 @@ contract TransferRestrictionEdgeCases is Setup {
 
         // Alice still cannot transfer during commitment (shutdown doesn't bypass transfer restrictions)
         vm.prank(alice);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(bob, aliceShares);
 
         // After commitment, transfer works
@@ -349,7 +349,7 @@ contract TransferRestrictionEdgeCases is Setup {
         uint256 aliceShares = IERC20(address(usd3Strategy)).balanceOf(alice);
 
         // Transfer to self should still be blocked during commitment
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(alice, aliceShares);
         vm.stopPrank();
     }
@@ -391,7 +391,7 @@ contract TransferRestrictionEdgeCases is Setup {
         // This should now be blocked entirely (not just prevent commitment extension)
         vm.startPrank(bob);
         underlyingAsset.approve(address(usd3Strategy), 1);
-        vm.expectRevert("USD3: Only self or whitelisted deposits allowed");
+        vm.expectRevert(bytes("!allowed"));
         usd3Strategy.deposit(1, alice); // Attempt to deposit to Alice
         vm.stopPrank();
 
@@ -494,7 +494,7 @@ contract TransferRestrictionEdgeCases is Setup {
 
         // Alice should NOT be able to transfer yet
         vm.startPrank(alice);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(bob, 1);
         vm.stopPrank();
 
@@ -525,7 +525,7 @@ contract TransferRestrictionEdgeCases is Setup {
         vm.warp(block.timestamp + 4 days + 1); // Original would have ended
 
         // Should still be locked
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(bob, 1);
 
         // After new period ends, can transfer
@@ -546,7 +546,7 @@ contract TransferRestrictionEdgeCases is Setup {
         underlyingAsset.approve(address(usd3Strategy), 100e6);
 
         // This should be blocked - can't deposit to a different address
-        vm.expectRevert("USD3: Only self or whitelisted deposits allowed");
+        vm.expectRevert(bytes("!allowed"));
         usd3Strategy.deposit(100e6, bob);
         vm.stopPrank();
 
@@ -563,7 +563,7 @@ contract TransferRestrictionEdgeCases is Setup {
 
         // Alice cannot transfer during commitment
         vm.startPrank(alice);
-        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        vm.expectRevert(bytes("!transfer"));
         IERC20(address(usd3Strategy)).transfer(bob, 50e6);
         vm.stopPrank();
     }
@@ -584,7 +584,7 @@ contract TransferRestrictionEdgeCases is Setup {
         // Test 2: Users cannot deposit to others
         vm.startPrank(bob);
         underlyingAsset.approve(address(usd3Strategy), 100e6);
-        vm.expectRevert("USD3: Only self or whitelisted deposits allowed");
+        vm.expectRevert(bytes("!allowed"));
         usd3Strategy.deposit(100e6, alice);
         vm.stopPrank();
 
@@ -609,7 +609,7 @@ contract TransferRestrictionEdgeCases is Setup {
 
         // Test 6: Charlie can no longer deposit for others
         vm.startPrank(charlie);
-        vm.expectRevert("USD3: Only self or whitelisted deposits allowed");
+        vm.expectRevert(bytes("!allowed"));
         usd3Strategy.deposit(50e6, alice);
         vm.stopPrank();
 

--- a/test/forge/usd3/upgrade/UpgradeTest.t.sol
+++ b/test/forge/usd3/upgrade/UpgradeTest.t.sol
@@ -253,7 +253,7 @@ contract UpgradeTest is Setup {
         // Test that it cannot be changed once set (use a valid address)
         address anotherSusd3 = makeAddr("anotherSusd3");
         vm.prank(management);
-        vm.expectRevert("sUSD3 already set");
+        vm.expectRevert();
         usd3Strategy.setSUSD3(anotherSusd3);
 
         // Verify link remains unchanged
@@ -278,7 +278,7 @@ contract UpgradeTest is Setup {
         // Test that even with a new address, it cannot be changed
         address yetAnotherSusd3 = address(0x123);
         vm.prank(management);
-        vm.expectRevert("sUSD3 already set");
+        vm.expectRevert();
         usd3Strategy.setSUSD3(yetAnotherSusd3);
 
         // Verify original link still intact


### PR DESCRIPTION
## Summary

Bundles the v1.2 audit-scope changes on this branch.

### Merged PRs

- #110
- #114
- #115
- #102

### Additional commits on this branch

- ci: require USD3 invariants to pass
- test: fix USD3 debt floor merge setup
- refactor(usd3): dedupe protocol-config retrieval via \`_protocolConfig\` helper (bytecode-size reduction; no behavior change)

## Test plan

- [x] \`yarn test:forge:noninvariant\`
- [x] \`yarn test:forge:invariant:core\`
- [x] \`yarn test:forge:invariant:usd3\`
- [x] \`yarn lint\`
- [x] \`yarn build:forge:size\` shows reduced USD3 runtime size

Closes #110
Closes #114
Closes #115
Closes #102