### PR TITLE
feat: add RevolvingCreditFacilityHolding borrower reserve

### DIFF
--- a/src/RevolvingCreditFacilityHolding.sol
+++ b/src/RevolvingCreditFacilityHolding.sol
@@ -20,8 +20,9 @@ import {SharesMathLib} from "./libraries/SharesMathLib.sol";
 /// @dev The reserve borrows USDC through Helper from a single Morpho market, deposits the USDC into the configured
 /// ERC4626 vault, and releases funds only through admin action or a proposer-scheduled fallback repayment. The
 /// proposer is the only fallback initiator and may schedule only after 180 days without admin activity; the admin may
-/// veto during a 7-day window, and execution after that window is permissionless. `emergencyRepay` bypasses Helper for
-/// repayment if the bound Helper is unavailable or unsafe.
+/// veto during a 7-day window, and execution after that window is permissionless. After a veto, the proposer may
+/// reschedule while the 180-day idle gate remains open; the admin can keep vetoing or rotate the proposer.
+/// `emergencyRepay` bypasses Helper for repayment if the bound Helper is unavailable or unsafe.
 contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
     using MarketParamsLib for MarketParams;
@@ -220,8 +221,8 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
         emit IdleInvested(amount, vaultShares);
     }
 
-    /// @notice Immediately releases vault liquidity to repay a fixed amount of this reserve's protocol debt.
-    /// @param amount USDC amount to repay; must not exceed the current outstanding debt.
+    /// @notice Immediately releases vault liquidity to repay this reserve's protocol debt.
+    /// @param amount USDC amount to repay, or `type(uint256).max` to repay the full outstanding debt.
     /// @return assetsRepaid USDC assets consumed by the repayment.
     /// @return sharesRepaid Borrow shares retired in the credit market.
     function releaseToProtocol(uint256 amount)
@@ -231,19 +232,6 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
         returns (uint256 assetsRepaid, uint256 sharesRepaid)
     {
         return _releaseToProtocol(amount);
-    }
-
-    /// @notice Immediately releases enough vault liquidity to repay the full outstanding protocol debt.
-    /// @dev Routes through Helper's share-based full-repay path to avoid leaving any dust shares.
-    /// @return assetsRepaid USDC assets consumed by the repayment.
-    /// @return sharesRepaid Borrow shares retired in the credit market.
-    function releaseAllToProtocol()
-        external
-        onlyAdminTouch
-        nonReentrant
-        returns (uint256 assetsRepaid, uint256 sharesRepaid)
-    {
-        return _releaseToProtocol(type(uint256).max);
     }
 
     /// @notice Repays protocol debt directly through Morpho, bypassing the bound Helper.

--- a/src/RevolvingCreditFacilityHolding.sol
+++ b/src/RevolvingCreditFacilityHolding.sol
@@ -18,10 +18,10 @@ import {SharesMathLib} from "./libraries/SharesMathLib.sol";
 /// @custom:contact support@3jane.xyz
 /// @notice Non-upgradeable borrower reserve that parks committed capital in an external ERC4626 yield vault.
 /// @dev The reserve borrows USDC through Helper from a single Morpho market, deposits the USDC into the configured
-/// ERC4626 vault, and releases funds only through three paths: (1) immediate admin action, (2) a proposer-scheduled
-/// repayment that the admin may veto during a 7-day window, or (3) a permissionless fallback repayment unlocked
-/// after 180 days without admin activity. The admin heartbeat is refreshed by any owner-gated call, including
-/// `adminPing`.
+/// ERC4626 vault, and releases funds only through admin action or a proposer-scheduled fallback repayment. The
+/// proposer is the only fallback initiator and may schedule only after 180 days without admin activity; the admin may
+/// veto during a 7-day window, and execution after that window is permissionless. `emergencyRepay` bypasses Helper for
+/// repayment if the bound Helper is unavailable or unsafe.
 contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
     using MarketParamsLib for MarketParams;
@@ -34,10 +34,10 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
         uint256 eta;
     }
 
-    /// @notice Veto window between scheduling and executing a proposer-initiated repayment.
+    /// @notice Veto window between scheduling and executing a proposer-initiated fallback repayment.
     uint256 public constant PROPOSER_DELAY = 7 days;
 
-    /// @notice Idle window after which any address may permissionlessly repay protocol debt.
+    /// @notice Idle window after which the proposer may schedule a fallback protocol repayment.
     uint256 public constant FALLBACK_DELAY = 180 days;
 
     /// @notice Helper contract used to borrow from and repay the Morpho credit market.
@@ -49,6 +49,9 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
     /// @notice USDC token used for borrowing, vault deposits, and off-ramp transfers.
     IERC20 public immutable usdc;
 
+    /// @notice ERC4626 loan token wrapper used by the bound Morpho credit market.
+    IERC4626 public immutable loanTokenVault;
+
     /// @notice ERC4626 yield vault that holds drawn USDC between draws and repayments.
     IERC4626 public immutable vault;
 
@@ -57,16 +60,16 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
 
     MarketParams internal _marketParams;
 
-    /// @notice Address authorized to schedule (but not directly execute) protocol repayments.
+    /// @notice Address authorized to schedule fallback protocol repayments after the idle window.
     address public proposer;
 
     /// @notice Fixed recipient of off-ramp releases; only the admin can change this address.
     address public offRampRecipient;
 
-    /// @notice Timestamp of the last admin-gated call; used as the heartbeat for the 180-day fallback.
+    /// @notice Timestamp of the last admin-gated call; used as the heartbeat for proposer fallback scheduling.
     uint256 public lastAdminTouch;
 
-    /// @notice Currently pending proposer-scheduled repayment, if any.
+    /// @notice Currently pending proposer-scheduled fallback repayment, if any.
     ScheduledRepayment public scheduledRepayment;
 
     /// @notice Emitted when the admin draws from the credit line and deposits the proceeds into the vault.
@@ -81,17 +84,14 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
     /// @notice Emitted when vault liquidity is released to the fixed off-ramp recipient.
     event OffRampRelease(address indexed recipient, uint256 assets, uint256 vaultShares);
 
-    /// @notice Emitted when the proposer schedules (or overwrites) a pending repayment.
+    /// @notice Emitted when the proposer schedules (or overwrites) a pending fallback repayment.
     event ProtocolRepaymentScheduled(uint256 amount, uint256 eta);
 
-    /// @notice Emitted when the admin vetoes the pending scheduled repayment.
+    /// @notice Emitted when the admin vetoes the pending scheduled fallback repayment.
     event ProtocolRepaymentVetoed();
 
-    /// @notice Emitted when a scheduled repayment is executed after its veto window elapses.
+    /// @notice Emitted when a scheduled fallback repayment is executed after its veto window elapses.
     event ScheduledProtocolRepaymentExecuted(uint256 amount, address indexed executor);
-
-    /// @notice Emitted when the permissionless fallback path repays protocol debt.
-    event FallbackProtocolRepayment(uint256 amount, address indexed executor);
 
     /// @notice Emitted when the proposer address is rotated by the admin.
     event ProposerUpdated(address indexed oldProposer, address indexed newProposer);
@@ -105,7 +105,7 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
     /// @notice Emitted when unrelated ERC20s are recovered via `rescueToken`.
     event RescueToken(address indexed token, address indexed recipient, uint256 amount);
 
-    /// @notice Thrown when `fallbackRepay` is invoked before the 180-day idle window has elapsed.
+    /// @notice Thrown when the proposer schedules before the 180-day idle window has elapsed.
     error FallbackNotReady();
 
     /// @notice Thrown when veto/execute is called and no repayment is currently scheduled.
@@ -117,10 +117,13 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
     /// @notice Thrown when a partial repayment amount exceeds the current outstanding debt.
     error RepayAmountExceedsDebt();
 
-    /// @notice Thrown when `rescueToken` is called with USDC or the vault token.
+    /// @notice Thrown when `rescueToken` is called with USDC, the market loan token, or the vault token.
     error ProtectedToken();
 
-    /// @notice Runs the owner check and refreshes the admin heartbeat for the 180-day fallback timer.
+    /// @notice Thrown when attempting to renounce ownership.
+    error RenounceOwnershipDisabled();
+
+    /// @notice Runs the owner check and refreshes the admin heartbeat for the 180-day fallback schedule timer.
     modifier onlyAdminTouch() {
         _checkOwner();
         lastAdminTouch = block.timestamp;
@@ -129,7 +132,7 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
 
     /// @notice Deploys a borrower reserve bound to a single Morpho market and a single ERC4626 vault.
     /// @param admin Initial owner; gates all admin actions and is required to keep the heartbeat alive.
-    /// @param initialProposer Address allowed to schedule (but not execute) protocol repayments.
+    /// @param initialProposer Address allowed to schedule fallback protocol repayments after the idle window.
     /// @param initialOffRampRecipient Fixed recipient of off-ramp releases.
     /// @param helper_ Helper contract used for borrow and repay routing.
     /// @param vault_ ERC4626 vault whose asset must equal Helper's configured USDC token.
@@ -150,11 +153,14 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
         }
 
         helper = IHelper(helper_);
