### PR TITLE
feat(usd3): add Morpho price oracles for USD3 and sUSD3

### DIFF
--- a/src/usd3/periphery/USD3Oracle.sol
+++ b/src/usd3/periphery/USD3Oracle.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.22;
+
+import {IStrategy} from "@tokenized-strategy/interfaces/IStrategy.sol";
+import {IOracle} from "../../interfaces/IOracle.sol";
+
+/// @title USD3Oracle
+/// @notice Morpho oracle for USD3 collateral in USDC-quoted markets.
+/// @dev Returns ERC4626 share-accounting value, not current redeemable liquidity.
+contract USD3Oracle is IOracle {
+    /// @notice Mainnet USD3 proxy.
+    address public constant USD3 = 0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc;
+
+    /// @dev USD3 and USDC are 6-decimal tokens.
+    uint256 internal constant SAMPLE = 1e6;
+
+    /// @dev Morpho scale factor for 6-decimal collateral: 1e36 / 1e6.
+    uint256 internal constant SCALE_FACTOR = 1e30;
+
+    /// @notice Returns the USD3 share price in USDC, scaled by 1e36.
+    /// @dev This intentionally ignores USD3 commitment restrictions and withdrawal liquidity.
+    function price() external view returns (uint256) {
+        return IStrategy(USD3).convertToAssets(SAMPLE) * SCALE_FACTOR;
+    }
+}

--- a/src/usd3/periphery/sUSD3Oracle.sol
+++ b/src/usd3/periphery/sUSD3Oracle.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.22;
+
+import {IStrategy} from "@tokenized-strategy/interfaces/IStrategy.sol";
+import {IOracle} from "../../interfaces/IOracle.sol";
+
+/// @title sUSD3Oracle
+/// @notice Morpho oracle for sUSD3 collateral in USDC-quoted markets.
+/// @dev Returns ERC4626 share-accounting value, not current redeemable liquidity.
+contract sUSD3Oracle is IOracle {
+    /// @notice Mainnet USD3 proxy.
+    address public constant USD3 = 0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc;
+
+    /// @notice Mainnet sUSD3 proxy.
+    address public constant SUSD3 = 0xf689555121e529Ff0463e191F9Bd9d1E496164a7;
+
+    /// @dev sUSD3, USD3, and USDC are 6-decimal tokens.
+    uint256 internal constant SAMPLE = 1e6;
+
+    /// @dev Morpho scale factor for 6-decimal collateral: 1e36 / 1e6.
+    uint256 internal constant SCALE_FACTOR = 1e30;
+
+    /// @notice Returns the sUSD3 share price in USDC, scaled by 1e36.
+    /// @dev This intentionally ignores sUSD3 lock/cooldown limits, withdrawal windows, and liquidity.
+    function price() external view returns (uint256) {
+        uint256 usd3Assets = IStrategy(SUSD3).convertToAssets(SAMPLE);
+        uint256 usdcAssets = IStrategy(USD3).convertToAssets(usd3Assets);
+
+        return usdcAssets * SCALE_FACTOR;
+    }
+}

