### PR TITLE
feat(usd3): async withdraw queue with FIFO ERC-721 receipts

### DIFF
--- a/script/deploy/upgrade/v3.2.0/UpgradeUSD3WithQueue.s.sol
+++ b/script/deploy/upgrade/v3.2.0/UpgradeUSD3WithQueue.s.sol
@@ -10,8 +10,16 @@ import {USD3WithdrawQueue} from "../../../../src/usd3/queue/USD3WithdrawQueue.so
 
 /// @title UpgradeUSD3WithQueue
 /// @notice Deploys the USD3 withdraw queue and a queue-enabled USD3 implementation.
-/// @dev The proxy upgrade should be batched through the production ProxyAdmin/Safe after reviewing the logs.
+/// @dev The proxy upgrade itself should be batched through the production ProxyAdmin/Safe
+/// after reviewing the logs. After the upgrade lands, management must call
+/// `setEntriesPaused(false)` on the queue to open new entries (queues deploy paused).
 contract UpgradeUSD3WithQueue is Script {
+    /// @notice Deploy the withdraw-queue proxy and the queue-aware USD3 implementation.
+    /// @dev Requires env vars:
+    /// - `USD3_PROXY`: address of the existing USD3 transparent proxy.
+    /// - `QUEUE_PROXY_OWNER`: address that will own the new queue's `ProxyAdmin`.
+    /// @return queue Address of the deployed `USD3WithdrawQueue` proxy.
+    /// @return implementation Address of the new USD3 implementation (with queue immutable set).
     function run() external returns (address queue, address implementation) {
         address usd3Proxy = vm.envAddress("USD3_PROXY");
         address queueProxyOwner = vm.envAddress("QUEUE_PROXY_OWNER");

--- a/script/deploy/upgrade/v3.2.0/UpgradeUSD3WithQueue.s.sol
+++ b/script/deploy/upgrade/v3.2.0/UpgradeUSD3WithQueue.s.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.22;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {
+    TransparentUpgradeableProxy
+} from "../../../../lib/openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {USD3} from "../../../../src/usd3/USD3.sol";
+import {USD3WithdrawQueue} from "../../../../src/usd3/queue/USD3WithdrawQueue.sol";
+
+/// @title UpgradeUSD3WithQueue
+/// @notice Deploys the USD3 withdraw queue and a queue-enabled USD3 implementation.
+/// @dev The proxy upgrade should be batched through the production ProxyAdmin/Safe after reviewing the logs.
+contract UpgradeUSD3WithQueue is Script {
+    function run() external returns (address queue, address implementation) {
+        address usd3Proxy = vm.envAddress("USD3_PROXY");
+        address queueProxyOwner = vm.envAddress("QUEUE_PROXY_OWNER");
+        require(usd3Proxy != address(0), "USD3_PROXY not set");
+        require(queueProxyOwner != address(0), "QUEUE_PROXY_OWNER not set");
+
+        console2.log("=== Deploying USD3 Withdraw Queue Upgrade ===");
+        console2.log("USD3 proxy:", usd3Proxy);
+
+        vm.startBroadcast();
+
+        USD3WithdrawQueue queueImplementation = new USD3WithdrawQueue(usd3Proxy);
+        bytes memory queueInitData = abi.encodeWithSelector(USD3WithdrawQueue.initialize.selector);
+        TransparentUpgradeableProxy withdrawQueueProxy =
+            new TransparentUpgradeableProxy(address(queueImplementation), queueProxyOwner, queueInitData);
+        USD3 usd3Implementation = new USD3(address(withdrawQueueProxy));
+
+        vm.stopBroadcast();
+
+        queue = address(withdrawQueueProxy);
+        implementation = address(usd3Implementation);
+
+        console2.log("USD3WithdrawQueue:", queue);
+        console2.log("USD3WithdrawQueue implementation:", address(queueImplementation));
+        console2.log("USD3 implementation:", implementation);
+        console2.log("");
+        console2.log("Next step: upgrade USD3 proxy to the new implementation through ProxyAdmin.");
+        console2.log("After the upgrade, call setEntriesPaused(false) on the queue.");
+    }
+}

--- a/src/mocks/ProxyImports.sol
+++ b/src/mocks/ProxyImports.sol
@@ -9,4 +9,5 @@ import {ProxyAdmin} from "lib/openzeppelin/contracts/proxy/transparent/ProxyAdmi
 // Dummy contract to force Hardhat to generate types for OpenZeppelin proxy contracts
 contract ProxyImports {
     // Empty contract - exists only to ensure proxy contract ABIs are included in compilation
-}
+
+    }

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -92,7 +92,10 @@ contract USD3 is BaseHooksUpgradeable {
     /// @dev Used to enforce commitment periods
     mapping(address => uint256) public depositTimestamp;
 
-    /// @notice USD3 withdraw queue address. address(0) disables queue reservation.
+    /// @notice Address of the USD3 withdraw queue.
+    /// @dev Set once per implementation via the constructor and baked into bytecode.
+    /// `address(0)` disables queue reservation entirely and is used by test / non-production
+    /// deployments. Changing the queue requires deploying a new USD3 implementation.
     address public immutable withdrawQueue;
 
     /*//////////////////////////////////////////////////////////////
@@ -104,6 +107,13 @@ contract USD3 is BaseHooksUpgradeable {
     event MinDepositUpdated(uint256 newMinDeposit);
     event TrancheShareSynced(uint256 trancheShare);
 
+    /**
+     * @notice Bind this USD3 implementation to a withdraw-queue address and disable initializers.
+     * @dev The queue address is captured as an immutable for gas-cheap reads on the hot
+     * redemption path. Pass `address(0)` to deploy a queue-less implementation (used by tests
+     * and historical deployments).
+     * @param _withdrawQueue Withdraw queue proxy address, or `address(0)` to disable.
+     */
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _withdrawQueue) {
         withdrawQueue = _withdrawQueue;
@@ -384,9 +394,15 @@ contract USD3 is BaseHooksUpgradeable {
                     PUBLIC VIEW FUNCTIONS (OVERRIDES)
     //////////////////////////////////////////////////////////////*/
 
-    /// @dev Returns available withdraw limit, enforcing commitment time
-    /// @param _owner Address to check limit for
-    /// @return Maximum amount that can be withdrawn
+    /// @notice Maximum USDC `_owner` can withdraw right now.
+    /// @dev Returns global executable liquidity (idle USDC + redeemable wrapped + Morpho-redeemable
+    /// wrapped) less the queue reservation, then gates the result on `_owner`'s commitment period.
+    /// The queue reservation is `totalPendingShares` priced at current PPS, rounded up to favor
+    /// the queue, and is applied before the shutdown short-circuit so FIFO fairness survives
+    /// shutdown. The queue contract itself is exempt from this reservation so it can process
+    /// its own pending requests.
+    /// @param _owner Address to check limit for.
+    /// @return Maximum USDC amount that can be withdrawn.
     function availableWithdrawLimit(address _owner) public view override returns (uint256) {
         // Get available liquidity first
         uint256 idleAsset = asset.balanceOf(address(this));

--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -13,6 +13,7 @@ import {Pausable} from "../../lib/openzeppelin/contracts/utils/Pausable.sol";
 import {TokenizedStrategyStorageLib, ERC20} from "@periphery/libraries/TokenizedStrategyStorageLib.sol";
 import {IProtocolConfig} from "../interfaces/IProtocolConfig.sol";
 import {ProtocolConfigLib} from "../libraries/ProtocolConfigLib.sol";
+import {IUSD3WithdrawQueue} from "./interfaces/IUSD3WithdrawQueue.sol";
 
 /**
  * @title USD3
@@ -91,6 +92,9 @@ contract USD3 is BaseHooksUpgradeable {
     /// @dev Used to enforce commitment periods
     mapping(address => uint256) public depositTimestamp;
 
+    /// @notice USD3 withdraw queue address. address(0) disables queue reservation.
+    address public immutable withdrawQueue;
+
     /*//////////////////////////////////////////////////////////////
                             EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -101,7 +105,8 @@ contract USD3 is BaseHooksUpgradeable {
     event TrancheShareSynced(uint256 trancheShare);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
+    constructor(address _withdrawQueue) {
+        withdrawQueue = _withdrawQueue;
         _disableInitializers();
     }
 
@@ -400,6 +405,18 @@ contract USD3 is BaseHooksUpgradeable {
         }
 
         uint256 availableLiquidity = idleAsset + WAUSDC.convertToAssets(availableWaUSDC);
+
+        if (withdrawQueue != address(0) && _owner != withdrawQueue) {
+            uint256 pendingShares = IUSD3WithdrawQueue(withdrawQueue).totalPendingShares();
+            if (pendingShares > 0) {
+                uint256 totalSupply = TokenizedStrategy.totalSupply();
+                uint256 reservedAssets = totalSupply == 0
+                    ? 0
+                    : pendingShares.mulDiv(TokenizedStrategy.totalAssets(), totalSupply, Math.Rounding.Ceil);
+
+                availableLiquidity = availableLiquidity > reservedAssets ? availableLiquidity - reservedAssets : 0;
+            }
+        }
 
         // During shutdown, bypass all checks
         if (TokenizedStrategy.isShutdown()) {

--- a/src/usd3/interfaces/IUSD3WithdrawQueue.sol
+++ b/src/usd3/interfaces/IUSD3WithdrawQueue.sol
@@ -1,34 +1,96 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.22;
 
+/**
+ * @title IUSD3WithdrawQueue
+ * @author 3Jane Protocol
+ * @notice External interface for the USD3 asynchronous FIFO withdraw queue
+ * @dev Receipts are share-denominated ERC-721 NFTs. Queue entry transfers USD3 shares
+ * into queue custody and mints a receipt to the chosen receiver. Processing redeems
+ * those shares for USDC FIFO with zero max-loss tolerance. Receipt holders claim
+ * accumulated USDC at any time; the NFT burns when a receipt is fully fulfilled
+ * and fully claimed.
+ */
 interface IUSD3WithdrawQueue {
+    /// @notice Per-request state stored by the queue.
     struct Request {
+        /// @notice USD3 shares queued at request time. Invariant once set.
         uint256 sharesRequested;
+        /// @notice USD3 shares still awaiting processing.
         uint256 sharesRemaining;
+        /// @notice USDC already allocated to this receipt and not yet claimed.
         uint256 claimableAssets;
+        /// @notice Lifetime USDC claimed by this receipt.
         uint256 claimedAssets;
+        /// @notice Unix timestamp at which the request was created.
         uint256 createdAt;
     }
 
+    /**
+     * @notice Queue USD3 shares for asynchronous redemption to USDC.
+     * @dev Pulls `shares` from `owner` via `transferFrom` (USD3 commitment-period
+     * restrictions on `owner` apply through USD3's transfer hook). Mints the receipt
+     * NFT to `receiver`. Reverts if the queue is paused, if USD3 is shutdown, on any
+     * zero argument, or if `previewRedeem(shares) == 0` (dust).
+     * @param shares USD3 shares to queue for redemption.
+     * @param receiver Address that will own the receipt NFT.
+     * @param owner Holder of the USD3 shares being queued; must have approved the queue.
+     * @return requestId Identifier of the new request, equal to the minted ERC-721 tokenId.
+     */
     function requestRedeem(uint256 shares, address receiver, address owner) external returns (uint256 requestId);
 
+    /**
+     * @notice Process up to `maxPositions` queued requests FIFO from the queue head.
+     * @dev Permissionless. Redeems USD3 shares via the 4-arg `redeem` with `maxLoss = 0`
+     * so temporary illiquidity is never realized as a loss. Returns `(0, 0)` when no
+     * executable liquidity exists or `maxPositions == 0`. Stale (fully-fulfilled) heads
+     * are walked over and count toward `maxPositions` to bound gas.
+     * @param maxPositions Maximum number of FIFO positions touched in this call.
+     * @return sharesProcessed Total USD3 shares redeemed across the touched requests.
+     * @return assetsAllocated Total USDC allocated to receipts across the touched requests.
+     */
     function process(uint256 maxPositions) external returns (uint256 sharesProcessed, uint256 assetsAllocated);
 
+    /**
+     * @notice Claim accumulated USDC for a single receipt.
+     * @dev Callable by the receipt owner or an approved operator. Pays the full
+     * `claimableAssets` to `receiver` and zeros it before transfer. Burns the receipt
+     * when `sharesRemaining == 0` after this claim.
+     * @param requestId Receipt identifier (also the ERC-721 tokenId).
+     * @param receiver Address receiving the USDC payout.
+     * @return assetsClaimed USDC transferred to `receiver`.
+     */
     function claim(uint256 requestId, address receiver) external returns (uint256 assetsClaimed);
 
+    /**
+     * @notice Run `process` then `claim` for a single receipt in one transaction.
+     * @dev Both steps share a single reentrancy guard. The `process` step may advance
+     * the queue beyond `requestId`; the `claim` step only pays what is allocated to
+     * `requestId`.
+     * @param requestId Receipt to claim.
+     * @param receiver Address receiving the USDC payout.
+     * @param maxPositions Bound passed to the inner `process` call.
+     * @return assetsClaimed USDC transferred to `receiver`.
+     */
     function processAndClaim(uint256 requestId, address receiver, uint256 maxPositions)
         external
         returns (uint256 assetsClaimed);
 
+    /// @notice Sum of `sharesRemaining` across all live requests. Used by USD3 to size queue reservation.
     function totalPendingShares() external view returns (uint256 shares);
 
+    /// @notice Unfulfilled USD3 shares for a given receipt.
     function pendingShares(uint256 requestId) external view returns (uint256 shares);
 
+    /// @notice USDC currently claimable for a given receipt.
     function claimableAssets(uint256 requestId) external view returns (uint256 assets);
 
+    /// @notice Full request state for a given receipt.
     function requestInfo(uint256 requestId) external view returns (Request memory request);
 
+    /// @notice Oldest request ID that may still need processing.
     function queueHead() external view returns (uint256 requestId);
 
+    /// @notice Highest minted request ID, or 0 when the queue has never received an entry.
     function queueTail() external view returns (uint256 requestId);
 }

--- a/src/usd3/interfaces/IUSD3WithdrawQueue.sol
+++ b/src/usd3/interfaces/IUSD3WithdrawQueue.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.22;
+
+interface IUSD3WithdrawQueue {
+    struct Request {
+        uint256 sharesRequested;
+        uint256 sharesRemaining;
+        uint256 claimableAssets;
+        uint256 claimedAssets;
+        uint256 createdAt;
+    }
+
+    function requestRedeem(uint256 shares, address receiver, address owner) external returns (uint256 requestId);
+
+    function process(uint256 maxPositions) external returns (uint256 sharesProcessed, uint256 assetsAllocated);
+
+    function claim(uint256 requestId, address receiver) external returns (uint256 assetsClaimed);
+
+    function processAndClaim(uint256 requestId, address receiver, uint256 maxPositions)
+        external
+        returns (uint256 assetsClaimed);
+
+    function totalPendingShares() external view returns (uint256 shares);
+
+    function pendingShares(uint256 requestId) external view returns (uint256 shares);
+
+    function claimableAssets(uint256 requestId) external view returns (uint256 assets);
+
+    function requestInfo(uint256 requestId) external view returns (Request memory request);
+
+    function queueHead() external view returns (uint256 requestId);
+
+    function queueTail() external view returns (uint256 requestId);
+}

--- a/src/usd3/queue/FifoReceiptQueue.sol
+++ b/src/usd3/queue/FifoReceiptQueue.sol
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.22;
+
+import {Initializable} from "../../../lib/openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {IERC721} from "../../../lib/openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC721Receiver} from "../../../lib/openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC721Metadata} from "../../../lib/openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import {IERC165} from "../../../lib/openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+/// @dev Minimal proxy-initialized ERC-721 receipt base. The repo does not include
+/// OpenZeppelin ERC721Upgradeable, and the queues only need the standard receipt
+/// surface plus tightly controlled FIFO cursor storage.
+abstract contract FifoReceiptQueue is Initializable, IERC721Metadata {
+    uint256 private constant NOT_ENTERED = 1;
+    uint256 private constant ENTERED = 2;
+
+    error ZeroAddress();
+    error NonexistentToken(uint256 tokenId);
+    error TokenAlreadyMinted(uint256 tokenId);
+    error IncorrectOwner(address from, uint256 tokenId, address owner);
+    error NotAuthorized(address account, uint256 tokenId);
+    error InvalidReceiver(address receiver);
+    error UnsafeRecipient(address receiver);
+    error ReentrantCall();
+
+    string private _name;
+    string private _symbol;
+
+    mapping(uint256 => address) private _owners;
+    mapping(address => uint256) private _balances;
+    mapping(uint256 => address) private _tokenApprovals;
+    mapping(address => mapping(address => bool)) private _operatorApprovals;
+
+    uint256 internal _queueHead;
+    uint256 internal _nextRequestId;
+    uint256 private _status;
+    uint256[40] private __gap;
+
+    modifier nonReentrant() {
+        if (_status == ENTERED) revert ReentrantCall();
+        _status = ENTERED;
+        _;
+        _status = NOT_ENTERED;
+    }
+
+    function __FifoReceiptQueue_init(string memory name_, string memory symbol_) internal onlyInitializing {
+        _name = name_;
+        _symbol = symbol_;
+        _queueHead = 1;
+        _nextRequestId = 1;
+        _status = NOT_ENTERED;
+    }
+
+    function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC721).interfaceId
+            || interfaceId == type(IERC721Metadata).interfaceId;
+    }
+
+    function name() external view returns (string memory) {
+        return _name;
+    }
+
+    function symbol() external view returns (string memory) {
+        return _symbol;
+    }
+
+    function tokenURI(uint256 tokenId) external view returns (string memory) {
+        _requireOwned(tokenId);
+        return "";
+    }
+
+    function balanceOf(address owner) public view returns (uint256) {
+        if (owner == address(0)) revert ZeroAddress();
+        return _balances[owner];
+    }
+
+    function ownerOf(uint256 tokenId) public view returns (address) {
+        return _requireOwned(tokenId);
+    }
+
+    function approve(address to, uint256 tokenId) external {
+        address owner = _requireOwned(tokenId);
+        if (msg.sender != owner && !isApprovedForAll(owner, msg.sender)) {
+            revert NotAuthorized(msg.sender, tokenId);
+        }
+
+        _approve(to, tokenId, owner);
+    }
+
+    function getApproved(uint256 tokenId) public view returns (address) {
+        _requireOwned(tokenId);
+        return _tokenApprovals[tokenId];
+    }
+
+    function setApprovalForAll(address operator, bool approved) external {
+        if (operator == address(0)) revert ZeroAddress();
+
+        _operatorApprovals[msg.sender][operator] = approved;
+        emit ApprovalForAll(msg.sender, operator, approved);
+    }
+
+    function isApprovedForAll(address owner, address operator) public view returns (bool) {
+        return _operatorApprovals[owner][operator];
+    }
+
+    function transferFrom(address from, address to, uint256 tokenId) public {
+        _transfer(from, to, tokenId, msg.sender);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId) external {
+        safeTransferFrom(from, to, tokenId, "");
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data) public {
+        _transfer(from, to, tokenId, msg.sender);
+        _checkOnERC721Received(msg.sender, from, to, tokenId, data);
+    }
+
+    function queueHead() public view virtual returns (uint256) {
+        return _queueHead;
+    }
+
+    function nextRequestId() public view virtual returns (uint256) {
+        return _nextRequestId;
+    }
+
+    function queueTail() public view virtual returns (uint256) {
+        return _nextRequestId == 1 ? 0 : _nextRequestId - 1;
+    }
+
+    function _mintReceipt(address receiver) internal returns (uint256 requestId) {
+        requestId = _nextRequestId++;
+        _safeMint(receiver, requestId);
+    }
+
+    function _burnReceipt(uint256 requestId) internal {
+        address owner = _requireOwned(requestId);
+
+        _approve(address(0), requestId, owner);
+        unchecked {
+            _balances[owner] -= 1;
+        }
+        delete _owners[requestId];
+
+        emit Transfer(owner, address(0), requestId);
+    }
+
+    function _isAuthorizedForReceipt(uint256 requestId, address account) internal view returns (bool) {
+        address owner = ownerOf(requestId);
+        return account == owner || getApproved(requestId) == account || isApprovedForAll(owner, account);
+    }
+
+    function _requireAuthorizedForReceipt(uint256 requestId) internal view {
+        if (!_isAuthorizedForReceipt(requestId, msg.sender)) revert NotAuthorized(msg.sender, requestId);
+    }
+
+    function _safeMint(address to, uint256 tokenId) private {
+        _mint(to, tokenId);
+        _checkOnERC721Received(msg.sender, address(0), to, tokenId, "");
+    }
+
+    function _mint(address to, uint256 tokenId) private {
+        if (to == address(0)) revert InvalidReceiver(address(0));
+        if (_owners[tokenId] != address(0)) revert TokenAlreadyMinted(tokenId);
+
+        unchecked {
+            _balances[to] += 1;
+        }
+        _owners[tokenId] = to;
+
+        emit Transfer(address(0), to, tokenId);
+    }
+
+    function _transfer(address from, address to, uint256 tokenId, address auth) private {
+        if (to == address(0)) revert InvalidReceiver(address(0));
+
+        address owner = _requireOwned(tokenId);
+        if (owner != from) revert IncorrectOwner(from, tokenId, owner);
+        if (auth != owner && getApproved(tokenId) != auth && !isApprovedForAll(owner, auth)) {
+            revert NotAuthorized(auth, tokenId);
+        }
+
+        _approve(address(0), tokenId, owner);
+
+        unchecked {
+            _balances[from] -= 1;
+            _balances[to] += 1;
+        }
+        _owners[tokenId] = to;
+
+        emit Transfer(from, to, tokenId);
+    }
+
+    function _approve(address to, uint256 tokenId, address owner) private {
+        _tokenApprovals[tokenId] = to;
+        emit Approval(owner, to, tokenId);
+    }
+
+    function _requireOwned(uint256 tokenId) private view returns (address owner) {
+        owner = _owners[tokenId];
+        if (owner == address(0)) revert NonexistentToken(tokenId);
+    }
+
+    function _checkOnERC721Received(address operator, address from, address to, uint256 tokenId, bytes memory data)
+        private
+    {
+        if (to.code.length == 0) return;
+
+        try IERC721Receiver(to).onERC721Received(operator, from, tokenId, data) returns (bytes4 retval) {
+            if (retval != IERC721Receiver.onERC721Received.selector) revert UnsafeRecipient(to);
+        } catch {
+            revert UnsafeRecipient(to);
+        }
+    }
+}

--- a/src/usd3/queue/FifoReceiptQueue.sol
+++ b/src/usd3/queue/FifoReceiptQueue.sol
@@ -7,35 +7,64 @@ import {IERC721Receiver} from "../../../lib/openzeppelin/contracts/token/ERC721/
 import {IERC721Metadata} from "../../../lib/openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import {IERC165} from "../../../lib/openzeppelin/contracts/utils/introspection/IERC165.sol";
 
-/// @dev Minimal proxy-initialized ERC-721 receipt base. The repo does not include
-/// OpenZeppelin ERC721Upgradeable, and the queues only need the standard receipt
-/// surface plus tightly controlled FIFO cursor storage.
+/**
+ * @title FifoReceiptQueue
+ * @author 3Jane Protocol
+ * @notice Abstract FIFO ERC-721 receipt base shared by 3Jane's asynchronous withdraw queues.
+ * @dev Hand-rolled ERC-721 (subset of OZ v5 semantics; no Enumerable) plus monotonic
+ * request IDs that double as both FIFO position and ERC-721 tokenId. The repo does not
+ * include `ERC721Upgradeable`, and the queues need tight control over storage layout
+ * for upgrade safety, so the minimal surface is implemented here directly.
+ *
+ * Inheriting contracts are expected to:
+ * - Take custody of the request-asset share token on entry and mint a receipt via
+ *   {_mintReceipt}.
+ * - Implement queue processing: redeeming custodied shares into a claim asset and
+ *   updating per-request state.
+ * - Implement claim payout, calling {_burnReceipt} when a request is fully settled.
+ * - Gate claim/cancel-style operations through {_requireAuthorizedForReceipt}.
+ */
 abstract contract FifoReceiptQueue is Initializable, IERC721Metadata {
     uint256 private constant NOT_ENTERED = 1;
     uint256 private constant ENTERED = 2;
 
+    /// @notice Thrown when a zero address is supplied where one is not allowed.
     error ZeroAddress();
+    /// @notice Thrown when a query or transfer references a tokenId that has never been minted or has been burned.
     error NonexistentToken(uint256 tokenId);
+    /// @notice Thrown if {_mint} is called for a tokenId that is already owned. Should not occur with monotonic IDs.
     error TokenAlreadyMinted(uint256 tokenId);
+    /// @notice Thrown when {transferFrom}/{safeTransferFrom} `from` does not match the current owner.
     error IncorrectOwner(address from, uint256 tokenId, address owner);
+    /// @notice Thrown when the caller lacks owner/approved/operator authority over the receipt.
     error NotAuthorized(address account, uint256 tokenId);
+    /// @notice Thrown when a transfer or mint targets the zero address.
     error InvalidReceiver(address receiver);
+    /// @notice Thrown when a contract receiver does not implement `onERC721Received` correctly.
     error UnsafeRecipient(address receiver);
+    /// @notice Thrown by {nonReentrant} when an entrypoint is invoked recursively.
     error ReentrantCall();
 
     string private _name;
     string private _symbol;
 
+    /// @dev Standard ERC-721 storage. Owner-of-token, balance-of-owner, per-token approval,
+    /// and operator approvals indexed by (owner, operator).
     mapping(uint256 => address) private _owners;
     mapping(address => uint256) private _balances;
     mapping(uint256 => address) private _tokenApprovals;
     mapping(address => mapping(address => bool)) private _operatorApprovals;
 
+    /// @notice Oldest request ID that may still need processing. Advances monotonically.
     uint256 internal _queueHead;
+    /// @notice Next request ID to mint. Starts at 1; tokenId 0 is never issued.
     uint256 internal _nextRequestId;
+    /// @dev Reentrancy guard state. NOT_ENTERED (1) or ENTERED (2); 0 indicates uninitialized.
     uint256 private _status;
+    /// @dev Storage gap reserved for future fields added to this base.
     uint256[40] private __gap;
 
+    /// @notice Single-entrancy guard reused by inheriting queues across request/process/claim entrypoints.
     modifier nonReentrant() {
         if (_status == ENTERED) revert ReentrantCall();
         _status = ENTERED;
@@ -43,6 +72,13 @@ abstract contract FifoReceiptQueue is Initializable, IERC721Metadata {
         _status = NOT_ENTERED;
     }
 
+    /**
+     * @notice Initialize the receipt metadata and FIFO cursors.
+     * @dev Head and tail both start at 1 so tokenId 0 is never minted; that lets `queueTail()`
+     * use 0 as the "no entries yet" sentinel.
+     * @param name_ ERC-721 collection name.
+     * @param symbol_ ERC-721 collection symbol.
+     */
     function __FifoReceiptQueue_init(string memory name_, string memory symbol_) internal onlyInitializing {
         _name = name_;
         _symbol = symbol_;
@@ -51,33 +87,43 @@ abstract contract FifoReceiptQueue is Initializable, IERC721Metadata {
         _status = NOT_ENTERED;
     }
 
+    /// @inheritdoc IERC165
+    /// @dev `pure` is permitted as a stricter override of the interface's `view`.
     function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
         return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC721).interfaceId
             || interfaceId == type(IERC721Metadata).interfaceId;
     }
 
+    /// @inheritdoc IERC721Metadata
     function name() external view returns (string memory) {
         return _name;
     }
 
+    /// @inheritdoc IERC721Metadata
     function symbol() external view returns (string memory) {
         return _symbol;
     }
 
+    /// @inheritdoc IERC721Metadata
+    /// @dev v1 returns the empty string for any owned token. Off-chain UIs should derive
+    /// receipt state from {requestInfo} on the concrete queue.
     function tokenURI(uint256 tokenId) external view returns (string memory) {
         _requireOwned(tokenId);
         return "";
     }
 
+    /// @inheritdoc IERC721
     function balanceOf(address owner) public view returns (uint256) {
         if (owner == address(0)) revert ZeroAddress();
         return _balances[owner];
     }
 
+    /// @inheritdoc IERC721
     function ownerOf(uint256 tokenId) public view returns (address) {
         return _requireOwned(tokenId);
     }
 
+    /// @inheritdoc IERC721
     function approve(address to, uint256 tokenId) external {
         address owner = _requireOwned(tokenId);
         if (msg.sender != owner && !isApprovedForAll(owner, msg.sender)) {
@@ -87,11 +133,13 @@ abstract contract FifoReceiptQueue is Initializable, IERC721Metadata {
         _approve(to, tokenId, owner);
     }
 
+    /// @inheritdoc IERC721
     function getApproved(uint256 tokenId) public view returns (address) {
         _requireOwned(tokenId);
         return _tokenApprovals[tokenId];
     }
 
+    /// @inheritdoc IERC721
     function setApprovalForAll(address operator, bool approved) external {
         if (operator == address(0)) revert ZeroAddress();
 
@@ -99,40 +147,58 @@ abstract contract FifoReceiptQueue is Initializable, IERC721Metadata {
         emit ApprovalForAll(msg.sender, operator, approved);
     }
 
+    /// @inheritdoc IERC721
     function isApprovedForAll(address owner, address operator) public view returns (bool) {
         return _operatorApprovals[owner][operator];
     }
 
+    /// @inheritdoc IERC721
     function transferFrom(address from, address to, uint256 tokenId) public {
         _transfer(from, to, tokenId, msg.sender);
     }
 
+    /// @inheritdoc IERC721
     function safeTransferFrom(address from, address to, uint256 tokenId) external {
         safeTransferFrom(from, to, tokenId, "");
     }
 
+    /// @inheritdoc IERC721
     function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data) public {
         _transfer(from, to, tokenId, msg.sender);
         _checkOnERC721Received(msg.sender, from, to, tokenId, data);
     }
 
+    /// @notice Oldest request ID that may still need processing.
     function queueHead() public view virtual returns (uint256) {
         return _queueHead;
     }
 
+    /// @notice Next request ID to mint.
     function nextRequestId() public view virtual returns (uint256) {
         return _nextRequestId;
     }
 
+    /// @notice Highest minted request ID, or 0 when the queue has never received an entry.
     function queueTail() public view virtual returns (uint256) {
         return _nextRequestId == 1 ? 0 : _nextRequestId - 1;
     }
 
+    /**
+     * @notice Mint the next FIFO receipt to `receiver` and return its ID.
+     * @dev Uses safe-mint so contract receivers must implement {IERC721Receiver}.
+     * @param receiver Address that will own the new receipt NFT.
+     * @return requestId The minted tokenId and the request's FIFO position.
+     */
     function _mintReceipt(address receiver) internal returns (uint256 requestId) {
         requestId = _nextRequestId++;
         _safeMint(receiver, requestId);
     }
 
+    /**
+     * @notice Burn a receipt NFT once its underlying request is fully settled.
+     * @dev Concrete queues should clear request storage before or after calling this.
+     * @param requestId Receipt to burn. Must currently be owned.
+     */
     function _burnReceipt(uint256 requestId) internal {
         address owner = _requireOwned(requestId);
 
@@ -145,20 +211,32 @@ abstract contract FifoReceiptQueue is Initializable, IERC721Metadata {
         emit Transfer(owner, address(0), requestId);
     }
 
+    /**
+     * @notice True if `account` is the owner of, an approved address for, or an operator over `requestId`.
+     * @param requestId Receipt being queried.
+     * @param account Account to test.
+     * @return True if `account` has receipt-level authority.
+     */
     function _isAuthorizedForReceipt(uint256 requestId, address account) internal view returns (bool) {
         address owner = ownerOf(requestId);
         return account == owner || getApproved(requestId) == account || isApprovedForAll(owner, account);
     }
 
+    /**
+     * @notice Revert with {NotAuthorized} if `msg.sender` lacks authority over `requestId`.
+     * @param requestId Receipt being acted on.
+     */
     function _requireAuthorizedForReceipt(uint256 requestId) internal view {
         if (!_isAuthorizedForReceipt(requestId, msg.sender)) revert NotAuthorized(msg.sender, requestId);
     }
 
+    /// @dev Mint and then call {_checkOnERC721Received} on contract receivers.
     function _safeMint(address to, uint256 tokenId) private {
         _mint(to, tokenId);
         _checkOnERC721Received(msg.sender, address(0), to, tokenId, "");
     }
 
+    /// @dev Low-level mint. Reverts on zero receiver or already-minted tokenId.
     function _mint(address to, uint256 tokenId) private {
         if (to == address(0)) revert InvalidReceiver(address(0));
         if (_owners[tokenId] != address(0)) revert TokenAlreadyMinted(tokenId);
@@ -171,6 +249,8 @@ abstract contract FifoReceiptQueue is Initializable, IERC721Metadata {
         emit Transfer(address(0), to, tokenId);
     }
 
+    /// @dev Low-level transfer. Clears any prior per-token approval. `auth` is the caller
+    /// whose authority is being verified.
     function _transfer(address from, address to, uint256 tokenId, address auth) private {
         if (to == address(0)) revert InvalidReceiver(address(0));
 
@@ -191,16 +271,20 @@ abstract contract FifoReceiptQueue is Initializable, IERC721Metadata {
         emit Transfer(from, to, tokenId);
     }
 
+    /// @dev Set per-token approval and emit {Approval}.
     function _approve(address to, uint256 tokenId, address owner) private {
         _tokenApprovals[tokenId] = to;
         emit Approval(owner, to, tokenId);
     }
 
+    /// @dev Read `_owners[tokenId]` and revert with {NonexistentToken} on zero.
     function _requireOwned(uint256 tokenId) private view returns (address owner) {
         owner = _owners[tokenId];
         if (owner == address(0)) revert NonexistentToken(tokenId);
     }
 
+    /// @dev If `to` is a contract, call `onERC721Received` and revert unless it returns the
+    /// expected selector. EOAs are accepted without a callback.
     function _checkOnERC721Received(address operator, address from, address to, uint256 tokenId, bytes memory data)
         private
     {

--- a/src/usd3/queue/USD3WithdrawQueue.sol
+++ b/src/usd3/queue/USD3WithdrawQueue.sol
@@ -7,33 +7,102 @@ import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrat
 import {IUSD3WithdrawQueue} from "../interfaces/IUSD3WithdrawQueue.sol";
 import {FifoReceiptQueue} from "./FifoReceiptQueue.sol";
 
+/**
+ * @title USD3WithdrawQueue
+ * @author 3Jane Protocol
+ * @notice Asynchronous FIFO withdraw queue for USD3 -> USDC redemptions used when USD3
+ * USDC liquidity is constrained.
+ * @dev Sidecar contract. USD3 reserves liquidity for pending claims via its immutable
+ * `withdrawQueue` pointer so ordinary redemptions never consume USDC owed to earlier
+ * queued requests. Receipts are share-denominated ERC-721 NFTs that float with USD3 PPS
+ * until fulfilled.
+ *
+ * Mechanism:
+ * - {requestRedeem} pulls USD3 shares into queue custody and mints a receipt NFT to the
+ *   chosen receiver. Commitment-period restrictions on the share owner are inherited
+ *   from USD3's transfer hook.
+ * - {process} is permissionless and walks the FIFO from the head, redeeming custodied
+ *   USD3 shares to USDC with `maxLoss = 0` so temporary illiquidity is never realized
+ *   as a loss. Stale (already-fulfilled) heads count toward `maxPositions`.
+ * - {claim} pays accumulated USDC to the receipt owner (or approved operator) and burns
+ *   the NFT once the request is fully fulfilled.
+ * - {processAndClaim} performs both in a single transaction under one reentrancy guard.
+ */
 contract USD3WithdrawQueue is FifoReceiptQueue, IUSD3WithdrawQueue {
     using SafeERC20 for IERC20;
 
+    /// @notice Thrown when constructed with `_usd3 == address(0)`.
     error InvalidUSD3();
+    /// @notice Thrown by {requestRedeem} when {entriesPaused} is true.
     error QueuePaused();
+    /// @notice Thrown by {requestRedeem} when USD3 reports `isShutdown() == true`.
     error Shutdown();
+    /// @notice Thrown by {requestRedeem} on a zero-share request.
     error ZeroShares();
+    /// @notice Thrown by {requestRedeem} when `previewRedeem(shares) == 0` (dust request that would otherwise revert in
+    /// USD3).
     error ZeroAssets();
+    /// @notice Thrown by {requestRedeem} / {claim} on a zero `receiver`.
     error ZeroReceiver();
+    /// @notice Thrown by {requestRedeem} on a zero `owner`.
     error ZeroOwner();
+    /// @notice Thrown by {setEntriesPaused} when caller is neither USD3 `management` nor `emergencyAdmin`.
     error Unauthorized(address account);
+    /// @notice Thrown by {claim} when the receipt has nothing currently claimable.
     error NothingClaimable(uint256 requestId);
 
+    /// @notice USD3 strategy this queue serves. Immutable across the implementation's lifetime.
     ITokenizedStrategy public immutable usd3;
+    /// @notice USDC token paid out on claim. Read once from `usd3.asset()` at deploy and invariant
+    /// for this implementation; a future USD3 asset change requires a new queue implementation.
     IERC20 public immutable usdc;
 
+    /// @notice Sum of `sharesRemaining` across all live requests. Used by USD3 to size queue reservation.
     uint256 public totalPendingShares;
+    /// @dev Per-request state keyed by `requestId == tokenId`.
     mapping(uint256 => Request) internal _requests;
+    /// @notice When true, {requestRedeem} reverts but {process}, {claim}, and {processAndClaim}
+    /// remain available. Defaults to `true` so a freshly-deployed queue is paused until
+    /// management explicitly opens entries.
     bool public entriesPaused = true;
+    /// @dev Storage gap reserved for future fields added to this contract.
     uint256[40] private __gap;
 
+    /// @notice Emitted when a user queues a redemption.
+    /// @param requestId New request / receipt ID.
+    /// @param owner Holder of the queued USD3 shares.
+    /// @param receiver Address granted the receipt NFT.
+    /// @param shares USD3 shares transferred into queue custody.
     event RequestRedeem(uint256 indexed requestId, address indexed owner, address indexed receiver, uint256 shares);
+
+    /// @notice Emitted once per request touched by {process} that actually moved shares.
+    /// @param requestId Request that was processed.
+    /// @param sharesProcessed USD3 shares redeemed for this request in this call.
+    /// @param assetsAllocated USDC allocated to this request in this call.
     event Processed(uint256 indexed requestId, uint256 sharesProcessed, uint256 assetsAllocated);
+
+    /// @notice Emitted at the end of every {process} invocation, summarizing the batch.
+    /// @param sharesProcessed Total USD3 shares redeemed in this call.
+    /// @param assetsAllocated Total USDC allocated to receipts in this call.
+    /// @param positionsProcessed FIFO positions touched (including stale-head skips).
     event ProcessBatch(uint256 sharesProcessed, uint256 assetsAllocated, uint256 positionsProcessed);
+
+    /// @notice Emitted when a claim is paid out.
+    /// @param requestId Receipt that was claimed.
+    /// @param receiver Address that received the USDC payout.
+    /// @param assets USDC transferred.
     event Claim(uint256 indexed requestId, address indexed receiver, uint256 assets);
+
+    /// @notice Emitted on every {setEntriesPaused} toggle.
     event EntriesPaused(bool paused);
 
+    /**
+     * @notice Deploy a queue bound to a specific USD3 strategy.
+     * @dev Reads `usdc = usd3.asset()` at deploy and freezes it for this implementation.
+     * Disables the proxy implementation initializer so this contract cannot be misused
+     * directly without a proxy.
+     * @param _usd3 USD3 proxy address. Reverts on zero.
+     */
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _usd3) {
         if (_usd3 == address(0)) revert InvalidUSD3();
@@ -43,11 +112,27 @@ contract USD3WithdrawQueue is FifoReceiptQueue, IUSD3WithdrawQueue {
         _disableInitializers();
     }
 
+    /**
+     * @notice Proxy initializer. Sets ERC-721 metadata and FIFO cursors.
+     * @dev Leaves `entriesPaused = true` so the queue is closed at deploy; management
+     * must call {setEntriesPaused} to open it.
+     */
     function initialize() external initializer {
         __FifoReceiptQueue_init("USD3 Withdraw Queue", "USD3-WQ");
         entriesPaused = true;
     }
 
+    /**
+     * @notice Queue USD3 shares for asynchronous redemption to USDC.
+     * @dev Pulls `shares` from `owner` via `transferFrom`, so USD3 commitment-period
+     * restrictions on `owner` apply through USD3's transfer hook. Mints the receipt NFT
+     * to `receiver`. Reverts on queue pause, USD3 shutdown, any zero argument, or when
+     * the request would redeem to zero USDC at current PPS.
+     * @param shares USD3 shares to queue.
+     * @param receiver Address that will own the receipt NFT.
+     * @param owner Holder of the shares; must have approved the queue to spend `shares`.
+     * @return requestId New request / receipt ID.
+     */
     function requestRedeem(uint256 shares, address receiver, address owner)
         external
         nonReentrant
@@ -75,6 +160,15 @@ contract USD3WithdrawQueue is FifoReceiptQueue, IUSD3WithdrawQueue {
         emit RequestRedeem(requestId, owner, receiver, shares);
     }
 
+    /**
+     * @notice Process up to `maxPositions` queued requests FIFO from the head.
+     * @dev Permissionless. Returns `(0, 0)` without reverting when there is no executable
+     * liquidity, when `maxPositions == 0`, or when the head's residual would otherwise
+     * trigger USD3's `ZERO_ASSETS` guard.
+     * @param maxPositions Maximum FIFO positions touched in this call (including stale-head skips).
+     * @return sharesProcessed Total USD3 shares redeemed across the batch.
+     * @return assetsAllocated Total USDC allocated to receipts across the batch.
+     */
     function process(uint256 maxPositions)
         external
         nonReentrant
@@ -83,10 +177,27 @@ contract USD3WithdrawQueue is FifoReceiptQueue, IUSD3WithdrawQueue {
         (sharesProcessed, assetsAllocated,) = _process(maxPositions);
     }
 
+    /**
+     * @notice Claim accumulated USDC for a single receipt.
+     * @dev Callable by the receipt owner or an approved operator. Zeros `claimableAssets`
+     * before transferring. Burns the receipt when `sharesRemaining == 0` after the claim.
+     * @param requestId Receipt to claim.
+     * @param receiver Address receiving the USDC payout.
+     * @return assetsClaimed USDC transferred to `receiver`.
+     */
     function claim(uint256 requestId, address receiver) external nonReentrant returns (uint256 assetsClaimed) {
         assetsClaimed = _claim(requestId, receiver);
     }
 
+    /**
+     * @notice Run {process} and then {claim} for `requestId` under a single reentrancy guard.
+     * @dev Lets a claimant advance the queue toward (or past) their position and collect
+     * accumulated USDC in one transaction.
+     * @param requestId Receipt to claim.
+     * @param receiver Address receiving the USDC payout.
+     * @param maxPositions Bound passed to the inner {process} call.
+     * @return assetsClaimed USDC transferred to `receiver`.
+     */
     function processAndClaim(uint256 requestId, address receiver, uint256 maxPositions)
         external
         nonReentrant
@@ -96,6 +207,12 @@ contract USD3WithdrawQueue is FifoReceiptQueue, IUSD3WithdrawQueue {
         assetsClaimed = _claim(requestId, receiver);
     }
 
+    /**
+     * @notice Pause or unpause new queue entries.
+     * @dev Callable by USD3 `management` or `emergencyAdmin`. Does not affect {process} or
+     * {claim}, so in-flight requests can always be drained.
+     * @param paused New paused state.
+     */
     function setEntriesPaused(bool paused) external {
         if (msg.sender != usd3.management() && msg.sender != usd3.emergencyAdmin()) revert Unauthorized(msg.sender);
 
@@ -103,26 +220,37 @@ contract USD3WithdrawQueue is FifoReceiptQueue, IUSD3WithdrawQueue {
         emit EntriesPaused(paused);
     }
 
+    /// @inheritdoc IUSD3WithdrawQueue
     function queueHead() public view override(FifoReceiptQueue, IUSD3WithdrawQueue) returns (uint256) {
         return super.queueHead();
     }
 
+    /// @inheritdoc IUSD3WithdrawQueue
     function queueTail() public view override(FifoReceiptQueue, IUSD3WithdrawQueue) returns (uint256) {
         return super.queueTail();
     }
 
+    /// @inheritdoc IUSD3WithdrawQueue
     function pendingShares(uint256 requestId) external view returns (uint256 shares) {
         return _requests[requestId].sharesRemaining;
     }
 
+    /// @inheritdoc IUSD3WithdrawQueue
     function claimableAssets(uint256 requestId) external view returns (uint256 assets) {
         return _requests[requestId].claimableAssets;
     }
 
+    /// @inheritdoc IUSD3WithdrawQueue
     function requestInfo(uint256 requestId) external view returns (Request memory request) {
         return _requests[requestId];
     }
 
+    /// @dev FIFO processing loop. Each iteration consumes one `maxPositions` slot whether it
+    /// skipped a stale (already-fulfilled) head or actually redeemed; this bounds gas against
+    /// long runs of out-of-order-claimed receipts. Before redeeming, both the prospective
+    /// `sharesToProcess` and any partial residual are checked via `previewRedeem` to avoid
+    /// USD3's `ZERO_ASSETS` revert on dust amounts. A non-empty partial fulfillment ends the
+    /// loop (it would block the next head anyway).
     function _process(uint256 maxPositions)
         internal
         returns (uint256 sharesProcessed, uint256 assetsAllocated, uint256 positionsProcessed)
@@ -178,6 +306,8 @@ contract USD3WithdrawQueue is FifoReceiptQueue, IUSD3WithdrawQueue {
         emit ProcessBatch(sharesProcessed, assetsAllocated, positionsProcessed);
     }
 
+    /// @dev Auth-check, zero-before-transfer, then burn-on-settlement. Reverts when there
+    /// is nothing claimable so callers do not pay gas for no-ops.
     function _claim(uint256 requestId, address receiver) internal returns (uint256 assetsClaimed) {
         if (receiver == address(0)) revert ZeroReceiver();
         _requireAuthorizedForReceipt(requestId);

--- a/src/usd3/queue/USD3WithdrawQueue.sol
+++ b/src/usd3/queue/USD3WithdrawQueue.sol
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.22;
+
+import {IERC20, SafeERC20} from "../../../lib/openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Math} from "../../../lib/openzeppelin/contracts/utils/math/Math.sol";
+import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
+import {IUSD3WithdrawQueue} from "../interfaces/IUSD3WithdrawQueue.sol";
+import {FifoReceiptQueue} from "./FifoReceiptQueue.sol";
+
+contract USD3WithdrawQueue is FifoReceiptQueue, IUSD3WithdrawQueue {
+    using SafeERC20 for IERC20;
+
+    error InvalidUSD3();
+    error QueuePaused();
+    error Shutdown();
+    error ZeroShares();
+    error ZeroAssets();
+    error ZeroReceiver();
+    error ZeroOwner();
+    error Unauthorized(address account);
+    error NothingClaimable(uint256 requestId);
+
+    ITokenizedStrategy public immutable usd3;
+    IERC20 public immutable usdc;
+
+    uint256 public totalPendingShares;
+    mapping(uint256 => Request) internal _requests;
+    bool public entriesPaused = true;
+    uint256[40] private __gap;
+
+    event RequestRedeem(uint256 indexed requestId, address indexed owner, address indexed receiver, uint256 shares);
+    event Processed(uint256 indexed requestId, uint256 sharesProcessed, uint256 assetsAllocated);
+    event ProcessBatch(uint256 sharesProcessed, uint256 assetsAllocated, uint256 positionsProcessed);
+    event Claim(uint256 indexed requestId, address indexed receiver, uint256 assets);
+    event EntriesPaused(bool paused);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address _usd3) {
+        if (_usd3 == address(0)) revert InvalidUSD3();
+
+        usd3 = ITokenizedStrategy(_usd3);
+        usdc = IERC20(ITokenizedStrategy(_usd3).asset());
+        _disableInitializers();
+    }
+
+    function initialize() external initializer {
+        __FifoReceiptQueue_init("USD3 Withdraw Queue", "USD3-WQ");
+        entriesPaused = true;
+    }
+
+    function requestRedeem(uint256 shares, address receiver, address owner)
+        external
+        nonReentrant
+        returns (uint256 requestId)
+    {
+        if (entriesPaused) revert QueuePaused();
+        if (usd3.isShutdown()) revert Shutdown();
+        if (shares == 0) revert ZeroShares();
+        if (usd3.previewRedeem(shares) == 0) revert ZeroAssets();
+        if (receiver == address(0)) revert ZeroReceiver();
+        if (owner == address(0)) revert ZeroOwner();
+
+        IERC20(address(usd3)).safeTransferFrom(owner, address(this), shares);
+
+        requestId = _mintReceipt(receiver);
+        _requests[requestId] = Request({
+            sharesRequested: shares,
+            sharesRemaining: shares,
+            claimableAssets: 0,
+            claimedAssets: 0,
+            createdAt: block.timestamp
+        });
+        totalPendingShares += shares;
+
+        emit RequestRedeem(requestId, owner, receiver, shares);
+    }
+
+    function process(uint256 maxPositions)
+        external
+        nonReentrant
+        returns (uint256 sharesProcessed, uint256 assetsAllocated)
+    {
+        (sharesProcessed, assetsAllocated,) = _process(maxPositions);
+    }
+
+    function claim(uint256 requestId, address receiver) external nonReentrant returns (uint256 assetsClaimed) {
+        assetsClaimed = _claim(requestId, receiver);
+    }
+
+    function processAndClaim(uint256 requestId, address receiver, uint256 maxPositions)
+        external
+        nonReentrant
+        returns (uint256 assetsClaimed)
+    {
+        _process(maxPositions);
+        assetsClaimed = _claim(requestId, receiver);
+    }
+
+    function setEntriesPaused(bool paused) external {
+        if (msg.sender != usd3.management() && msg.sender != usd3.emergencyAdmin()) revert Unauthorized(msg.sender);
+
+        entriesPaused = paused;
+        emit EntriesPaused(paused);
+    }
+
+    function queueHead() public view override(FifoReceiptQueue, IUSD3WithdrawQueue) returns (uint256) {
+        return super.queueHead();
+    }
+
+    function queueTail() public view override(FifoReceiptQueue, IUSD3WithdrawQueue) returns (uint256) {
+        return super.queueTail();
+    }
+
+    function pendingShares(uint256 requestId) external view returns (uint256 shares) {
+        return _requests[requestId].sharesRemaining;
+    }
+
+    function claimableAssets(uint256 requestId) external view returns (uint256 assets) {
+        return _requests[requestId].claimableAssets;
+    }
+
+    function requestInfo(uint256 requestId) external view returns (Request memory request) {
+        return _requests[requestId];
+    }
+
+    function _process(uint256 maxPositions)
+        internal
+        returns (uint256 sharesProcessed, uint256 assetsAllocated, uint256 positionsProcessed)
+    {
+        if (maxPositions == 0) {
+            return (0, 0, 0);
+        }
+
+        uint256 sharesAvailable = usd3.maxRedeem(address(this));
+        if (sharesAvailable == 0) {
+            return (0, 0, 0);
+        }
+
+        uint256 current = _queueHead;
+        while (current < _nextRequestId && positionsProcessed < maxPositions && sharesAvailable > 0) {
+            Request storage request = _requests[current];
+
+            if (request.sharesRemaining == 0) {
+                current++;
+                _queueHead = current;
+                positionsProcessed++;
+                continue;
+            }
+
+            uint256 sharesToProcess = Math.min(request.sharesRemaining, sharesAvailable);
+            if (sharesToProcess < request.sharesRemaining) {
+                uint256 remainingAfterProcess = request.sharesRemaining - sharesToProcess;
+                if (usd3.previewRedeem(remainingAfterProcess) == 0) break;
+            }
+            if (usd3.previewRedeem(sharesToProcess) == 0) break;
+
+            uint256 assetsOut = usd3.redeem(sharesToProcess, address(this), address(this), 0);
+
+            request.sharesRemaining -= sharesToProcess;
+            request.claimableAssets += assetsOut;
+            totalPendingShares -= sharesToProcess;
+
+            sharesProcessed += sharesToProcess;
+            assetsAllocated += assetsOut;
+            sharesAvailable -= sharesToProcess;
+            positionsProcessed++;
+
+            emit Processed(current, sharesToProcess, assetsOut);
+
+            if (request.sharesRemaining == 0) {
+                current++;
+                _queueHead = current;
+            } else {
+                break;
+            }
+        }
+
+        emit ProcessBatch(sharesProcessed, assetsAllocated, positionsProcessed);
+    }
+
+    function _claim(uint256 requestId, address receiver) internal returns (uint256 assetsClaimed) {
+        if (receiver == address(0)) revert ZeroReceiver();
+        _requireAuthorizedForReceipt(requestId);
+
+        Request storage request = _requests[requestId];
+        assetsClaimed = request.claimableAssets;
+        if (assetsClaimed == 0) revert NothingClaimable(requestId);
+
+        request.claimableAssets = 0;
+        request.claimedAssets += assetsClaimed;
+
+        usdc.safeTransfer(receiver, assetsClaimed);
+
+        if (request.sharesRemaining == 0) {
+            delete _requests[requestId];
+            _burnReceipt(requestId);
+        }
+
+        emit Claim(requestId, receiver, assetsClaimed);
+    }
+}

--- a/test/forge/usd3/Operation.t.sol
+++ b/test/forge/usd3/Operation.t.sol
@@ -490,7 +490,7 @@ contract OperationTest is Setup {
 
     function test_marketId_initialization_invalidMarket() public {
         // Create a new USD3 implementation
-        USD3 newUsd3Implementation = new USD3();
+        USD3 newUsd3Implementation = new USD3(address(0));
 
         // Create an invalid market ID (market doesn't exist in Morpho)
         Id invalidId = Id.wrap(keccak256("INVALID_MARKET"));

--- a/test/forge/usd3/USD3WithdrawQueue.t.sol
+++ b/test/forge/usd3/USD3WithdrawQueue.t.sol
@@ -1,0 +1,537 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.22;
+
+import {ProxyAdmin} from "../../../lib/openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {
+    ITransparentUpgradeableProxy,
+    TransparentUpgradeableProxy
+} from "../../../lib/openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ERC20} from "../../../lib/openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC721Receiver} from "../../../lib/openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
+import {USD3} from "../../../src/usd3/USD3.sol";
+import {USD3WithdrawQueue} from "../../../src/usd3/queue/USD3WithdrawQueue.sol";
+import {Setup} from "./utils/Setup.sol";
+
+contract USD3WithdrawQueueTest is Setup {
+    USD3WithdrawQueue public queue;
+
+    address public alice = makeAddr("alice");
+    address public bob = makeAddr("bob");
+    address public charlie = makeAddr("charlie");
+
+    bytes32 internal constant ERC1967_ADMIN_SLOT = bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1);
+
+    function setUp() public override {
+        super.setUp();
+
+        USD3WithdrawQueue queueImplementation = new USD3WithdrawQueue(address(strategy));
+        bytes memory queueInitData = abi.encodeWithSelector(USD3WithdrawQueue.initialize.selector);
+        TransparentUpgradeableProxy queueProxy =
+            new TransparentUpgradeableProxy(address(queueImplementation), management, queueInitData);
+        queue = USD3WithdrawQueue(address(queueProxy));
+
+        USD3 newImplementation = new USD3(address(queue));
+
+        address proxyAdmin = address(uint160(uint256(vm.load(address(strategy), ERC1967_ADMIN_SLOT))));
+        address proxyAdminOwner = ProxyAdmin(proxyAdmin).owner();
+
+        vm.prank(proxyAdminOwner);
+        ProxyAdmin(proxyAdmin)
+            .upgradeAndCall(ITransparentUpgradeableProxy(address(strategy)), address(newImplementation), "");
+
+        assertEq(USD3(address(strategy)).withdrawQueue(), address(queue));
+
+        vm.prank(management);
+        queue.setEntriesPaused(false);
+    }
+
+    function test_requestRedeemTransfersSharesAndMintsReceipt() public {
+        uint256 amount = 1_000e6;
+        _depositUnlocked(alice, amount);
+        uint256 shares = strategy.balanceOf(alice);
+
+        vm.prank(alice);
+        strategy.approve(address(queue), shares);
+
+        vm.prank(alice);
+        uint256 requestId = queue.requestRedeem(shares, alice, alice);
+
+        assertEq(requestId, 1);
+        assertEq(queue.ownerOf(requestId), alice);
+        assertEq(strategy.balanceOf(alice), 0);
+        assertEq(strategy.balanceOf(address(queue)), shares);
+        assertEq(queue.totalPendingShares(), shares);
+        assertEq(queue.pendingShares(requestId), shares);
+    }
+
+    function test_requestRedeemRespectsCommitmentGate() public {
+        testProtocolConfig.setConfig(keccak256("USD3_COMMITMENT_TIME"), 7 days);
+
+        uint256 amount = 1_000e6;
+        mintAndDepositIntoStrategy(strategy, alice, amount);
+        uint256 shares = strategy.balanceOf(alice);
+
+        vm.prank(alice);
+        strategy.approve(address(queue), shares);
+
+        vm.prank(alice);
+        vm.expectRevert("USD3: Cannot transfer during commitment period");
+        queue.requestRedeem(shares, alice, alice);
+    }
+
+    function test_requestRedeemRejectsInvalidInputs() public {
+        _depositUnlocked(alice, 1_000e6);
+        uint256 shares = strategy.balanceOf(alice);
+
+        vm.prank(alice);
+        strategy.approve(address(queue), shares);
+
+        vm.prank(alice);
+        vm.expectRevert(USD3WithdrawQueue.ZeroShares.selector);
+        queue.requestRedeem(0, alice, alice);
+
+        vm.prank(alice);
+        vm.expectRevert(USD3WithdrawQueue.ZeroReceiver.selector);
+        queue.requestRedeem(shares, address(0), alice);
+
+        vm.prank(alice);
+        vm.expectRevert(USD3WithdrawQueue.ZeroOwner.selector);
+        queue.requestRedeem(shares, alice, address(0));
+    }
+
+    function test_requestRedeemRejectsZeroAssetShares() public {
+        ZeroPreviewUSD3 fakeUsd3 = new ZeroPreviewUSD3(address(asset), management, emergencyAdmin);
+        USD3WithdrawQueue queueImplementation = new USD3WithdrawQueue(address(fakeUsd3));
+        bytes memory queueInitData = abi.encodeWithSelector(USD3WithdrawQueue.initialize.selector);
+        TransparentUpgradeableProxy queueProxy =
+            new TransparentUpgradeableProxy(address(queueImplementation), management, queueInitData);
+        USD3WithdrawQueue dustQueue = USD3WithdrawQueue(address(queueProxy));
+
+        vm.prank(management);
+        dustQueue.setEntriesPaused(false);
+
+        fakeUsd3.mint(alice, 1);
+
+        vm.prank(alice);
+        fakeUsd3.approve(address(dustQueue), 1);
+
+        vm.prank(alice);
+        vm.expectRevert(USD3WithdrawQueue.ZeroAssets.selector);
+        dustQueue.requestRedeem(1, alice, alice);
+    }
+
+    function test_thirdPartyCanRequestWithOwnerApproval() public {
+        _depositUnlocked(alice, 1_000e6);
+        uint256 shares = strategy.balanceOf(alice);
+
+        vm.prank(alice);
+        strategy.approve(address(queue), shares);
+
+        vm.prank(bob);
+        uint256 requestId = queue.requestRedeem(shares, bob, alice);
+
+        assertEq(queue.ownerOf(requestId), bob);
+        assertEq(strategy.balanceOf(alice), 0);
+        assertEq(strategy.balanceOf(address(queue)), shares);
+    }
+
+    function test_receiptTransferDoesNotRequireWhitelist() public {
+        uint256 requestId = _queueShares(alice, 1_000e6);
+
+        vm.prank(management);
+        USD3(address(strategy)).setWhitelistEnabled(true);
+
+        assertFalse(USD3(address(strategy)).whitelist(bob));
+
+        vm.prank(alice);
+        queue.transferFrom(alice, bob, requestId);
+
+        assertEq(queue.ownerOf(requestId), bob);
+    }
+
+    function test_safeTransferToReceiverContract() public {
+        uint256 requestId = _queueShares(alice, 1_000e6);
+        ReceiptReceiver receiver = new ReceiptReceiver();
+
+        vm.prank(alice);
+        queue.safeTransferFrom(alice, address(receiver), requestId);
+
+        assertEq(queue.ownerOf(requestId), address(receiver));
+    }
+
+    function test_safeTransferToUnsafeReceiverReverts() public {
+        uint256 requestId = _queueShares(alice, 1_000e6);
+        UnsafeReceiptReceiver receiver = new UnsafeReceiptReceiver();
+
+        vm.prank(alice);
+        vm.expectRevert();
+        queue.safeTransferFrom(alice, address(receiver), requestId);
+    }
+
+    function test_processAllocatesFifo() public {
+        uint256 requestOne = _queueShares(alice, 700e6);
+        uint256 requestTwo = _queueShares(bob, 300e6);
+
+        (uint256 sharesProcessed, uint256 assetsAllocated) = queue.process(2);
+
+        assertEq(
+            sharesProcessed,
+            queue.requestInfo(requestOne).sharesRequested + queue.requestInfo(requestTwo).sharesRequested
+        );
+        assertEq(assetsAllocated, 1_000e6);
+        assertEq(queue.claimableAssets(requestOne), 700e6);
+        assertEq(queue.claimableAssets(requestTwo), 300e6);
+        assertEq(queue.queueHead(), 3);
+        assertEq(queue.totalPendingShares(), 0);
+    }
+
+    function test_partiallyFulfilledHeadBlocksLaterRequests() public {
+        _queueShares(alice, 700e6);
+        uint256 requestTwo = _queueShares(bob, 300e6);
+
+        _removeIdleUsdc(500e6);
+
+        queue.process(2);
+
+        assertEq(queue.queueHead(), 1);
+        assertEq(queue.pendingShares(1), 200e6);
+        assertEq(queue.claimableAssets(1), 500e6);
+        assertEq(queue.claimableAssets(requestTwo), 0);
+        assertEq(queue.pendingShares(requestTwo), 300e6);
+    }
+
+    function test_fullyFundedUnclaimedHeadDoesNotBlock() public {
+        uint256 requestOne = _queueShares(alice, 400e6);
+        uint256 requestTwo = _queueShares(bob, 600e6);
+
+        queue.process(1);
+        assertEq(queue.queueHead(), 2);
+        assertEq(queue.claimableAssets(requestOne), 400e6);
+
+        queue.process(1);
+        assertEq(queue.queueHead(), 3);
+        assertEq(queue.claimableAssets(requestTwo), 600e6);
+    }
+
+    function test_processBoundsStaleHeadWalk() public {
+        USD3WithdrawQueueHarness harness = new USD3WithdrawQueueHarness(address(strategy));
+        _depositUnlocked(address(harness), 1_000e6);
+        harness.seedCursor(1, 4);
+        harness.seedRequest(3, 1_000e6, 1_000e6);
+
+        (uint256 sharesProcessed, uint256 assetsAllocated) = harness.process(1);
+        assertEq(sharesProcessed, 0);
+        assertEq(assetsAllocated, 0);
+        assertEq(harness.queueHead(), 2);
+
+        (sharesProcessed, assetsAllocated) = harness.process(1);
+        assertEq(sharesProcessed, 0);
+        assertEq(assetsAllocated, 0);
+        assertEq(harness.queueHead(), 3);
+
+        (sharesProcessed, assetsAllocated) = harness.process(1);
+        assertEq(sharesProcessed, 1_000e6);
+        assertEq(assetsAllocated, 1_000e6);
+        assertEq(harness.queueHead(), 4);
+    }
+
+    function test_claimPaysAndBurnsFullyFulfilledReceipt() public {
+        uint256 requestId = _queueShares(alice, 1_000e6);
+        queue.process(1);
+
+        uint256 balanceBefore = asset.balanceOf(bob);
+
+        vm.prank(alice);
+        uint256 claimed = queue.claim(requestId, bob);
+
+        assertEq(claimed, 1_000e6);
+        assertEq(asset.balanceOf(bob) - balanceBefore, 1_000e6);
+        assertEq(queue.claimableAssets(requestId), 0);
+        vm.expectRevert();
+        queue.ownerOf(requestId);
+    }
+
+    function test_approvedOperatorCanClaim() public {
+        uint256 requestId = _queueShares(alice, 1_000e6);
+        queue.process(1);
+
+        vm.prank(alice);
+        queue.approve(bob, requestId);
+
+        vm.prank(bob);
+        uint256 claimed = queue.claim(requestId, bob);
+
+        assertEq(claimed, 1_000e6);
+        assertEq(asset.balanceOf(bob), 1_000e6);
+    }
+
+    function test_claimRejectsZeroReceiver() public {
+        uint256 requestId = _queueShares(alice, 1_000e6);
+        queue.process(1);
+
+        vm.prank(alice);
+        vm.expectRevert(USD3WithdrawQueue.ZeroReceiver.selector);
+        queue.claim(requestId, address(0));
+    }
+
+    function test_partialClaimLeavesReceiptAlive() public {
+        uint256 requestId = _queueShares(alice, 1_000e6);
+        _removeIdleUsdc(500e6);
+        queue.process(1);
+
+        vm.prank(alice);
+        queue.claim(requestId, alice);
+
+        assertEq(queue.ownerOf(requestId), alice);
+        assertEq(queue.pendingShares(requestId), 500e6);
+        assertEq(queue.claimableAssets(requestId), 0);
+    }
+
+    function test_reclaimBurnedReceiptReverts() public {
+        uint256 requestId = _queueShares(alice, 1_000e6);
+        queue.process(1);
+
+        vm.prank(alice);
+        queue.claim(requestId, alice);
+
+        vm.prank(alice);
+        vm.expectRevert();
+        queue.claim(requestId, alice);
+    }
+
+    function test_processAndClaimProcessesThenClaims() public {
+        uint256 requestId = _queueShares(alice, 1_000e6);
+
+        vm.prank(alice);
+        uint256 claimed = queue.processAndClaim(requestId, alice, 1);
+
+        assertEq(claimed, 1_000e6);
+        assertEq(asset.balanceOf(alice), 1_000e6);
+        assertEq(queue.totalPendingShares(), 0);
+    }
+
+    function test_processWithNoLiquidityReturnsZero() public {
+        _queueShares(alice, 1_000e6);
+        _removeIdleUsdc(1_000e6);
+
+        (uint256 sharesProcessed, uint256 assetsAllocated) = queue.process(1);
+
+        assertEq(sharesProcessed, 0);
+        assertEq(assetsAllocated, 0);
+    }
+
+    function test_directRedeemNeverEnqueues() public {
+        _depositUnlocked(alice, 1_000e6);
+        uint256 shares = strategy.balanceOf(alice);
+
+        vm.prank(alice);
+        strategy.redeem(shares, alice, alice);
+
+        assertEq(queue.nextRequestId(), 1);
+        assertEq(queue.totalPendingShares(), 0);
+    }
+
+    function test_reservationReducesOrdinaryLimitsWithoutBinaryCliff() public {
+        _queueShares(alice, 700e6);
+        _depositUnlocked(bob, 300e6);
+
+        assertEq(strategy.maxWithdraw(bob), 300e6);
+        assertEq(strategy.maxRedeem(bob), 300e6);
+        assertEq(strategy.maxRedeem(address(queue)), 700e6);
+    }
+
+    function test_reservationCanExhaustOrdinaryLiquidity() public {
+        _queueShares(alice, 700e6);
+        _depositUnlocked(bob, 300e6);
+        _removeIdleUsdc(300e6);
+
+        assertEq(strategy.maxWithdraw(bob), 0);
+        assertEq(strategy.maxRedeem(bob), 0);
+        assertEq(strategy.maxRedeem(address(queue)), 700e6);
+    }
+
+    function test_shutdownKeepsQueueReservationButAllowsQueueEntryDisabled() public {
+        _queueShares(alice, 700e6);
+        _depositUnlocked(bob, 300e6);
+        _removeIdleUsdc(300e6);
+
+        vm.prank(emergencyAdmin);
+        strategy.shutdownStrategy();
+
+        assertEq(strategy.maxWithdraw(bob), 0);
+        assertEq(strategy.maxRedeem(address(queue)), 700e6);
+
+        vm.prank(bob);
+        strategy.approve(address(queue), 300e6);
+
+        vm.prank(bob);
+        vm.expectRevert(USD3WithdrawQueue.Shutdown.selector);
+        queue.requestRedeem(300e6, bob, bob);
+
+        queue.process(1);
+        assertEq(queue.claimableAssets(1), 700e6);
+
+        vm.prank(alice);
+        assertEq(queue.claim(1, alice), 700e6);
+    }
+
+    function test_entriesPausedOnlyBlocksRequests() public {
+        uint256 requestId = _queueShares(alice, 1_000e6);
+
+        vm.prank(management);
+        queue.setEntriesPaused(true);
+
+        _depositUnlocked(bob, 100e6);
+        vm.prank(bob);
+        strategy.approve(address(queue), 100e6);
+
+        vm.prank(bob);
+        vm.expectRevert(USD3WithdrawQueue.QueuePaused.selector);
+        queue.requestRedeem(100e6, bob, bob);
+
+        queue.process(1);
+
+        vm.prank(alice);
+        assertEq(queue.claim(requestId, alice), 1_000e6);
+    }
+
+    function test_setEntriesPausedRejectsUnauthorizedCaller() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(USD3WithdrawQueue.Unauthorized.selector, alice));
+        queue.setEntriesPaused(true);
+    }
+
+    function test_reservationRoundsTowardQueue() public {
+        _depositUnlocked(alice, 1e6);
+        _depositUnlocked(bob, 10e6);
+        airdrop(asset, address(strategy), 1);
+        vm.prank(keeper);
+        strategy.report();
+        vm.warp(block.timestamp + strategy.profitMaxUnlockTime() + 1);
+
+        vm.prank(alice);
+        strategy.approve(address(queue), 1);
+
+        vm.prank(alice);
+        queue.requestRedeem(1, alice, alice);
+
+        uint256 totalAssets = strategy.totalAssets();
+        uint256 totalSupply = strategy.totalSupply();
+        uint256 reservedAssets = (1 * totalAssets + totalSupply - 1) / totalSupply;
+        uint256 availableWithoutReservation = USD3(address(strategy)).availableWithdrawLimit(address(queue));
+
+        assertEq(reservedAssets, 2);
+        assertEq(USD3(address(strategy)).availableWithdrawLimit(bob), availableWithoutReservation - reservedAssets);
+    }
+
+    function test_receiptValueFloatsWithPpsBeforeFulfillment() public {
+        uint256 requestId = _queueShares(alice, 1_000e6);
+
+        waUSDC.simulateYield(1000);
+        airdrop(asset, address(waUSDC), 100e6);
+        vm.prank(keeper);
+        strategy.report();
+        vm.warp(block.timestamp + strategy.profitMaxUnlockTime() + 1);
+
+        queue.process(1);
+
+        assertGt(queue.claimableAssets(requestId), 1_000e6);
+    }
+
+    function _queueShares(address owner, uint256 assets) internal returns (uint256 requestId) {
+        _depositUnlocked(owner, assets);
+        uint256 shares = strategy.balanceOf(owner);
+
+        vm.prank(owner);
+        strategy.approve(address(queue), shares);
+
+        vm.prank(owner);
+        requestId = queue.requestRedeem(shares, owner, owner);
+    }
+
+    function _depositUnlocked(address owner, uint256 assets) internal {
+        mintAndDepositIntoStrategy(strategy, owner, assets);
+        vm.warp(block.timestamp + USD3(address(strategy)).minCommitmentTime() + 1);
+    }
+
+    function _removeIdleUsdc(uint256 amount) internal {
+        createMarketDebt(charlie, amount);
+    }
+}
+
+contract USD3WithdrawQueueHarness is USD3WithdrawQueue {
+    constructor(address usd3_) USD3WithdrawQueue(usd3_) {}
+
+    function seedCursor(uint256 head, uint256 nextRequest) external {
+        _queueHead = head;
+        _nextRequestId = nextRequest;
+    }
+
+    function seedRequest(uint256 requestId, uint256 sharesRequested, uint256 sharesRemaining) external {
+        _requests[requestId] = Request({
+            sharesRequested: sharesRequested,
+            sharesRemaining: sharesRemaining,
+            claimableAssets: 0,
+            claimedAssets: 0,
+            createdAt: block.timestamp
+        });
+        totalPendingShares += sharesRemaining;
+    }
+}
+
+contract ReceiptReceiver is IERC721Receiver {
+    function onERC721Received(address, address, uint256, bytes calldata) external pure returns (bytes4) {
+        return IERC721Receiver.onERC721Received.selector;
+    }
+}
+
+contract UnsafeReceiptReceiver {}
+
+contract ZeroPreviewUSD3 is ERC20 {
+    address private immutable _asset;
+    address private immutable _management;
+    address private immutable _emergencyAdmin;
+
+    constructor(address asset_, address management_, address emergencyAdmin_) ERC20("Zero Preview USD3", "zUSD3") {
+        _asset = asset_;
+        _management = management_;
+        _emergencyAdmin = emergencyAdmin_;
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function asset() external view returns (address) {
+        return _asset;
+    }
+
+    function isShutdown() external pure returns (bool) {
+        return false;
+    }
+
+    function previewRedeem(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function maxRedeem(address owner) external view returns (uint256) {
+        return balanceOf(owner);
+    }
+
+    function redeem(uint256, address, address, uint256) external pure returns (uint256) {
+        revert("unused");
+    }
+
+    function management() external view returns (address) {
+        return _management;
+    }
+
+    function emergencyAdmin() external view returns (address) {
+        return _emergencyAdmin;
+    }
+}

--- a/test/forge/usd3/fork/USD3UpgradeForkTest.t.sol
+++ b/test/forge/usd3/fork/USD3UpgradeForkTest.t.sol
@@ -41,7 +41,7 @@ contract USD3UpgradeForkTest is MainnetForkBase {
         if (!isForkTest) return;
 
         // Deploy new USD3 implementation
-        newImplementation = new USD3();
+        newImplementation = new USD3(address(0));
 
         // Find actual USD3 holders from mainnet
         findUSD3Holders();

--- a/test/forge/usd3/fuzz/USD3UpgradeFuzzTest.t.sol
+++ b/test/forge/usd3/fuzz/USD3UpgradeFuzzTest.t.sol
@@ -96,7 +96,7 @@ contract USD3UpgradeFuzzTest is Setup {
         strategyInterface.report();
 
         // Step 4: Deploy new implementation
-        newImplementation = new USD3();
+        newImplementation = new USD3(address(0));
 
         // Step 5: Upgrade proxy to new implementation
         usd3ProxyAdmin.upgradeAndCall(

--- a/test/forge/usd3/integration/USD3RestartStrategy.t.sol
+++ b/test/forge/usd3/integration/USD3RestartStrategy.t.sol
@@ -84,7 +84,7 @@ contract USD3RestartStrategyTest is Setup {
     }
 
     function _deployRestartableUSD3() internal returns (USD3 usd3, ProxyAdmin proxyAdmin) {
-        USD3 implementation = new USD3();
+        USD3 implementation = new USD3(address(0));
         USD3 setupStrategy = USD3(address(strategy));
 
         bytes memory initData = abi.encodeWithSelector(
@@ -112,7 +112,7 @@ contract USD3RestartStrategyTest is Setup {
     }
 
     function _upgradeAndRestart(USD3 usd3, ProxyAdmin proxyAdmin) internal {
-        USD3 newImplementation = new USD3();
+        USD3 newImplementation = new USD3(address(0));
         proxyAdmin.upgradeAndCall(
             ITransparentUpgradeableProxy(address(usd3)),
             address(newImplementation),

--- a/test/forge/usd3/integration/USD3UpgradeIntegrationTest.t.sol
+++ b/test/forge/usd3/integration/USD3UpgradeIntegrationTest.t.sol
@@ -165,7 +165,7 @@ contract USD3UpgradeIntegrationTest is Setup {
 
     function _performUpgrade() internal {
         // Deploy new implementation
-        newImplementation = new USD3();
+        newImplementation = new USD3(address(0));
 
         // Upgrade proxy to new implementation
         // Pass empty bytes since we'll call reinitialize separately

--- a/test/forge/usd3/unit/ReinitializeTest.t.sol
+++ b/test/forge/usd3/unit/ReinitializeTest.t.sol
@@ -37,7 +37,7 @@ contract ReinitializeTest is Setup {
 
     function test_reinitializeUpdatesAsset() public {
         // Deploy a fresh USD3 without reinitialize being called
-        USD3 freshImpl = new USD3();
+        USD3 freshImpl = new USD3(address(0));
         ProxyAdmin freshProxyAdmin = new ProxyAdmin(address(this));
 
         // Initialize with waUSDC as asset (simulating old version)
@@ -67,7 +67,7 @@ contract ReinitializeTest is Setup {
 
     function test_reinitializeApprovesWaUSDC() public {
         // Deploy fresh instance
-        USD3 freshImpl = new USD3();
+        USD3 freshImpl = new USD3(address(0));
         ProxyAdmin freshProxyAdmin = new ProxyAdmin(address(this));
 
         bytes memory initData = abi.encodeWithSelector(
@@ -93,7 +93,7 @@ contract ReinitializeTest is Setup {
 
     function test_reinitializeOnlyOnce() public {
         // Deploy fresh instance
-        USD3 freshImpl = new USD3();
+        USD3 freshImpl = new USD3(address(0));
         ProxyAdmin freshProxyAdmin = new ProxyAdmin(address(this));
 
         bytes memory initData = abi.encodeWithSelector(
@@ -150,7 +150,7 @@ contract ReinitializeTest is Setup {
 
     function test_reinitializeUpdatesTokenizedStrategySlot() public {
         // Deploy fresh instance
-        USD3 freshImpl = new USD3();
+        USD3 freshImpl = new USD3(address(0));
         ProxyAdmin freshProxyAdmin = new ProxyAdmin(address(this));
 
         bytes memory initData = abi.encodeWithSelector(
@@ -187,7 +187,7 @@ contract ReinitializeTest is Setup {
 
     function test_reinitializeWithExistingWaUSDCPosition() public {
         // Deploy fresh instance
-        USD3 freshImpl = new USD3();
+        USD3 freshImpl = new USD3(address(0));
         ProxyAdmin freshProxyAdmin = new ProxyAdmin(address(this));
 
         bytes memory initData = abi.encodeWithSelector(

--- a/test/forge/usd3/utils/Setup.sol
+++ b/test/forge/usd3/utils/Setup.sol
@@ -158,7 +158,7 @@ contract Setup is Test, IEvents {
         vm.stopPrank();
 
         // Deploy USD3 implementation
-        USD3 usd3Implementation = new USD3();
+        USD3 usd3Implementation = new USD3(address(0));
 
         // Deploy proxy admin
         ProxyAdmin usd3ProxyAdmin = new ProxyAdmin(proxyAdminOwner);


### PR DESCRIPTION
## Summary
- Adds `USD3WithdrawQueue` sidecar: ERC-721 receipts, FIFO processing, native API (no ERC-7540 mimicry).
- Wires queue-aware liquidity reservation into `USD3.availableWithdrawLimit` via an immutable `withdrawQueue` set in the new USD3 implementation constructor. Reservation rounds up to favor the queue and persists during shutdown.
- Introduces thin `FifoReceiptQueue` ERC-721 base for the future sUSD3 queue to reuse.
- Adds upgrade script under `script/deploy/upgrade/v3.2.0/`.

## Test plan
- [x] `yarn test:forge:noninvariant --match-path 'test/forge/usd3/USD3WithdrawQueue.t.sol'` — 27 tests pass
- [x] FIFO ordering, partial head, fully-funded-unclaimed non-blocking, stale-head walk bounded by `maxPositions`
- [x] Reservation reduces ordinary `maxRedeem`/`maxWithdraw`, exempts queue caller, rounds toward queue
- [x] Shutdown preserves queue reservation; queue can still process and claim during shutdown
- [x] ERC-721 paths: approved-operator claim, `safeTransferFrom` happy path + unsafe-receiver revert
- [x] Negative paths: zero shares/receiver/owner, claim zero receiver, unauthorized `setEntriesPaused`, ZERO_ASSETS guards
- [ ] Full forge suite green in CI
- [ ] Manual fork dry-run of `UpgradeUSD3WithQueue.s.sol`

Spec: https://www.notion.so/3616d08e68c081819cc1c83262a68224