-        morpho = IMorpho(IHelper(helper_).MORPHO());
+        address morpho_ = IHelper(helper_).MORPHO();
+        morpho = IMorpho(morpho_);
+        loanTokenVault = IERC4626(marketParams_.loanToken);
         vault = IERC4626(vault_);
         usdc = IERC20(IERC4626(vault_).asset());
 
         if (address(usdc) != IHelper(helper_).USDC()) revert ErrorsLib.InconsistentInput();
+        if (loanTokenVault.asset() != address(usdc)) revert ErrorsLib.InconsistentInput();
 
         _marketParams = marketParams_;
         marketId = marketParams_.id();
@@ -163,7 +169,9 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
         lastAdminTouch = block.timestamp;
 
         usdc.forceApprove(helper_, type(uint256).max);
+        usdc.forceApprove(marketParams_.loanToken, type(uint256).max);
         usdc.forceApprove(vault_, type(uint256).max);
+        IERC20(marketParams_.loanToken).forceApprove(morpho_, type(uint256).max);
     }
 
     /// @notice Returns the full market parameters bound at construction time.
@@ -172,9 +180,20 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
         return _marketParams;
     }
 
-    /// @notice Refreshes the admin heartbeat used by the 180-day permissionless repayment fallback.
+    /// @notice Refreshes the admin heartbeat used by the 180-day proposer fallback schedule gate.
     function adminPing() external onlyAdminTouch {
         emit AdminPing(block.timestamp);
+    }
+
+    /// @notice Transfers ownership and refreshes the admin heartbeat.
+    /// @param newOwner New admin address.
+    function transferOwnership(address newOwner) public override onlyAdminTouch {
+        super.transferOwnership(newOwner);
+    }
+
+    /// @notice Ownership renouncement is disabled so an admin remains available for veto and recovery actions.
+    function renounceOwnership() public override onlyAdminTouch {
+        revert RenounceOwnershipDisabled();
     }
 
     /// @notice Draws committed capital through Helper and deposits the received USDC into the vault.
@@ -185,6 +204,7 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
 
         (usdcReceived,) = helper.borrow(_marketParams, amount);
         uint256 vaultShares = vault.deposit(usdcReceived, address(this));
+        if (vaultShares == 0) revert ErrorsLib.ZeroAssets();
 
         emit DrawnAndInvested(amount, usdcReceived, vaultShares);
     }
@@ -196,6 +216,7 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
         if (amount == 0) revert ErrorsLib.ZeroAssets();
 
         vaultShares = vault.deposit(amount, address(this));
+        if (vaultShares == 0) revert ErrorsLib.ZeroAssets();
         emit IdleInvested(amount, vaultShares);
     }
 
@@ -225,8 +246,23 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
         return _releaseToProtocol(type(uint256).max);
     }
 
+    /// @notice Repays protocol debt directly through Morpho, bypassing the bound Helper.
+    /// @dev Intended as an admin recovery path if Helper is unavailable or unsafe. `amount == type(uint256).max`
+    /// repays all current borrow shares to avoid dust.
+    /// @param amount USDC amount to repay, or `type(uint256).max` for full repayment.
+    /// @return assetsRepaid USDC assets withdrawn from the vault for the repayment.
+    /// @return sharesRepaid Borrow shares retired in the credit market.
+    function emergencyRepay(uint256 amount)
+        external
+        onlyAdminTouch
+        nonReentrant
+        returns (uint256 assetsRepaid, uint256 sharesRepaid)
+    {
+        return _emergencyRepay(amount);
+    }
+
     /// @notice Immediately releases vault liquidity to the fixed off-ramp recipient.
-    /// @param amount USDC amount to redeem from the vault and transfer to the off-ramp recipient.
+    /// @param amount USDC amount to withdraw from the vault and transfer to the off-ramp recipient.
     /// @return vaultShares Vault shares burned to obtain the USDC.
     function releaseToOfframp(uint256 amount) external onlyAdminTouch nonReentrant returns (uint256 vaultShares) {
         if (amount == 0) revert ErrorsLib.ZeroAssets();
@@ -237,12 +273,13 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
         emit OffRampRelease(offRampRecipient, amount, vaultShares);
     }
 
-    /// @notice Schedules or overwrites the pending proposer-initiated repayment.
-    /// @dev Restricted to the configured proposer. Overwrites any prior pending schedule.
+    /// @notice Schedules or overwrites the pending proposer-initiated fallback repayment.
+    /// @dev Restricted to the configured proposer and available only after 180 days without admin activity.
     /// @param amount USDC amount the proposer wants to repay once the veto window elapses.
     function scheduleProtocolRepayment(uint256 amount) external {
         if (msg.sender != proposer) revert ErrorsLib.Unauthorized();
         if (amount == 0) revert ErrorsLib.ZeroAssets();
+        if (block.timestamp < lastAdminTouch + FALLBACK_DELAY) revert FallbackNotReady();
 
         uint256 eta = block.timestamp + PROPOSER_DELAY;
         scheduledRepayment = ScheduledRepayment({amount: amount, eta: eta});
@@ -250,7 +287,7 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
         emit ProtocolRepaymentScheduled(amount, eta);
     }
 
-    /// @notice Vetoes the pending proposer-initiated repayment.
+    /// @notice Vetoes the pending proposer-initiated fallback repayment.
     /// @dev Reverts if no repayment is currently scheduled.
     function vetoScheduledRepayment() external onlyAdminTouch {
         if (scheduledRepayment.eta == 0) revert InvalidOperation();
@@ -259,7 +296,7 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
         emit ProtocolRepaymentVetoed();
     }
 
-    /// @notice Executes the pending proposer-initiated repayment once the 7-day veto window has elapsed.
+    /// @notice Executes the pending proposer-initiated fallback repayment once the 7-day veto window has elapsed.
     /// @return assetsRepaid USDC assets consumed by the repayment.
     /// @return sharesRepaid Borrow shares retired in the credit market.
     function executeScheduledRepayment() external nonReentrant returns (uint256 assetsRepaid, uint256 sharesRepaid) {
@@ -274,27 +311,14 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
         emit ScheduledProtocolRepaymentExecuted(amount, msg.sender);
     }
 
-    /// @notice Permissionlessly repays protocol debt after 180 days without admin activity.
-    /// @param amount USDC amount to repay; must not exceed the current outstanding debt.
-    /// @return assetsRepaid USDC assets consumed by the repayment.
-    /// @return sharesRepaid Borrow shares retired in the credit market.
-    function fallbackRepay(uint256 amount) external nonReentrant returns (uint256 assetsRepaid, uint256 sharesRepaid) {
-        if (block.timestamp < lastAdminTouch + FALLBACK_DELAY) revert FallbackNotReady();
-
-        (assetsRepaid, sharesRepaid) = _releaseToProtocol(amount);
-        emit FallbackProtocolRepayment(amount, msg.sender);
-    }
-
     /// @notice Rotates the proposer address.
     /// @param newProposer New proposer; must be non-zero and different from the current value.
     function setProposer(address newProposer) external onlyAdminTouch {
         if (newProposer == address(0)) revert ErrorsLib.ZeroAddress();
         if (newProposer == proposer) revert ErrorsLib.AlreadySet();
 
-        address oldProposer = proposer;
+        emit ProposerUpdated(proposer, newProposer);
         proposer = newProposer;
-
-        emit ProposerUpdated(oldProposer, newProposer);
     }
 
     /// @notice Rotates the off-ramp recipient address.
@@ -303,19 +327,19 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
         if (newOffRampRecipient == address(0)) revert ErrorsLib.ZeroAddress();
         if (newOffRampRecipient == offRampRecipient) revert ErrorsLib.AlreadySet();
 
-        address oldRecipient = offRampRecipient;
+        emit OffRampRecipientUpdated(offRampRecipient, newOffRampRecipient);
         offRampRecipient = newOffRampRecipient;
-
-        emit OffRampRecipientUpdated(oldRecipient, newOffRampRecipient);
     }
 
     /// @notice Recovers unrelated tokens accidentally sent to the reserve.
-    /// @dev USDC and the vault share token are protected and cannot be rescued.
+    /// @dev USDC, the market loan token, and the vault share token are protected and cannot be rescued.
     /// @param token ERC20 token to recover.
     /// @param recipient Address that receives the recovered tokens.
     /// @param amount Amount of `token` to transfer.
     function rescueToken(address token, address recipient, uint256 amount) external onlyAdminTouch {
-        if (token == address(usdc) || token == address(vault)) revert ProtectedToken();
+        if (token == address(usdc) || token == address(loanTokenVault) || token == address(vault)) {
+            revert ProtectedToken();
+        }
         if (recipient == address(0)) revert ErrorsLib.ZeroAddress();
         if (amount == 0) revert ErrorsLib.ZeroAssets();
 
@@ -335,7 +359,7 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
         uint256 loanTokenDebt = uint256(reservePosition.borrowShares)
             .toAssetsUp(targetMarket.totalBorrowAssets, targetMarket.totalBorrowShares);
 
-        return IERC4626(_marketParams.loanToken).previewMint(loanTokenDebt);
+        return loanTokenVault.previewMint(loanTokenDebt);
     }
 
     /// @dev Shared repayment routine. `amount == type(uint256).max` routes through Helper's share-based full-repay
@@ -356,6 +380,41 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
 
         vault.withdraw(usdcToWithdraw, address(this), address(this));
         (assetsRepaid, sharesRepaid) = helper.repay(_marketParams, amount, address(this), "");