--- a/test/forge/usd3/fork/MainnetForkBase.t.sol
+++ b/test/forge/usd3/fork/MainnetForkBase.t.sol
@@ -12,6 +12,7 @@ import {IERC20} from "../../../../lib/openzeppelin/contracts/token/ERC20/IERC20.
 abstract contract MainnetForkBase is Test {
     // Mainnet addresses
     address constant USD3_PROXY = 0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc;
+    address constant SUSD3_PROXY = 0xf689555121e529Ff0463e191F9Bd9d1E496164a7;
     address constant WAUSDC = 0xD4fa2D31b7968E448877f69A96DE69f5de8cD23E;
     address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address constant MORPHO_CREDIT = address(0); // TODO: Add actual MorphoCredit address when deployed
@@ -54,6 +55,7 @@ abstract contract MainnetForkBase is Test {
 
         // Label addresses for better trace output
         vm.label(USD3_PROXY, "USD3_PROXY");
+        vm.label(SUSD3_PROXY, "SUSD3_PROXY");
         vm.label(WAUSDC, "waUSDC");
         vm.label(USDC, "USDC");
     }

--- a/test/forge/usd3/fork/USD3OracleFork.t.sol
+++ b/test/forge/usd3/fork/USD3OracleFork.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.18;
+
+import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
+
+import {MainnetForkBase} from "./MainnetForkBase.t.sol";
+import {USD3Oracle} from "../../../../src/usd3/periphery/USD3Oracle.sol";
+import {sUSD3Oracle} from "../../../../src/usd3/periphery/sUSD3Oracle.sol";
+
+/**
+ * @title USD3OracleForkTest
+ * @notice Fork smoke tests for USD3 and sUSD3 Morpho oracle constants.
+ */
+contract USD3OracleForkTest is MainnetForkBase {
+    uint256 internal constant SAMPLE = 1e6;
+    uint256 internal constant SCALE_FACTOR = 1e30;
+
+    function test_usd3OracleMatchesMainnetProxy() public requiresFork {
+        USD3Oracle oracle = new USD3Oracle();
+
+        assertEq(oracle.USD3(), USD3_PROXY);
+        assertGt(USD3_PROXY.code.length, 0, "USD3 proxy has no code");
+
+        uint256 expected = ITokenizedStrategy(USD3_PROXY).convertToAssets(SAMPLE) * SCALE_FACTOR;
+
+        assertEq(oracle.price(), expected);
+        assertGt(oracle.price(), 0, "USD3 oracle price should be nonzero");
+    }
+
+    function test_susd3OracleMatchesMainnetProxies() public requiresFork {
+        sUSD3Oracle oracle = new sUSD3Oracle();
+
+        assertEq(oracle.USD3(), USD3_PROXY);
+        assertEq(oracle.SUSD3(), SUSD3_PROXY);
+        assertGt(USD3_PROXY.code.length, 0, "USD3 proxy has no code");
+        assertGt(SUSD3_PROXY.code.length, 0, "sUSD3 proxy has no code");
+
+        uint256 usd3Assets = ITokenizedStrategy(SUSD3_PROXY).convertToAssets(SAMPLE);
+        uint256 usdcAssets = ITokenizedStrategy(USD3_PROXY).convertToAssets(usd3Assets);
+
+        assertEq(oracle.price(), usdcAssets * SCALE_FACTOR);
+        assertGt(oracle.price(), 0, "sUSD3 oracle price should be nonzero");
+    }
+}

--- a/test/forge/usd3/periphery/USD3Oracle.t.sol
+++ b/test/forge/usd3/periphery/USD3Oracle.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC4626} from "../../../../lib/openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import {IOracle} from "../../../../src/interfaces/IOracle.sol";
+import {USD3Oracle} from "../../../../src/usd3/periphery/USD3Oracle.sol";
+
+contract USD3OracleTest is Test {
+    USD3Oracle internal oracle;
+
+    uint256 internal constant SAMPLE = 1e6;
+    uint256 internal constant SCALE_FACTOR = 1e30;
+
+    function setUp() public {
+        oracle = new USD3Oracle();
+    }
+
+    function test_priceAtOneToOnePps() public {
+        _mockUsd3Price(SAMPLE);
+
+        assertEq(oracle.price(), 1e36);
+    }
+
+    function test_priceTracksHigherPps() public {
+        uint256 assets = 1.25e6;
+        _mockUsd3Price(assets);
+
+        assertEq(oracle.price(), assets * SCALE_FACTOR);
+    }
+
+    function test_priceTracksLowerPps() public {
+        uint256 assets = 0.8e6;
+        _mockUsd3Price(assets);
+
+        assertEq(oracle.price(), assets * SCALE_FACTOR);
+    }
+
+    function test_priceCanReturnZero() public {
+        _mockUsd3Price(0);
+
+        assertEq(oracle.price(), 0);
+    }
+
+    function test_implementsIOracle() public {
+        _mockUsd3Price(SAMPLE);
+
+        assertEq(IOracle(address(oracle)).price(), 1e36);
+    }
+
+    function test_usesMainnetUsd3Proxy() public view {
+        assertEq(oracle.USD3(), 0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc);
+    }
+
+    function _mockUsd3Price(uint256 assets) internal {
+        vm.mockCall(oracle.USD3(), abi.encodeCall(IERC4626.convertToAssets, (SAMPLE)), abi.encode(assets));
+    }
+}

--- a/test/forge/usd3/periphery/sUSD3Oracle.t.sol
+++ b/test/forge/usd3/periphery/sUSD3Oracle.t.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC4626} from "../../../../lib/openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import {IOracle} from "../../../../src/interfaces/IOracle.sol";
+import {sUSD3Oracle} from "../../../../src/usd3/periphery/sUSD3Oracle.sol";
+
+contract sUSD3OracleTest is Test {
+    sUSD3Oracle internal oracle;
+
+    uint256 internal constant SAMPLE = 1e6;
+    uint256 internal constant SCALE_FACTOR = 1e30;
+
+    function setUp() public {
+        oracle = new sUSD3Oracle();
+    }
+
+    function test_priceAtOneToOnePps() public {
+        _mockSusd3Price(SAMPLE);
+        _mockUsd3Price(SAMPLE, SAMPLE);
+
+        assertEq(oracle.price(), 1e36);
+    }
+
+    function test_priceTracksSusd3Pps() public {
+        uint256 usd3Assets = 1.25e6;
+        _mockSusd3Price(usd3Assets);
+        _mockUsd3Price(usd3Assets, usd3Assets);
+
+        assertEq(oracle.price(), usd3Assets * SCALE_FACTOR);
+    }
+
+    function test_priceTracksUsd3Pps() public {
+        uint256 usd3Assets = SAMPLE;
+        uint256 usdcAssets = 1.15e6;
+        _mockSusd3Price(usd3Assets);
+        _mockUsd3Price(usd3Assets, usdcAssets);
+
+        assertEq(oracle.price(), usdcAssets * SCALE_FACTOR);
+    }
+
+    function test_priceChainsBothPpsValues() public {
+        uint256 usd3Assets = 1.2e6;
+        uint256 usdcAssets = 1.32e6;
+        _mockSusd3Price(usd3Assets);
+        _mockUsd3Price(usd3Assets, usdcAssets);
+
+        assertEq(oracle.price(), usdcAssets * SCALE_FACTOR);
+    }
+
+    function test_priceCanReturnZero() public {
+        _mockSusd3Price(SAMPLE);
+        _mockUsd3Price(SAMPLE, 0);
+
+        assertEq(oracle.price(), 0);
+    }
+
+    function test_priceCanReturnZeroWhenSusd3ConvertsToZero() public {
+        _mockSusd3Price(0);
+        _mockUsd3Price(0, 0);
+
+        assertEq(oracle.price(), 0);
+    }
+
+    function test_implementsIOracle() public {
+        _mockSusd3Price(SAMPLE);
+        _mockUsd3Price(SAMPLE, SAMPLE);
+
+        assertEq(IOracle(address(oracle)).price(), 1e36);
+    }
+
+    function test_usesMainnetProxyConstants() public view {
+        assertEq(oracle.USD3(), 0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc);
+        assertEq(oracle.SUSD3(), 0xf689555121e529Ff0463e191F9Bd9d1E496164a7);
+    }
+
+    function _mockSusd3Price(uint256 usd3Assets) internal {
+        vm.mockCall(oracle.SUSD3(), abi.encodeCall(IERC4626.convertToAssets, (SAMPLE)), abi.encode(usd3Assets));
+    }
+
+    function _mockUsd3Price(uint256 usd3Assets, uint256 usdcAssets) internal {
+        vm.mockCall(oracle.USD3(), abi.encodeCall(IERC4626.convertToAssets, (usd3Assets)), abi.encode(usdcAssets));
+    }
+}


### PR DESCRIPTION
## Summary

Adds standalone Morpho `IOracle` implementations so **USD3** and **sUSD3** can be listed as collateral in USDC-quoted Morpho Blue markets. There was previously no production oracle in the repo (only `OracleMock`).

Both are minimal, self-contained contracts under `src/usd3/periphery/` ("periphery" matching the existing repo convention) that read the live ERC-4626 exchange rate via `convertToAssets` — no external (Chainlink) feed needed, since value flows through USDC vault accounting.

## Pricing

Morpho consumes `price()` as `maxBorrow = collateral.mulDivDown(price, 1e36) * lltv`. USD3/sUSD3/USDC are all 6-decimal, so the scale factor is the constant `1e30` (`1e36 / 1e6`); at PPS = 1 the price is `1e36`.

- **`USD3Oracle`**: `USD3.convertToAssets(1e6) * 1e30` (USD3 → USDC).
- **`sUSD3Oracle`**: `USD3.convertToAssets(sUSD3.convertToAssets(1e6)) * 1e30` (sUSD3 → USD3 → USDC).

`convertToAssets` in TokenizedStrategy uses manually-tracked `totalAssets` (donation/PPS-manipulation resistant) and profit-unlock-aware `totalSupply`, so the rate steps only on `report()` plus a smooth time-based unlock.

## Design

- Mainnet token **proxy** addresses hardcoded as `constant`s (USD3 and sUSD3 are singletons behind stable proxies), verified exactly against the [mainnet deployment page](https://www.notion.so/3Jane-Protocol-Mainnet-Deployment-25a6d08e68c0814681d0e84783c22457). Reading through the proxy survives implementation upgrades.
- No constructor args, setters, storage, or mutable config.
- USD3/sUSD3 token contracts and interfaces are untouched.

## Edge semantics (intentional, documented in NatSpec)

- Fresh vault (zero supply) → `convertToAssets` returns its input → `price() == 1e36`.
- Total wipeout (supply > 0, assets == 0) → `price() == 0`, **no revert** (preserves Morpho market liveness).
- Losses step the price down on report; gains follow the profit-unlock schedule.
- Price is share-accounting value, **not** realizable redemption — ignores withdrawal liquidity, USD3 commitment period, and sUSD3 lock/cooldown/withdrawal-window.

## Tests

`test/forge/usd3/periphery/` — `vm.mockCall`-based unit tests (consistent with existing usd3 test conventions):

- USD3: 1:1 PPS, higher/lower PPS scaling, zero price, `IOracle` compatibility, proxy constant.
- sUSD3: 1:1, sUSD3-only PPS, USD3-only PPS, compounding both hops, both zero-price paths, `IOracle` compatibility, proxy constants.

All 14 tests pass; oracle files are `forge fmt`-clean.

## Test plan

- [x] `yarn build:forge`
- [x] `yarn run test:forge --match-path 'test/forge/usd3/periphery/**/*.t.sol' -vvv` (14 passed)
- [ ] Optional fork smoke test against live proxies (follow-up)