+
+        emit ProtocolRepayment(assetsRepaid, sharesRepaid, msg.sender);
+    }
+
+    function _emergencyRepay(uint256 amount) internal returns (uint256 assetsRepaid, uint256 sharesRepaid) {
+        if (amount == 0) revert ErrorsLib.ZeroAssets();
+
+        _accrueReserveDebt();
+
+        uint256 loanTokenAssets;
+        uint256 borrowShares;
+        if (amount == type(uint256).max) {
+            Position memory reservePosition = morpho.position(marketId, address(this));
+            borrowShares = reservePosition.borrowShares;
+            if (borrowShares == 0) revert ErrorsLib.ZeroAssets();
+
+            Market memory targetMarket = morpho.market(marketId);
+            loanTokenAssets =
+                uint256(borrowShares).toAssetsUp(targetMarket.totalBorrowAssets, targetMarket.totalBorrowShares);
+            assetsRepaid = loanTokenVault.previewMint(loanTokenAssets);
+        } else {
+            if (amount > outstandingDebtAssets()) revert RepayAmountExceedsDebt();
+            assetsRepaid = amount;
+        }
+
+        vault.withdraw(assetsRepaid, address(this), address(this));
+        uint256 mintedLoanTokens = loanTokenVault.deposit(assetsRepaid, address(this));
+        if (mintedLoanTokens == 0) revert ErrorsLib.ZeroAssets();
+
+        if (amount == type(uint256).max) {
+            // `previewMint` can round up by at most dust; any excess loan-token dust stays protected.
+            (, sharesRepaid) = morpho.repay(_marketParams, 0, borrowShares, address(this), "");
+        } else {
+            (, sharesRepaid) = morpho.repay(_marketParams, mintedLoanTokens, 0, address(this), "");
+        }
 
         emit ProtocolRepayment(assetsRepaid, sharesRepaid, msg.sender);
     }

--- a/src/RevolvingCreditFacilityHolding.sol
+++ b/src/RevolvingCreditFacilityHolding.sol
@@ -352,14 +352,8 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
     /// trigger premium accrual first.
     /// @return USDC amount that would fully repay the position at current accrued state.
     function outstandingDebtAssets() public view returns (uint256) {
-        Position memory reservePosition = morpho.position(marketId, address(this));
-        if (reservePosition.borrowShares == 0) return 0;
-
-        Market memory targetMarket = morpho.market(marketId);
-        uint256 loanTokenDebt = uint256(reservePosition.borrowShares)
-            .toAssetsUp(targetMarket.totalBorrowAssets, targetMarket.totalBorrowShares);
-
-        return loanTokenVault.previewMint(loanTokenDebt);
+        (,, uint256 usdcAssets) = _currentDebt();
+        return usdcAssets;
     }
 
     /// @dev Shared repayment routine. `amount == type(uint256).max` routes through Helper's share-based full-repay
@@ -369,12 +363,13 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
 
         _accrueReserveDebt();
 
+        (,, uint256 fullDebt) = _currentDebt();
         uint256 usdcToWithdraw;
         if (amount == type(uint256).max) {
-            usdcToWithdraw = outstandingDebtAssets();
-            if (usdcToWithdraw == 0) revert ErrorsLib.ZeroAssets();
+            if (fullDebt == 0) revert ErrorsLib.ZeroAssets();
+            usdcToWithdraw = fullDebt;
         } else {
-            if (amount > outstandingDebtAssets()) revert RepayAmountExceedsDebt();
+            if (amount > fullDebt) revert RepayAmountExceedsDebt();
             usdcToWithdraw = amount;
         }
 
@@ -389,34 +384,39 @@ contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
 
         _accrueReserveDebt();
 
-        uint256 loanTokenAssets;
-        uint256 borrowShares;
         if (amount == type(uint256).max) {
-            Position memory reservePosition = morpho.position(marketId, address(this));
-            borrowShares = reservePosition.borrowShares;
-            if (borrowShares == 0) revert ErrorsLib.ZeroAssets();
+            (uint256 borrowShares, uint256 loanTokenAssets, uint256 usdcAssets) = _currentDebt();
+            if (borrowShares == 0 || usdcAssets == 0) revert ErrorsLib.ZeroAssets();
 
-            Market memory targetMarket = morpho.market(marketId);
-            loanTokenAssets =
-                uint256(borrowShares).toAssetsUp(targetMarket.totalBorrowAssets, targetMarket.totalBorrowShares);
-            assetsRepaid = loanTokenVault.previewMint(loanTokenAssets);
-        } else {
-            if (amount > outstandingDebtAssets()) revert RepayAmountExceedsDebt();
-            assetsRepaid = amount;
+            assetsRepaid = usdcAssets;
+            vault.withdraw(assetsRepaid, address(this), address(this));
+            loanTokenVault.mint(loanTokenAssets, address(this));
+            (, sharesRepaid) = morpho.repay(_marketParams, 0, borrowShares, address(this), "");
+
+            emit ProtocolRepayment(assetsRepaid, sharesRepaid, msg.sender);
+            return (assetsRepaid, sharesRepaid);
         }
+
+        (,, uint256 fullDebt) = _currentDebt();
+        if (amount > fullDebt) revert RepayAmountExceedsDebt();
+        assetsRepaid = amount;
 
         vault.withdraw(assetsRepaid, address(this), address(this));
         uint256 mintedLoanTokens = loanTokenVault.deposit(assetsRepaid, address(this));
         if (mintedLoanTokens == 0) revert ErrorsLib.ZeroAssets();
-
-        if (amount == type(uint256).max) {
-            // `previewMint` can round up by at most dust; any excess loan-token dust stays protected.
-            (, sharesRepaid) = morpho.repay(_marketParams, 0, borrowShares, address(this), "");
-        } else {
-            (, sharesRepaid) = morpho.repay(_marketParams, mintedLoanTokens, 0, address(this), "");
-        }
+        (, sharesRepaid) = morpho.repay(_marketParams, mintedLoanTokens, 0, address(this), "");
 
         emit ProtocolRepayment(assetsRepaid, sharesRepaid, msg.sender);
+    }
+
+    function _currentDebt() internal view returns (uint256 borrowShares, uint256 loanTokenAssets, uint256 usdcAssets) {
+        Position memory reservePosition = morpho.position(marketId, address(this));
+        borrowShares = uint256(reservePosition.borrowShares);
+        if (borrowShares == 0) return (0, 0, 0);
+
+        Market memory targetMarket = morpho.market(marketId);
+        loanTokenAssets = borrowShares.toAssetsUp(targetMarket.totalBorrowAssets, targetMarket.totalBorrowShares);
+        usdcAssets = loanTokenVault.previewMint(loanTokenAssets);
     }
 
     /// @dev Forces premium accrual against this reserve's borrow position so the subsequent debt read is accurate.

--- a/src/RevolvingCreditFacilityHolding.sol
+++ b/src/RevolvingCreditFacilityHolding.sol
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.22;
+
+import {Ownable} from "../lib/openzeppelin/contracts/access/Ownable.sol";
+import {IERC4626} from "../lib/openzeppelin/contracts/interfaces/IERC4626.sol";
+import {IERC20} from "../lib/openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "../lib/openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "../lib/openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import {IHelper} from "./interfaces/IHelper.sol";
+import {Id, IMorpho, IMorphoCredit, Market, MarketParams, Position} from "./interfaces/IMorpho.sol";
+import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+import {MarketParamsLib} from "./libraries/MarketParamsLib.sol";
+import {SharesMathLib} from "./libraries/SharesMathLib.sol";
+
+/// @title RevolvingCreditFacilityHolding
+/// @author 3Jane
+/// @custom:contact support@3jane.xyz
+/// @notice Non-upgradeable borrower reserve that parks committed capital in an external ERC4626 yield vault.
+/// @dev The reserve borrows USDC through Helper from a single Morpho market, deposits the USDC into the configured
+/// ERC4626 vault, and releases funds only through three paths: (1) immediate admin action, (2) a proposer-scheduled
+/// repayment that the admin may veto during a 7-day window, or (3) a permissionless fallback repayment unlocked
+/// after 180 days without admin activity. The admin heartbeat is refreshed by any owner-gated call, including
+/// `adminPing`.
+contract RevolvingCreditFacilityHolding is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+    using MarketParamsLib for MarketParams;
+    using SharesMathLib for uint256;
+
+    /// @notice Pending proposer-initiated protocol repayment awaiting the veto window to elapse.
+    /// @dev `eta == 0` indicates no scheduled repayment is pending.
+    struct ScheduledRepayment {
+        uint256 amount;
+        uint256 eta;
+    }
+
+    /// @notice Veto window between scheduling and executing a proposer-initiated repayment.
+    uint256 public constant PROPOSER_DELAY = 7 days;
+
+    /// @notice Idle window after which any address may permissionlessly repay protocol debt.
+    uint256 public constant FALLBACK_DELAY = 180 days;
+
+    /// @notice Helper contract used to borrow from and repay the Morpho credit market.
+    IHelper public immutable helper;
+
+    /// @notice Morpho protocol contract that holds this reserve's borrow position.
+    IMorpho public immutable morpho;
+
+    /// @notice USDC token used for borrowing, vault deposits, and off-ramp transfers.
+    IERC20 public immutable usdc;
+
+    /// @notice ERC4626 yield vault that holds drawn USDC between draws and repayments.
+    IERC4626 public immutable vault;
+
+    /// @notice Identifier of the Morpho market that this reserve borrows from.
+    Id public immutable marketId;
+
+    MarketParams internal _marketParams;
+
+    /// @notice Address authorized to schedule (but not directly execute) protocol repayments.
+    address public proposer;
+
+    /// @notice Fixed recipient of off-ramp releases; only the admin can change this address.
+    address public offRampRecipient;
+
+    /// @notice Timestamp of the last admin-gated call; used as the heartbeat for the 180-day fallback.
+    uint256 public lastAdminTouch;
+
+    /// @notice Currently pending proposer-scheduled repayment, if any.
+    ScheduledRepayment public scheduledRepayment;
+
+    /// @notice Emitted when the admin draws from the credit line and deposits the proceeds into the vault.
+    event DrawnAndInvested(uint256 requestedAmount, uint256 usdcReceived, uint256 vaultShares);
+
+    /// @notice Emitted when idle USDC already held by the contract is invested into the vault.
+    event IdleInvested(uint256 assets, uint256 vaultShares);
+
+    /// @notice Emitted whenever protocol debt is repaid, regardless of which path triggered it.
+    event ProtocolRepayment(uint256 assets, uint256 sharesRepaid, address indexed executor);
+
+    /// @notice Emitted when vault liquidity is released to the fixed off-ramp recipient.
+    event OffRampRelease(address indexed recipient, uint256 assets, uint256 vaultShares);
+
+    /// @notice Emitted when the proposer schedules (or overwrites) a pending repayment.
+    event ProtocolRepaymentScheduled(uint256 amount, uint256 eta);
+
+    /// @notice Emitted when the admin vetoes the pending scheduled repayment.
+    event ProtocolRepaymentVetoed();
+
+    /// @notice Emitted when a scheduled repayment is executed after its veto window elapses.
+    event ScheduledProtocolRepaymentExecuted(uint256 amount, address indexed executor);
+
+    /// @notice Emitted when the permissionless fallback path repays protocol debt.
+    event FallbackProtocolRepayment(uint256 amount, address indexed executor);
+
+    /// @notice Emitted when the proposer address is rotated by the admin.
+    event ProposerUpdated(address indexed oldProposer, address indexed newProposer);
+
+    /// @notice Emitted when the off-ramp recipient is rotated by the admin.
+    event OffRampRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
+
+    /// @notice Emitted when the admin explicitly refreshes the heartbeat via `adminPing`.
+    event AdminPing(uint256 timestamp);
+
+    /// @notice Emitted when unrelated ERC20s are recovered via `rescueToken`.
+    event RescueToken(address indexed token, address indexed recipient, uint256 amount);
+
+    /// @notice Thrown when `fallbackRepay` is invoked before the 180-day idle window has elapsed.
+    error FallbackNotReady();
+
+    /// @notice Thrown when veto/execute is called and no repayment is currently scheduled.
+    error InvalidOperation();
+
+    /// @notice Thrown when `executeScheduledRepayment` is called before the veto window elapses.
+    error OperationNotReady();
+
+    /// @notice Thrown when a partial repayment amount exceeds the current outstanding debt.
+    error RepayAmountExceedsDebt();
+
+    /// @notice Thrown when `rescueToken` is called with USDC or the vault token.
+    error ProtectedToken();
+
+    /// @notice Runs the owner check and refreshes the admin heartbeat for the 180-day fallback timer.
+    modifier onlyAdminTouch() {
+        _checkOwner();
+        lastAdminTouch = block.timestamp;
+        _;
+    }
+
+    /// @notice Deploys a borrower reserve bound to a single Morpho market and a single ERC4626 vault.
+    /// @param admin Initial owner; gates all admin actions and is required to keep the heartbeat alive.
+    /// @param initialProposer Address allowed to schedule (but not execute) protocol repayments.
+    /// @param initialOffRampRecipient Fixed recipient of off-ramp releases.
+    /// @param helper_ Helper contract used for borrow and repay routing.
+    /// @param vault_ ERC4626 vault whose asset must equal Helper's configured USDC token.
+    /// @param marketParams_ Market this reserve borrows from; `marketId` is derived once at construction.
+    constructor(
+        address admin,
+        address initialProposer,
+        address initialOffRampRecipient,
+        address helper_,
+        address vault_,
+        MarketParams memory marketParams_
+    ) Ownable(admin) {
+        if (
+            admin == address(0) || initialProposer == address(0) || initialOffRampRecipient == address(0)
+                || helper_ == address(0) || vault_ == address(0) || marketParams_.loanToken == address(0)
+        ) {
+            revert ErrorsLib.ZeroAddress();
+        }
+
+        helper = IHelper(helper_);
+        morpho = IMorpho(IHelper(helper_).MORPHO());
+        vault = IERC4626(vault_);
+        usdc = IERC20(IERC4626(vault_).asset());
+
+        if (address(usdc) != IHelper(helper_).USDC()) revert ErrorsLib.InconsistentInput();
+
+        _marketParams = marketParams_;
+        marketId = marketParams_.id();
+        proposer = initialProposer;
+        offRampRecipient = initialOffRampRecipient;
+        lastAdminTouch = block.timestamp;
+
+        usdc.forceApprove(helper_, type(uint256).max);
+        usdc.forceApprove(vault_, type(uint256).max);
+    }
+
+    /// @notice Returns the full market parameters bound at construction time.
+    /// @return The `MarketParams` struct used for every borrow and repay call.
+    function marketParams() external view returns (MarketParams memory) {
+        return _marketParams;
+    }
+
+    /// @notice Refreshes the admin heartbeat used by the 180-day permissionless repayment fallback.
+    function adminPing() external onlyAdminTouch {
+        emit AdminPing(block.timestamp);
+    }
+
+    /// @notice Draws committed capital through Helper and deposits the received USDC into the vault.
+    /// @param amount Amount of credit-market loan tokens to borrow.
+    /// @return usdcReceived USDC delivered by Helper and deposited into the vault.
+    function drawAndInvest(uint256 amount) external onlyAdminTouch nonReentrant returns (uint256 usdcReceived) {
+        if (amount == 0) revert ErrorsLib.ZeroAssets();
+
+        (usdcReceived,) = helper.borrow(_marketParams, amount);
+        uint256 vaultShares = vault.deposit(usdcReceived, address(this));
+
+        emit DrawnAndInvested(amount, usdcReceived, vaultShares);
+    }
+
+    /// @notice Invests idle USDC already held by this contract into the vault.
+    /// @param amount USDC to deposit into the vault.
+    /// @return vaultShares Vault shares minted to this contract.
+    function investIdle(uint256 amount) external onlyAdminTouch nonReentrant returns (uint256 vaultShares) {
+        if (amount == 0) revert ErrorsLib.ZeroAssets();
+
+        vaultShares = vault.deposit(amount, address(this));
+        emit IdleInvested(amount, vaultShares);
+    }
+
+    /// @notice Immediately releases vault liquidity to repay a fixed amount of this reserve's protocol debt.
+    /// @param amount USDC amount to repay; must not exceed the current outstanding debt.
+    /// @return assetsRepaid USDC assets consumed by the repayment.
+    /// @return sharesRepaid Borrow shares retired in the credit market.
+    function releaseToProtocol(uint256 amount)
+        external
+        onlyAdminTouch
+        nonReentrant
+        returns (uint256 assetsRepaid, uint256 sharesRepaid)
+    {
+        return _releaseToProtocol(amount);
+    }
+
+    /// @notice Immediately releases enough vault liquidity to repay the full outstanding protocol debt.
+    /// @dev Routes through Helper's share-based full-repay path to avoid leaving any dust shares.
+    /// @return assetsRepaid USDC assets consumed by the repayment.
+    /// @return sharesRepaid Borrow shares retired in the credit market.
+    function releaseAllToProtocol()
+        external
+        onlyAdminTouch
+        nonReentrant
+        returns (uint256 assetsRepaid, uint256 sharesRepaid)
+    {
+        return _releaseToProtocol(type(uint256).max);
+    }
+
+    /// @notice Immediately releases vault liquidity to the fixed off-ramp recipient.
+    /// @param amount USDC amount to redeem from the vault and transfer to the off-ramp recipient.
+    /// @return vaultShares Vault shares burned to obtain the USDC.
+    function releaseToOfframp(uint256 amount) external onlyAdminTouch nonReentrant returns (uint256 vaultShares) {
+        if (amount == 0) revert ErrorsLib.ZeroAssets();
+
+        vaultShares = vault.withdraw(amount, address(this), address(this));
+        usdc.safeTransfer(offRampRecipient, amount);
+
+        emit OffRampRelease(offRampRecipient, amount, vaultShares);
+    }
+
+    /// @notice Schedules or overwrites the pending proposer-initiated repayment.
+    /// @dev Restricted to the configured proposer. Overwrites any prior pending schedule.
+    /// @param amount USDC amount the proposer wants to repay once the veto window elapses.
+    function scheduleProtocolRepayment(uint256 amount) external {
+        if (msg.sender != proposer) revert ErrorsLib.Unauthorized();
+        if (amount == 0) revert ErrorsLib.ZeroAssets();
+
+        uint256 eta = block.timestamp + PROPOSER_DELAY;
+        scheduledRepayment = ScheduledRepayment({amount: amount, eta: eta});
+
+        emit ProtocolRepaymentScheduled(amount, eta);
+    }
+
+    /// @notice Vetoes the pending proposer-initiated repayment.
+    /// @dev Reverts if no repayment is currently scheduled.
+    function vetoScheduledRepayment() external onlyAdminTouch {
+        if (scheduledRepayment.eta == 0) revert InvalidOperation();
+
+        delete scheduledRepayment;
+        emit ProtocolRepaymentVetoed();
+    }
+
+    /// @notice Executes the pending proposer-initiated repayment once the 7-day veto window has elapsed.
+    /// @return assetsRepaid USDC assets consumed by the repayment.
+    /// @return sharesRepaid Borrow shares retired in the credit market.
+    function executeScheduledRepayment() external nonReentrant returns (uint256 assetsRepaid, uint256 sharesRepaid) {
+        ScheduledRepayment memory operation = scheduledRepayment;
+        if (operation.eta == 0) revert InvalidOperation();
+        if (block.timestamp < operation.eta) revert OperationNotReady();
+
+        uint256 amount = operation.amount;
+        delete scheduledRepayment;
+        (assetsRepaid, sharesRepaid) = _releaseToProtocol(amount);
+
+        emit ScheduledProtocolRepaymentExecuted(amount, msg.sender);
+    }
+
+    /// @notice Permissionlessly repays protocol debt after 180 days without admin activity.
+    /// @param amount USDC amount to repay; must not exceed the current outstanding debt.
+    /// @return assetsRepaid USDC assets consumed by the repayment.
+    /// @return sharesRepaid Borrow shares retired in the credit market.
+    function fallbackRepay(uint256 amount) external nonReentrant returns (uint256 assetsRepaid, uint256 sharesRepaid) {
+        if (block.timestamp < lastAdminTouch + FALLBACK_DELAY) revert FallbackNotReady();
+
+        (assetsRepaid, sharesRepaid) = _releaseToProtocol(amount);
+        emit FallbackProtocolRepayment(amount, msg.sender);
+    }
+
+    /// @notice Rotates the proposer address.
+    /// @param newProposer New proposer; must be non-zero and different from the current value.
+    function setProposer(address newProposer) external onlyAdminTouch {
+        if (newProposer == address(0)) revert ErrorsLib.ZeroAddress();
+        if (newProposer == proposer) revert ErrorsLib.AlreadySet();
+
+        address oldProposer = proposer;
+        proposer = newProposer;
+
+        emit ProposerUpdated(oldProposer, newProposer);
+    }
+
+    /// @notice Rotates the off-ramp recipient address.
+    /// @param newOffRampRecipient New off-ramp recipient; must be non-zero and different from the current value.
+    function setOffRampRecipient(address newOffRampRecipient) external onlyAdminTouch {
+        if (newOffRampRecipient == address(0)) revert ErrorsLib.ZeroAddress();
+        if (newOffRampRecipient == offRampRecipient) revert ErrorsLib.AlreadySet();
+
+        address oldRecipient = offRampRecipient;
+        offRampRecipient = newOffRampRecipient;
+
+        emit OffRampRecipientUpdated(oldRecipient, newOffRampRecipient);
+    }
+
+    /// @notice Recovers unrelated tokens accidentally sent to the reserve.
+    /// @dev USDC and the vault share token are protected and cannot be rescued.
+    /// @param token ERC20 token to recover.
+    /// @param recipient Address that receives the recovered tokens.
+    /// @param amount Amount of `token` to transfer.
+    function rescueToken(address token, address recipient, uint256 amount) external onlyAdminTouch {
+        if (token == address(usdc) || token == address(vault)) revert ProtectedToken();
+        if (recipient == address(0)) revert ErrorsLib.ZeroAddress();
+        if (amount == 0) revert ErrorsLib.ZeroAssets();
+
+        IERC20(token).safeTransfer(recipient, amount);
+        emit RescueToken(token, recipient, amount);
+    }
+
+    /// @notice Returns this reserve's outstanding protocol debt denominated in USDC.
+    /// @dev Reads the live position and market state without accruing premium; for in-tx accuracy callers should
+    /// trigger premium accrual first.
+    /// @return USDC amount that would fully repay the position at current accrued state.
+    function outstandingDebtAssets() public view returns (uint256) {
+        Position memory reservePosition = morpho.position(marketId, address(this));
+        if (reservePosition.borrowShares == 0) return 0;
+
+        Market memory targetMarket = morpho.market(marketId);
+        uint256 loanTokenDebt = uint256(reservePosition.borrowShares)
+            .toAssetsUp(targetMarket.totalBorrowAssets, targetMarket.totalBorrowShares);
+
+        return IERC4626(_marketParams.loanToken).previewMint(loanTokenDebt);
+    }
+
+    /// @dev Shared repayment routine. `amount == type(uint256).max` routes through Helper's share-based full-repay
+    /// path to avoid dust; any other value performs an assets-based partial repay bounded by current debt.
+    function _releaseToProtocol(uint256 amount) internal returns (uint256 assetsRepaid, uint256 sharesRepaid) {
+        if (amount == 0) revert ErrorsLib.ZeroAssets();
+
+        _accrueReserveDebt();
+
+        uint256 usdcToWithdraw;
+        if (amount == type(uint256).max) {
+            usdcToWithdraw = outstandingDebtAssets();
+            if (usdcToWithdraw == 0) revert ErrorsLib.ZeroAssets();
+        } else {
+            if (amount > outstandingDebtAssets()) revert RepayAmountExceedsDebt();
+            usdcToWithdraw = amount;
+        }
+
+        vault.withdraw(usdcToWithdraw, address(this), address(this));
+        (assetsRepaid, sharesRepaid) = helper.repay(_marketParams, amount, address(this), "");
+
+        emit ProtocolRepayment(assetsRepaid, sharesRepaid, msg.sender);
+    }
+
+    /// @dev Forces premium accrual against this reserve's borrow position so the subsequent debt read is accurate.
+    function _accrueReserveDebt() internal {
+        address[] memory borrowers = new address[](1);
+        borrowers[0] = address(this);
+        IMorphoCredit(address(morpho)).accruePremiumsForBorrowers(marketId, borrowers);
+    }
+}

--- a/test/forge/unit/RevolvingCreditFacilityHoldingTest.sol
+++ b/test/forge/unit/RevolvingCreditFacilityHoldingTest.sol
@@ -142,11 +142,11 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
         assertEq(vault.balanceOf(address(reserve)), 60_000e6, "vault shares should be withdrawn");
     }
 
-    function test_adminReleasesAllToProtocol() public {
+    function test_adminReleasesMaxToProtocol() public {
         _draw(DRAW);
 
         vm.prank(admin);
-        reserve.releaseAllToProtocol();
+        reserve.releaseToProtocol(type(uint256).max);
 
         assertEq(reserve.outstandingDebtAssets(), 0, "debt should be fully repaid");
         assertEq(vault.balanceOf(address(reserve)), 0, "vault shares should be fully withdrawn");
@@ -180,6 +180,7 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
 
         assertEq(reserve.outstandingDebtAssets(), 0, "emergency repay should clear debt");
         assertEq(IERC20(reserveMarketParams.loanToken).balanceOf(address(reserve)), 0, "loan-token dust should be zero");
+        assertEq(underlyingAsset.balanceOf(address(reserve)), 0, "USDC residual should be zero");
         assertEq(vault.balanceOf(address(reserve)), 0, "vault shares should be fully withdrawn");
     }
 
@@ -239,6 +240,47 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
 
         vm.expectRevert(RevolvingCreditFacilityHolding.InvalidOperation.selector);
         reserve.executeScheduledRepayment();
+    }
+
+    function test_adminCanVetoScheduledRepaymentAfterEta() public {
+        _draw(DRAW);
+
+        skip(180 days);
+
+        vm.prank(proposer);
+        reserve.scheduleProtocolRepayment(10_000e6);
+
+        skip(7 days);
+
+        vm.prank(admin);
+        reserve.vetoScheduledRepayment();
+
+        vm.expectRevert(RevolvingCreditFacilityHolding.InvalidOperation.selector);
+        reserve.executeScheduledRepayment();
+    }
+
+    function test_proposerCanScheduleMaxRepayment() public {
+        _draw(DRAW);
+
+        skip(180 days);
+
+        vm.prank(proposer);
+        reserve.scheduleProtocolRepayment(type(uint256).max);
+
+        skip(7 days);
+
+        _postEmptyCycle();
+        morpho.accrueInterest(reserveMarketParams);
+        uint256 fullDebt = reserve.outstandingDebtAssets();
+        deal(address(underlyingAsset), address(reserve), fullDebt - DRAW);
+
+        vm.prank(admin);
+        reserve.investIdle(fullDebt - DRAW);
+
+        reserve.executeScheduledRepayment();
+
+        assertEq(reserve.outstandingDebtAssets(), 0, "scheduled max repayment should clear debt");
+        assertEq(vault.balanceOf(address(reserve)), 0, "vault shares should be fully withdrawn");
     }
 
     function test_proposerCanOverwriteScheduledRepayment() public {

--- a/test/forge/unit/RevolvingCreditFacilityHoldingTest.sol
+++ b/test/forge/unit/RevolvingCreditFacilityHoldingTest.sol
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.22;
 
+import {stdError} from "forge-std/StdError.sol";
+
 import {ERC20} from "../../../lib/openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IERC20} from "../../../lib/openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Ownable} from "../../../lib/openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "../../../lib/openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 import {RevolvingCreditFacilityHolding} from "../../../src/RevolvingCreditFacilityHolding.sol";
 import {Helper} from "../../../src/Helper.sol";
@@ -12,6 +16,14 @@ import {ErrorsLib} from "../../../src/libraries/ErrorsLib.sol";
 import {USD3} from "../../../src/usd3/USD3.sol";
 import {MockWaUSDC} from "../usd3/mocks/MockWaUSDC.sol";
 import {Setup} from "../usd3/utils/Setup.sol";
+
+contract SimpleERC20 is ERC20 {
+    constructor() ERC20("Simple Token", "SIMPLE") {}
+
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
+    }
+}
 
 contract MaliciousVault is ERC20 {
     IERC20 public immutable underlying;
@@ -44,7 +56,7 @@ contract MaliciousVault is ERC20 {
         shares = assets;
 
         if (attackEnabled) {
-            RevolvingCreditFacilityHolding(reserve).fallbackRepay(1);
+            RevolvingCreditFacilityHolding(reserve).executeScheduledRepayment();
         }
 
         if (msg.sender != owner) {
@@ -87,6 +99,7 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
             address(morpho), address(strategy), makeAddr("sUSD3"), address(underlyingAsset), address(waUSDC)
         );
 
+        // The reserve tests exercise the production Helper, so the protocol-wide helper is swapped from Setup's mock.
         vm.prank(morpho.owner());
         morpho.setHelper(address(realHelper));
 
@@ -97,6 +110,18 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
         reserve = _deployReserve(address(vault));
         _setReserveCredit(address(reserve), CREDIT);
         _postEmptyCycle();
+    }
+
+    function test_constructorRejectsLoanTokenWithDifferentAsset() public {
+        SimpleERC20 otherAsset = new SimpleERC20();
+        MockWaUSDC badLoanToken = new MockWaUSDC(address(otherAsset));
+        MarketParams memory badMarketParams = reserveMarketParams;
+        badMarketParams.loanToken = address(badLoanToken);
+
+        vm.expectRevert(ErrorsLib.InconsistentInput.selector);
+        new RevolvingCreditFacilityHolding(
+            admin, proposer, offRampRecipient, address(realHelper), address(vault), badMarketParams
+        );
     }
 
     function test_adminDrawsAndInvestsInVault() public {
@@ -127,6 +152,36 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
         assertEq(vault.balanceOf(address(reserve)), 0, "vault shares should be fully withdrawn");
     }
 
+    function test_emergencyRepayBypassesHelperForExistingDebt() public {
+        _draw(DRAW);
+
+        vm.prank(morpho.owner());
+        morpho.setHelper(makeAddr("rotatedHelper"));
+
+        vm.expectRevert(ErrorsLib.NotHelper.selector);
+        vm.prank(admin);
+        reserve.drawAndInvest(1e6);
+
+        vm.prank(admin);
+        reserve.emergencyRepay(40_000e6);
+
+        assertEq(reserve.outstandingDebtAssets(), 60_000e6, "emergency repay should reduce debt");
+        assertEq(vault.balanceOf(address(reserve)), 60_000e6, "vault shares should be withdrawn");
+    }
+
+    function test_emergencyRepayAllBypassesHelper() public {
+        _draw(DRAW);
+
+        vm.prank(morpho.owner());
+        morpho.setHelper(makeAddr("rotatedHelper"));
+
+        vm.prank(admin);
+        reserve.emergencyRepay(type(uint256).max);
+
+        assertEq(reserve.outstandingDebtAssets(), 0, "emergency repay should clear debt");
+        assertEq(vault.balanceOf(address(reserve)), 0, "vault shares should be fully withdrawn");
+    }
+
     function test_adminReleasesOnlyToFixedOffRampRecipient() public {
         _draw(DRAW);
 
@@ -138,16 +193,18 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
         assertEq(reserve.outstandingDebtAssets(), DRAW, "off-ramp release should not repay protocol debt");
     }
 
-    function test_usd3CannotPullVaultFundsAutomatically() public {
+    function test_vaultRejectsThirdPartyWithdrawWithoutAllowance() public {
         _draw(DRAW);
 
-        vm.expectRevert();
+        vm.expectRevert(stdError.arithmeticError);
         vm.prank(address(strategy));
         vault.withdraw(1e6, address(strategy), address(reserve));
     }
 
     function test_proposerRepaymentExecutesAfterDelay() public {
         _draw(DRAW);
+
+        skip(180 days);
 
         vm.prank(proposer);
         reserve.scheduleProtocolRepayment(10_000e6);
@@ -157,6 +214,7 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
 
         skip(7 days);
 
+        _postEmptyCycle();
         morpho.accrueInterest(reserveMarketParams);
         uint256 debtBefore = reserve.outstandingDebtAssets();
 
@@ -167,6 +225,8 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
 
     function test_adminCanVetoProposerRepayment() public {
         _draw(DRAW);
+
+        skip(180 days);
 
         vm.prank(proposer);
         reserve.scheduleProtocolRepayment(10_000e6);
@@ -182,6 +242,8 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
 
     function test_proposerCanOverwriteScheduledRepayment() public {
         _draw(DRAW);
+
+        skip(180 days);
 
         vm.prank(proposer);
         reserve.scheduleProtocolRepayment(10_000e6);
@@ -202,6 +264,8 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
     function test_overwrittenRepaymentUsesLatestAmountAndTimer() public {
         _draw(DRAW);
 
+        skip(180 days);
+
         vm.prank(proposer);
         reserve.scheduleProtocolRepayment(10_000e6);
 
@@ -217,6 +281,7 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
 
         skip(6 days);
 
+        _postEmptyCycle();
         morpho.accrueInterest(reserveMarketParams);
         uint256 debtBefore = reserve.outstandingDebtAssets();
 
@@ -228,32 +293,83 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
     function test_proposerCannotReleaseToOfframp() public {
         _draw(DRAW);
 
-        vm.expectRevert();
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, proposer));
         vm.prank(proposer);
         reserve.releaseToOfframp(10_000e6);
     }
 
-    function test_fallbackRepayRequiresExpiredAdminHeartbeat() public {
+    function test_adminSetterRefreshesFallbackScheduleDelay() public {
+        _draw(DRAW);
+
+        skip(100 days);
+
+        address newProposer = makeAddr("newProposer");
+        vm.prank(admin);
+        reserve.setProposer(newProposer);
+        skip(100 days);
+
+        vm.expectRevert(RevolvingCreditFacilityHolding.FallbackNotReady.selector);
+        vm.prank(newProposer);
+        reserve.scheduleProtocolRepayment(10_000e6);
+    }
+
+    function test_proposerCannotScheduleBeforeFallbackDelay() public {
+        _draw(DRAW);
+
+        skip(180 days - 1);
+
+        vm.expectRevert(RevolvingCreditFacilityHolding.FallbackNotReady.selector);
+        vm.prank(proposer);
+        reserve.scheduleProtocolRepayment(10_000e6);
+    }
+
+    function test_adminPingResetsFallbackScheduleDelay() public {
         _draw(DRAW);
 
         skip(100 days);
 
         vm.prank(admin);
         reserve.adminPing();
-
         skip(100 days);
 
         vm.expectRevert(RevolvingCreditFacilityHolding.FallbackNotReady.selector);
-        reserve.fallbackRepay(10_000e6);
+        vm.prank(proposer);
+        reserve.scheduleProtocolRepayment(10_000e6);
+    }
 
-        skip(80 days);
-        _postEmptyCycle();
-        morpho.accrueInterest(reserveMarketParams);
-        uint256 debtBefore = reserve.outstandingDebtAssets();
+    function test_proposerCanScheduleAfterFallbackDelay() public {
+        _draw(DRAW);
 
-        reserve.fallbackRepay(10_000e6);
+        skip(180 days);
 
-        assertEq(reserve.outstandingDebtAssets(), debtBefore - 10_000e6, "fallback repayment should reduce debt");
+        vm.prank(proposer);
+        reserve.scheduleProtocolRepayment(10_000e6);
+
+        (uint256 amount, uint256 eta) = reserve.scheduledRepayment();
+        assertEq(amount, 10_000e6, "fallback amount should be scheduled");
+        assertEq(eta, block.timestamp + reserve.PROPOSER_DELAY(), "scheduled repayment should retain veto window");
+    }
+
+    function test_transferOwnershipRefreshesFallbackScheduleDelay() public {
+        address newAdmin = makeAddr("newAdmin");
+
+        _draw(DRAW);
+        skip(180 days);
+
+        vm.prank(admin);
+        reserve.transferOwnership(newAdmin);
+
+        vm.expectRevert(RevolvingCreditFacilityHolding.FallbackNotReady.selector);
+        vm.prank(proposer);
+        reserve.scheduleProtocolRepayment(10_000e6);
+    }
+
+    function test_renounceOwnershipIsDisabled() public {
+        _draw(DRAW);
+
+        vm.expectRevert(RevolvingCreditFacilityHolding.RenounceOwnershipDisabled.selector);
+        vm.prank(admin);
+        reserve.renounceOwnership();
     }
 
     function test_repayCannotExceedOutstandingDebt() public {
@@ -264,12 +380,36 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
         reserve.releaseToProtocol(DRAW + 1);
     }
 
+    function test_setProposerRejectsZeroAddressAndSameValue() public {
+        vm.expectRevert(ErrorsLib.ZeroAddress.selector);
+        vm.prank(admin);
+        reserve.setProposer(address(0));
+
+        vm.expectRevert(ErrorsLib.AlreadySet.selector);
+        vm.prank(admin);
+        reserve.setProposer(proposer);
+    }
+
+    function test_setOffRampRecipientRejectsZeroAddressAndSameValue() public {
+        vm.expectRevert(ErrorsLib.ZeroAddress.selector);
+        vm.prank(admin);
+        reserve.setOffRampRecipient(address(0));
+
+        vm.expectRevert(ErrorsLib.AlreadySet.selector);
+        vm.prank(admin);
+        reserve.setOffRampRecipient(offRampRecipient);
+    }
+
     function test_rescueCannotRecoverProtectedAssets() public {
         _draw(DRAW);
 
         vm.expectRevert(RevolvingCreditFacilityHolding.ProtectedToken.selector);
         vm.prank(admin);
         reserve.rescueToken(address(vault), admin, 1);
+
+        vm.expectRevert(RevolvingCreditFacilityHolding.ProtectedToken.selector);
+        vm.prank(admin);
+        reserve.rescueToken(reserveMarketParams.loanToken, admin, 1);
 
         deal(address(underlyingAsset), address(reserve), 1e6);
 
@@ -278,7 +418,40 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
         reserve.rescueToken(address(underlyingAsset), admin, 1e6);
     }
 
-    function test_reentrantWrapperCannotReenterFallbackRepay() public {
+    function test_rescueTokenTransfersUnrelatedErc20() public {
+        SimpleERC20 token = new SimpleERC20();
+        token.mint(address(reserve), 100e18);
+
+        vm.prank(admin);
+        reserve.rescueToken(address(token), admin, 40e18);
+
+        assertEq(token.balanceOf(admin), 40e18, "admin should receive rescued token");
+        assertEq(token.balanceOf(address(reserve)), 60e18, "reserve should keep unrescued balance");
+    }
+
+    function test_investIdleRevertsWhenVaultMintsZeroShares() public {
+        MockWaUSDC zeroShareVault = new MockWaUSDC(address(underlyingAsset));
+        zeroShareVault.setSharePrice(2e6);
+        RevolvingCreditFacilityHolding zeroShareReserve = _deployReserve(address(zeroShareVault));
+        deal(address(underlyingAsset), address(zeroShareReserve), 1);
+
+        vm.expectRevert(ErrorsLib.ZeroAssets.selector);
+        vm.prank(admin);
+        zeroShareReserve.investIdle(1);
+    }
+
+    function test_drawAndInvestRevertsWhenVaultMintsZeroShares() public {
+        MockWaUSDC zeroShareVault = new MockWaUSDC(address(underlyingAsset));
+        zeroShareVault.setSharePrice(DRAW * 1e6 + 1);
+        RevolvingCreditFacilityHolding zeroShareReserve = _deployReserve(address(zeroShareVault));
+        _setReserveCredit(address(zeroShareReserve), CREDIT);
+
+        vm.expectRevert(ErrorsLib.ZeroAssets.selector);
+        vm.prank(admin);
+        zeroShareReserve.drawAndInvest(DRAW);
+    }
+
+    function test_reentrantWrapperCannotReenterScheduledRepayment() public {
         MaliciousVault maliciousVault = new MaliciousVault(address(underlyingAsset));
         RevolvingCreditFacilityHolding maliciousReserve = _deployReserve(address(maliciousVault));
         maliciousVault.setReserve(address(maliciousReserve));
@@ -288,11 +461,15 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
         maliciousReserve.drawAndInvest(DRAW);
 
         skip(181 days);
+        vm.prank(proposer);
+        maliciousReserve.scheduleProtocolRepayment(10_000e6);
+        skip(7 days);
         _postEmptyCycle();
+
         maliciousVault.setAttackEnabled(true);
 
-        vm.expectRevert();
-        maliciousReserve.fallbackRepay(10_000e6);
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
+        maliciousReserve.executeScheduledRepayment();
     }
 
     function _deployReserve(address vault_) internal returns (RevolvingCreditFacilityHolding deployedReserve) {

--- a/test/forge/unit/RevolvingCreditFacilityHoldingTest.sol
+++ b/test/forge/unit/RevolvingCreditFacilityHoldingTest.sol
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.22;
+
+import {ERC20} from "../../../lib/openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "../../../lib/openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {RevolvingCreditFacilityHolding} from "../../../src/RevolvingCreditFacilityHolding.sol";
+import {Helper} from "../../../src/Helper.sol";
+import {MorphoCredit} from "../../../src/MorphoCredit.sol";
+import {Id, MarketParams} from "../../../src/interfaces/IMorpho.sol";
+import {ErrorsLib} from "../../../src/libraries/ErrorsLib.sol";
+import {USD3} from "../../../src/usd3/USD3.sol";
+import {MockWaUSDC} from "../usd3/mocks/MockWaUSDC.sol";
+import {Setup} from "../usd3/utils/Setup.sol";
+
+contract MaliciousVault is ERC20 {
+    IERC20 public immutable underlying;
+    address public reserve;
+    bool public attackEnabled;
+
+    constructor(address asset_) ERC20("Malicious Vault", "mVAULT") {
+        underlying = IERC20(asset_);
+    }
+
+    function asset() external view returns (address) {
+        return address(underlying);
+    }
+
+    function setReserve(address reserve_) external {
+        reserve = reserve_;
+    }
+
+    function setAttackEnabled(bool attackEnabled_) external {
+        attackEnabled = attackEnabled_;
+    }
+
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
+        underlying.transferFrom(msg.sender, address(this), assets);
+        _mint(receiver, assets);
+        return assets;
+    }
+
+    function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares) {
+        shares = assets;
+
+        if (attackEnabled) {
+            RevolvingCreditFacilityHolding(reserve).fallbackRepay(1);
+        }
+
+        if (msg.sender != owner) {
+            uint256 allowed = allowance(owner, msg.sender);
+            if (allowed != type(uint256).max) {
+                _approve(owner, msg.sender, allowed - shares);
+            }
+        }
+
+        _burn(owner, shares);
+        underlying.transfer(receiver, assets);
+    }
+}
+
+contract RevolvingCreditFacilityHoldingTest is Setup {
+    address internal admin = makeAddr("admin");
+    address internal proposer = makeAddr("proposer");
+    address internal offRampRecipient = makeAddr("offRampRecipient");
+    address internal lender = makeAddr("lender");
+
+    uint256 internal constant LIQUIDITY = 1_000_000e6;
+    uint256 internal constant CREDIT = 500_000e6;
+    uint256 internal constant DRAW = 100_000e6;
+
+    Helper internal realHelper;
+    MorphoCredit internal morpho;
+    MarketParams internal reserveMarketParams;
+    Id internal reserveMarketId;
+    MockWaUSDC internal vault;
+    RevolvingCreditFacilityHolding internal reserve;
+
+    function setUp() public override {
+        super.setUp();
+
+        morpho = MorphoCredit(address(USD3(address(strategy)).morphoCredit()));
+        reserveMarketParams = USD3(address(strategy)).marketParams();
+        reserveMarketId = USD3(address(strategy)).marketId();
+
+        realHelper = new Helper(
+            address(morpho), address(strategy), makeAddr("sUSD3"), address(underlyingAsset), address(waUSDC)
+        );
+
+        vm.prank(morpho.owner());
+        morpho.setHelper(address(realHelper));
+
+        setMaxOnCredit(10_000);
+        mintAndDepositIntoStrategy(strategy, lender, LIQUIDITY);
+
+        vault = new MockWaUSDC(address(underlyingAsset));
+        reserve = _deployReserve(address(vault));
+        _setReserveCredit(address(reserve), CREDIT);
+        _postEmptyCycle();
+    }
+
+    function test_adminDrawsAndInvestsInVault() public {
+        _draw(DRAW);
+
+        assertEq(underlyingAsset.balanceOf(address(reserve)), 0, "reserve should not keep idle USDC");
+        assertEq(vault.balanceOf(address(reserve)), DRAW, "reserve should hold vault shares");
+        assertEq(reserve.outstandingDebtAssets(), DRAW, "reserve debt should match draw");
+    }
+
+    function test_adminReleasesToProtocolByRepayingReserveDebt() public {
+        _draw(DRAW);
+
+        vm.prank(admin);
+        reserve.releaseToProtocol(40_000e6);
+
+        assertEq(reserve.outstandingDebtAssets(), 60_000e6, "debt should be partially repaid");
+        assertEq(vault.balanceOf(address(reserve)), 60_000e6, "vault shares should be withdrawn");
+    }
+
+    function test_adminReleasesAllToProtocol() public {
+        _draw(DRAW);
+
+        vm.prank(admin);
+        reserve.releaseAllToProtocol();
+
+        assertEq(reserve.outstandingDebtAssets(), 0, "debt should be fully repaid");
+        assertEq(vault.balanceOf(address(reserve)), 0, "vault shares should be fully withdrawn");
+    }
+
+    function test_adminReleasesOnlyToFixedOffRampRecipient() public {
+        _draw(DRAW);
+
+        vm.prank(admin);
+        reserve.releaseToOfframp(25_000e6);
+
+        assertEq(underlyingAsset.balanceOf(offRampRecipient), 25_000e6, "off-ramp should receive USDC");
+        assertEq(underlyingAsset.balanceOf(address(this)), 0, "arbitrary recipient should not receive funds");
+        assertEq(reserve.outstandingDebtAssets(), DRAW, "off-ramp release should not repay protocol debt");
+    }
+
+    function test_usd3CannotPullVaultFundsAutomatically() public {
+        _draw(DRAW);
+
+        vm.expectRevert();
+        vm.prank(address(strategy));
+        vault.withdraw(1e6, address(strategy), address(reserve));
+    }
+
+    function test_proposerRepaymentExecutesAfterDelay() public {
+        _draw(DRAW);
+
+        vm.prank(proposer);
+        reserve.scheduleProtocolRepayment(10_000e6);
+
+        vm.expectRevert(RevolvingCreditFacilityHolding.OperationNotReady.selector);
+        reserve.executeScheduledRepayment();
+
+        skip(7 days);
+
+        morpho.accrueInterest(reserveMarketParams);
+        uint256 debtBefore = reserve.outstandingDebtAssets();
+
+        reserve.executeScheduledRepayment();
+
+        assertEq(reserve.outstandingDebtAssets(), debtBefore - 10_000e6, "scheduled repayment should reduce debt");
+    }
+
+    function test_adminCanVetoProposerRepayment() public {
+        _draw(DRAW);
+
+        vm.prank(proposer);
+        reserve.scheduleProtocolRepayment(10_000e6);
+
+        vm.prank(admin);
+        reserve.vetoScheduledRepayment();
+
+        skip(7 days);
+
+        vm.expectRevert(RevolvingCreditFacilityHolding.InvalidOperation.selector);
+        reserve.executeScheduledRepayment();
+    }
+
+    function test_proposerCanOverwriteScheduledRepayment() public {
+        _draw(DRAW);
+
+        vm.prank(proposer);
+        reserve.scheduleProtocolRepayment(10_000e6);
+        (uint256 firstAmount, uint256 firstEta) = reserve.scheduledRepayment();
+
+        skip(1 days);
+
+        vm.prank(proposer);
+        reserve.scheduleProtocolRepayment(15_000e6);
+        (uint256 secondAmount, uint256 secondEta) = reserve.scheduledRepayment();
+
+        assertEq(firstAmount, 10_000e6, "first scheduled amount");
+        assertEq(secondAmount, 15_000e6, "overwritten scheduled amount");
+        assertEq(secondEta, block.timestamp + reserve.PROPOSER_DELAY(), "overwrite should reset eta");
+        assertGt(secondEta, firstEta, "new eta should be later");
+    }
+
+    function test_overwrittenRepaymentUsesLatestAmountAndTimer() public {
+        _draw(DRAW);
+
+        vm.prank(proposer);
+        reserve.scheduleProtocolRepayment(10_000e6);
+
+        skip(6 days);
+
+        vm.prank(proposer);
+        reserve.scheduleProtocolRepayment(15_000e6);
+
+        skip(1 days);
+
+        vm.expectRevert(RevolvingCreditFacilityHolding.OperationNotReady.selector);
+        reserve.executeScheduledRepayment();
+
+        skip(6 days);
+
+        morpho.accrueInterest(reserveMarketParams);
+        uint256 debtBefore = reserve.outstandingDebtAssets();
+
+        reserve.executeScheduledRepayment();
+
+        assertEq(reserve.outstandingDebtAssets(), debtBefore - 15_000e6, "latest repayment amount should execute");
+    }
+
+    function test_proposerCannotReleaseToOfframp() public {
+        _draw(DRAW);
+
+        vm.expectRevert();
+        vm.prank(proposer);
+        reserve.releaseToOfframp(10_000e6);
+    }
+
+    function test_fallbackRepayRequiresExpiredAdminHeartbeat() public {
+        _draw(DRAW);
+
+        skip(100 days);
+
+        vm.prank(admin);
+        reserve.adminPing();
+
+        skip(100 days);
+
+        vm.expectRevert(RevolvingCreditFacilityHolding.FallbackNotReady.selector);
+        reserve.fallbackRepay(10_000e6);
+
+        skip(80 days);
+        _postEmptyCycle();
+        morpho.accrueInterest(reserveMarketParams);
+        uint256 debtBefore = reserve.outstandingDebtAssets();
+
+        reserve.fallbackRepay(10_000e6);
+
+        assertEq(reserve.outstandingDebtAssets(), debtBefore - 10_000e6, "fallback repayment should reduce debt");
+    }
+
+    function test_repayCannotExceedOutstandingDebt() public {
+        _draw(DRAW);
+
+        vm.expectRevert(RevolvingCreditFacilityHolding.RepayAmountExceedsDebt.selector);
+        vm.prank(admin);
+        reserve.releaseToProtocol(DRAW + 1);
+    }
+
+    function test_rescueCannotRecoverProtectedAssets() public {
+        _draw(DRAW);
+
+        vm.expectRevert(RevolvingCreditFacilityHolding.ProtectedToken.selector);
+        vm.prank(admin);
+        reserve.rescueToken(address(vault), admin, 1);
+
+        deal(address(underlyingAsset), address(reserve), 1e6);
+
+        vm.expectRevert(RevolvingCreditFacilityHolding.ProtectedToken.selector);
+        vm.prank(admin);
+        reserve.rescueToken(address(underlyingAsset), admin, 1e6);
+    }
+
+    function test_reentrantWrapperCannotReenterFallbackRepay() public {
+        MaliciousVault maliciousVault = new MaliciousVault(address(underlyingAsset));
+        RevolvingCreditFacilityHolding maliciousReserve = _deployReserve(address(maliciousVault));
+        maliciousVault.setReserve(address(maliciousReserve));
+        _setReserveCredit(address(maliciousReserve), CREDIT);
+
+        vm.prank(admin);
+        maliciousReserve.drawAndInvest(DRAW);
+
+        skip(181 days);
+        _postEmptyCycle();
+        maliciousVault.setAttackEnabled(true);
+
+        vm.expectRevert();
+        maliciousReserve.fallbackRepay(10_000e6);
+    }
+
+    function _deployReserve(address vault_) internal returns (RevolvingCreditFacilityHolding deployedReserve) {
+        deployedReserve = new RevolvingCreditFacilityHolding(
+            admin, proposer, offRampRecipient, address(realHelper), vault_, reserveMarketParams
+        );
+    }
+
+    function _setReserveCredit(address borrower, uint256 credit) internal {
+        vm.prank(reserveMarketParams.creditLine);
+        morpho.setCreditLine(reserveMarketId, borrower, credit, 0);
+    }
+
+    function _postEmptyCycle() internal {
+        address[] memory borrowers = new address[](0);
+        uint256[] memory repaymentBps = new uint256[](0);
+        uint256[] memory endingBalances = new uint256[](0);
+
+        vm.prank(reserveMarketParams.creditLine);
+        morpho.closeCycleAndPostObligations(reserveMarketId, block.timestamp, borrowers, repaymentBps, endingBalances);
+    }
+
+    function _draw(uint256 amount) internal {
+        vm.prank(admin);
+        reserve.drawAndInvest(amount);
+    }
+}

--- a/test/forge/unit/RevolvingCreditFacilityHoldingTest.sol
+++ b/test/forge/unit/RevolvingCreditFacilityHoldingTest.sol
@@ -179,6 +179,7 @@ contract RevolvingCreditFacilityHoldingTest is Setup {
         reserve.emergencyRepay(type(uint256).max);
 
         assertEq(reserve.outstandingDebtAssets(), 0, "emergency repay should clear debt");
+        assertEq(IERC20(reserveMarketParams.loanToken).balanceOf(address(reserve)), 0, "loan-token dust should be zero");
         assertEq(vault.balanceOf(address(reserve)), 0, "vault shares should be fully withdrawn");
     }
 


### PR DESCRIPTION
## Summary
- New `RevolvingCreditFacilityHolding` contract: borrows USDC via Helper from a single Morpho market, deposits the proceeds into an ERC4626 yield vault, and exposes three repay paths (admin-immediate, proposer-scheduled with 7-day admin veto, permissionless 180-day fallback) plus an off-ramp release to a fixed recipient.
- Unit test suite at `test/forge/unit/RevolvingCreditFacilityHoldingTest.sol` covering draw/invest, partial and full repay, off-ramp release, proposer scheduling (execute / veto / overwrite), fallback timing gate, repay-exceeds-debt guard, protected-token rescue guard, and reentrancy.

## Test plan
- [x] `yarn build:forge` — clean
- [x] `yarn run test:forge --match-contract RevolvingCreditFacilityHoldingTest` — 14/14 pass