### PR TITLE
feat(usd3): KeeperRelayer — atomic USD3+sUSD3 reports with health checks

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -20,6 +20,19 @@ wrap_comments = true
 test = "/dev/null"
 script = "/dev/null"
 
+[profile.script]
+test = "/dev/null"
+ffi = true
+ast = true
+solc = "0.8.22"
+cbor_metadata = false
+fs_permissions = [
+  { access = "read-write", path = "." },
+  { access = "read", path = "/tmp" },
+]
+build_info = true
+extra_output = ["storageLayout"]
+
 [profile.test]
 via-ir = false
 script = "/dev/null"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:forge:snapshot": "FOUNDRY_PROFILE=test forge snapshot",
     "test:hardhat": "npx hardhat test",
     "test:halmos": "FOUNDRY_PROFILE=halmos halmos --function check_",
+    "script:forge": "FOUNDRY_PROFILE=script forge script",
     "lint": "yarn lint:forge && yarn lint:hardhat",
     "lint:forge": "forge fmt --check",
     "lint:hardhat": "prettier --check test/hardhat",

--- a/script/deploy/upgrade/v1.1.4-keeper/01_DeployKeeperRelayer.s.sol
+++ b/script/deploy/upgrade/v1.1.4-keeper/01_DeployKeeperRelayer.s.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.22;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {KeeperRelayer} from "../../../../src/usd3/KeeperRelayer.sol";
+import {IUSD3} from "../../../../src/usd3/interfaces/IUSD3.sol";
+
+/// @title DeployKeeperRelayer
+/// @notice Deploys the KeeperRelayer for the mainnet USD3/sUSD3 strategy pair.
+contract DeployKeeperRelayer is Script {
+    address private constant USD3 = 0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc;
+    address private constant SUSD3 = 0xf689555121e529Ff0463e191F9Bd9d1E496164a7;
+    address private constant DEFAULT_SAFE = 0x33333333Bd7045F1A601A1E289D7AB21036fB5EF;
+    address private constant THREE_JANE_DEPLOYER = 0x1226858E04b9d077258F153275613734421cD06B;
+
+    function run() external returns (address) {
+        require(USD3.code.length > 0, "USD3 has no code");
+
+        address linkedSusd3 = IUSD3(USD3).sUSD3();
+        require(linkedSusd3 == SUSD3, "USD3 sUSD3 link is not canonical sUSD3");
+        address[] memory keepers = new address[](2);
+        keepers[0] = THREE_JANE_DEPLOYER;
+        keepers[1] = DEFAULT_SAFE;
+
+        console2.log("=== Deploying KeeperRelayer ===");
+        console2.log("USD3:", USD3);
+        console2.log("On-chain sUSD3:", linkedSusd3);
+        console2.log("Keeper[0] (3Jane deployer):", keepers[0]);
+        console2.log("Keeper[1] (protocol Safe):", keepers[1]);
+        console2.log("");
+
+        vm.startBroadcast();
+
+        KeeperRelayer relayer = new KeeperRelayer{salt: "3jane"}(USD3, keepers);
+
+        vm.stopBroadcast();
+
+        console2.log("=== KeeperRelayer Deployed ===");
+        console2.log("Address:", address(relayer));
+        console2.log("sUSD3:", relayer.susd3());
+        console2.log("3Jane deployer keeper:", relayer.keepers(THREE_JANE_DEPLOYER));
+        console2.log("Protocol Safe keeper:", relayer.keepers(DEFAULT_SAFE));
+        console2.log("");
+
+        _logHealthCheck("USD3 health check", relayer, USD3);
+        _logHealthCheck("sUSD3 health check", relayer, linkedSusd3);
+
+        console2.log("");
+        console2.log("Next steps:");
+        console2.log("1. export KEEPER_RELAYER=%s", address(relayer));
+        console2.log(
+            "2. yarn script:forge script/deploy/upgrade/v1.1.4-keeper/02_SetRelayerKeeperSafe.s.sol --rpc-url $MAINNET_RPC_URL --sig 'run(bool)' false"
+        );
+
+        return address(relayer);
+    }
+
+    function _logHealthCheck(string memory label, KeeperRelayer relayer, address strategy) private view {
+        (uint32 profitLimitRatio, uint16 lossLimitRatio, bool doHealthCheck) = relayer.healthCheck(strategy);
+
+        console2.log(label);
+        console2.log("  strategy:", strategy);
+        console2.log("  profit limit ratio:", profitLimitRatio);
+        console2.log("  loss limit ratio:", lossLimitRatio);
+        console2.log("  enabled:", doHealthCheck);
+    }
+}

--- a/script/deploy/upgrade/v1.1.4-keeper/02_SetRelayerKeeperSafe.s.sol
+++ b/script/deploy/upgrade/v1.1.4-keeper/02_SetRelayerKeeperSafe.s.sol
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.22;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {SafeHelper} from "../../../utils/SafeHelper.sol";
+import {KeeperRelayer} from "../../../../src/usd3/KeeperRelayer.sol";
+
+interface ITokenizedStrategyKeeper {
+    function management() external view returns (address);
+    function keeper() external view returns (address);
+    function performanceFeeRecipient() external view returns (address);
+    function performanceFee() external view returns (uint16);
+    function setKeeper(address keeper) external;
+    function setPerformanceFeeRecipient(address performanceFeeRecipient) external;
+    function setPerformanceFee(uint16 performanceFee) external;
+}
+
+/// @title SetRelayerKeeperSafe
+/// @notice Configures the KeeperRelayer and report wiring for USD3 and sUSD3 via the protocol Safe.
+contract SetRelayerKeeperSafe is Script, SafeHelper {
+    address private constant DEFAULT_SAFE = 0x33333333Bd7045F1A601A1E289D7AB21036fB5EF;
+    address private constant USD3 = 0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc;
+    address private constant SUSD3 = 0xf689555121e529Ff0463e191F9Bd9d1E496164a7;
+
+    struct TokenKeeperStatus {
+        string label;
+        address token;
+        address management;
+        address currentKeeper;
+        bool needsUpdate;
+    }
+
+    struct WiringStatus {
+        address currentPerformanceFeeRecipient;
+        uint16 currentSusd3PerformanceFee;
+        bool performanceFeeRecipientNeedsUpdate;
+        bool susd3PerformanceFeeNeedsUpdate;
+    }
+
+    function run() external {
+        this.run(false);
+    }
+
+    function run(bool send) external isBatch(vm.envOr("SAFE_ADDRESS", DEFAULT_SAFE)) {
+        if (!_baseFeeOkay()) {
+            console2.log("Aborting: Base fee too high");
+            return;
+        }
+
+        address relayer = vm.envAddress("KEEPER_RELAYER");
+        _validateRelayer(relayer);
+
+        address safe = vm.envOr("SAFE_ADDRESS", DEFAULT_SAFE);
+        TokenKeeperStatus[2] memory statuses = _loadStatuses(safe, relayer);
+        WiringStatus memory wiring = _loadWiringStatus();
+        uint256 updates = _countUpdates(statuses, wiring);
+        require(updates > 0, "configuration already set");
+
+        _logStatuses("Set USD3/sUSD3 KeeperRelayer Configuration", statuses, wiring, relayer);
+        console2.log("Send to Safe:", send);
+        console2.log("");
+
+        _addSetKeeperIfNeeded(statuses[0], relayer);
+        _addSetKeeperIfNeeded(statuses[1], relayer);
+        _addPerformanceFeeRecipientIfNeeded(wiring);
+        _addSusd3PerformanceFeeIfNeeded(wiring);
+
+        if (send) {
+            console2.log("");
+            console2.log("Sending KeeperRelayer configuration transaction to Safe API...");
+            executeBatch(true);
+            console2.log("Transaction sent successfully.");
+        } else {
+            console2.log("");
+            console2.log("Simulation mode - not sending to Safe");
+            executeBatch(false);
+            console2.log("Simulation completed successfully.");
+        }
+    }
+
+    function preview() external view {
+        address relayer = vm.envAddress("KEEPER_RELAYER");
+        _validateRelayer(relayer);
+
+        address safe = vm.envOr("SAFE_ADDRESS", DEFAULT_SAFE);
+        _logStatuses(
+            "Preview USD3/sUSD3 KeeperRelayer Configuration", _loadStatuses(safe, relayer), _loadWiringStatus(), relayer
+        );
+    }
+
+    function verify() external view {
+        address relayer = vm.envAddress("KEEPER_RELAYER");
+        _validateRelayer(relayer);
+
+        address safe = vm.envOr("SAFE_ADDRESS", DEFAULT_SAFE);
+        TokenKeeperStatus[2] memory statuses = _loadStatuses(safe, relayer);
+        WiringStatus memory wiring = _loadWiringStatus();
+
+        require(statuses[0].currentKeeper == relayer, "USD3 keeper mismatch");
+        require(statuses[1].currentKeeper == relayer, "sUSD3 keeper mismatch");
+        require(wiring.currentPerformanceFeeRecipient == SUSD3, "USD3 performance fee recipient mismatch");
+        require(wiring.currentSusd3PerformanceFee == 0, "sUSD3 performance fee mismatch");
+
+        console2.log("=== Verify USD3/sUSD3 KeeperRelayer Configuration ===");
+        console2.log("Safe address:", safe);
+        console2.log("USD3 management:", statuses[0].management);
+        console2.log("sUSD3 management:", statuses[1].management);
+        console2.log("USD3 keeper:", statuses[0].currentKeeper);
+        console2.log("sUSD3 keeper:", statuses[1].currentKeeper);
+        console2.log("Expected keeper:", relayer);
+        console2.log("USD3 performance fee recipient:", wiring.currentPerformanceFeeRecipient);
+        console2.log("Expected performance fee recipient:", SUSD3);
+        console2.log("sUSD3 performance fee:", wiring.currentSusd3PerformanceFee);
+        console2.log("Expected sUSD3 performance fee:", uint256(0));
+    }
+
+    function _validateRelayer(address relayer) private view {
+        require(relayer.code.length > 0, "KEEPER_RELAYER has no code");
+        require(
+            KeeperRelayer(relayer).usd3() == USD3 && KeeperRelayer(relayer).susd3() == SUSD3,
+            "KEEPER_RELAYER strategy pair mismatch"
+        );
+    }
+
+    function _loadStatuses(address safe, address relayer) private view returns (TokenKeeperStatus[2] memory statuses) {
+        statuses[0] = _loadStatus("USD3", USD3, safe, relayer);
+        statuses[1] = _loadStatus("sUSD3", SUSD3, safe, relayer);
+    }
+
+    function _loadStatus(string memory label, address token, address safe, address relayer)
+        private
+        view
+        returns (TokenKeeperStatus memory status)
+    {
+        ITokenizedStrategyKeeper strategy = ITokenizedStrategyKeeper(token);
+        address management = strategy.management();
+        require(management == safe, string.concat(label, " management is not protocol Safe"));
+
+        address currentKeeper = strategy.keeper();
+        status = TokenKeeperStatus({
+            label: label,
+            token: token,
+            management: management,
+            currentKeeper: currentKeeper,
+            needsUpdate: currentKeeper != relayer
+        });
+    }
+
+    function _loadWiringStatus() private view returns (WiringStatus memory wiring) {
+        address currentPerformanceFeeRecipient = ITokenizedStrategyKeeper(USD3).performanceFeeRecipient();
+        uint16 currentSusd3PerformanceFee = ITokenizedStrategyKeeper(SUSD3).performanceFee();
+
+        wiring = WiringStatus({
+            currentPerformanceFeeRecipient: currentPerformanceFeeRecipient,
+            currentSusd3PerformanceFee: currentSusd3PerformanceFee,
+            performanceFeeRecipientNeedsUpdate: currentPerformanceFeeRecipient != SUSD3,
+            susd3PerformanceFeeNeedsUpdate: currentSusd3PerformanceFee != 0
+        });
+    }
+
+    function _addSetKeeperIfNeeded(TokenKeeperStatus memory status, address relayer) private {
+        if (!status.needsUpdate) {
+            console2.log("%s keeper already set; skipping", status.label);
+            return;
+        }
+
+        addToBatch(status.token, abi.encodeCall(ITokenizedStrategyKeeper.setKeeper, (relayer)));
+        console2.log("Added %s setKeeper call", status.label);
+    }
+
+    function _addPerformanceFeeRecipientIfNeeded(WiringStatus memory wiring) private {
+        if (!wiring.performanceFeeRecipientNeedsUpdate) {
+            console2.log("USD3 performance fee recipient already set; skipping");
+            return;
+        }
+
+        addToBatch(USD3, abi.encodeCall(ITokenizedStrategyKeeper.setPerformanceFeeRecipient, (SUSD3)));
+        console2.log("Added USD3 setPerformanceFeeRecipient call");
+    }
+
+    function _addSusd3PerformanceFeeIfNeeded(WiringStatus memory wiring) private {
+        if (!wiring.susd3PerformanceFeeNeedsUpdate) {
+            console2.log("sUSD3 performance fee already zero; skipping");
+            return;
+        }
+
+        addToBatch(SUSD3, abi.encodeCall(ITokenizedStrategyKeeper.setPerformanceFee, (0)));
+        console2.log("Added sUSD3 setPerformanceFee call");
+    }
+
+    function _countUpdates(TokenKeeperStatus[2] memory statuses, WiringStatus memory wiring)
+        private
+        pure
+        returns (uint256 updates)
+    {
+        for (uint256 i = 0; i < statuses.length; i++) {
+            if (statuses[i].needsUpdate) updates++;
+        }
+        if (wiring.performanceFeeRecipientNeedsUpdate) updates++;
+        if (wiring.susd3PerformanceFeeNeedsUpdate) updates++;
+    }
+
+    function _logStatuses(
+        string memory label,
+        TokenKeeperStatus[2] memory statuses,
+        WiringStatus memory wiring,
+        address relayer
+    ) private view {
+        console2.log("===", label, "===");
+        console2.log("Safe address:", vm.envOr("SAFE_ADDRESS", DEFAULT_SAFE));
+        console2.log("Target keeper:", relayer);
+        console2.log("");
+
+        for (uint256 i = 0; i < statuses.length; i++) {
+            console2.log(statuses[i].label);
+            console2.log("  token:", statuses[i].token);
+            console2.log("  management:", statuses[i].management);
+            console2.log("  current keeper:", statuses[i].currentKeeper);
+            console2.log("  target keeper:", relayer);
+            console2.log("  needs update:", statuses[i].needsUpdate);
+        }
+
+        console2.log("USD3 report wiring");
+        console2.log("  current performance fee recipient:", wiring.currentPerformanceFeeRecipient);
+        console2.log("  target performance fee recipient:", SUSD3);
+        console2.log("  needs update:", wiring.performanceFeeRecipientNeedsUpdate);
+        console2.log("sUSD3 report wiring");
+        console2.log("  current performance fee:", wiring.currentSusd3PerformanceFee);
+        console2.log("  target performance fee:", uint256(0));
+        console2.log("  needs update:", wiring.susd3PerformanceFeeNeedsUpdate);
+    }
+
+    function _baseFeeOkay() private view returns (bool) {
+        uint256 basefeeLimit = vm.envOr("BASE_FEE_LIMIT", uint256(50)) * 1e9;
+        if (block.basefee >= basefeeLimit) {
+            console2.log("Base fee too high: %d gwei > %d gwei limit", block.basefee / 1e9, basefeeLimit / 1e9);
+            return false;
+        }
+        console2.log("Base fee OK: %d gwei", block.basefee / 1e9);
+        return true;
+    }
+}

--- a/script/utils/SafeHelper.sol
+++ b/script/utils/SafeHelper.sol
@@ -105,8 +105,16 @@ abstract contract SafeHelper is Script, Test {
         bytes signature;
     }
 
+    struct SafeTransaction {
+        address to;
+        uint256 value;
+        bytes data;
+        Operation operation;
+    }
+
     // New struct to track a batch and its gas
     struct BatchData {
+        SafeTransaction[] transactions;
         bytes[] encodedTxns; // Array to store encoded transactions
         uint256 totalGas; // Total gas used by the batch
     }
@@ -122,15 +130,11 @@ abstract contract SafeHelper is Script, Test {
 
     constructor() {
         // Initialize first batch
-        batches.push(BatchData({encodedTxns: new bytes[](0), totalGas: 0}));
+        batches.push();
     }
 
     modifier isBatch(address safe_) {
-        // Set the Safe API base URL and multisend address based on chain
-        chainId = block.chainid;
-        SAFE_API_BASE_URL = "https://api.safe.global/tx-service/eth/api/v1/";
-        SAFE_MULTISEND_ADDRESS = 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D;
-        safe = safe_;
+        _configureSafe(safe_);
 
         // Load wallet information
         walletType = keccak256(abi.encodePacked(vm.envString("WALLET_TYPE")));
@@ -152,6 +156,14 @@ abstract contract SafeHelper is Script, Test {
             revert("Unsupported wallet type");
         }
         _;
+    }
+
+    function _configureSafe(address safe_) internal {
+        // Set the Safe API base URL and multisend address based on chain.
+        chainId = block.chainid;
+        SAFE_API_BASE_URL = "https://api.safe.global/tx-service/eth/api/v1/";
+        SAFE_MULTISEND_ADDRESS = 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D;
+        safe = safe_;
     }
 
     // Adds an encoded transaction to the batch.
@@ -177,12 +189,14 @@ abstract contract SafeHelper is Script, Test {
             // Only create a new batch if the current one has transactions
             if (batches[currentBatchIndex].encodedTxns.length > 0) {
                 currentBatchIndex++;
-                batches.push(BatchData({encodedTxns: new bytes[](0), totalGas: 0}));
+                batches.push();
             }
         }
 
         // Encode the transaction and add it to the current batch
         bytes memory encodedTxn = abi.encodePacked(Operation.CALL, to_, value_, data_.length, data_);
+        batches[currentBatchIndex].transactions
+            .push(SafeTransaction({to: to_, value: value_, data: data_, operation: Operation.CALL}));
         batches[currentBatchIndex].encodedTxns.push(encodedTxn);
         batches[currentBatchIndex].totalGas += gasUsed;
 
@@ -216,14 +230,25 @@ abstract contract SafeHelper is Script, Test {
     }
 
     // Creates a batch from the transactions at the specified index
-    function _createBatchFromIndex(uint256 batchIndex, uint256 nonce_) private view returns (Batch memory batch) {
+    function _createBatchFromIndex(uint256 batchIndex, uint256 nonce_) internal view returns (Batch memory batch) {
+        uint256 len = batches[batchIndex].encodedTxns.length;
+        if (len == 1) {
+            SafeTransaction storage transaction = batches[batchIndex].transactions[0];
+            batch.to = transaction.to;
+            batch.value = transaction.value;
+            batch.data = transaction.data;
+            batch.operation = transaction.operation;
+            batch.nonce = nonce_;
+            batch.txHash = _getTransactionHash(safe, batch);
+            return batch;
+        }
+
         batch.to = SAFE_MULTISEND_ADDRESS;
         batch.value = 0;
         batch.operation = Operation.DELEGATECALL;
 
         // Concatenate all encoded transactions into a single data payload
         bytes memory data;
-        uint256 len = batches[batchIndex].encodedTxns.length;
         for (uint256 i; i < len; ++i) {
             data = bytes.concat(data, batches[batchIndex].encodedTxns[i]);
         }

--- a/src/usd3/KeeperRelayer.sol
+++ b/src/usd3/KeeperRelayer.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.22;
+
+import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
+import {ErrorsLib} from "../libraries/ErrorsLib.sol";
+import {IUSD3} from "./interfaces/IUSD3.sol";
+
+/// @title KeeperRelayer
+/// @author 3Jane
+/// @custom:contact support@3jane.xyz
+/// @notice Atomically reports USD3 before sUSD3 for a configurable set of keeper accounts.
+/// @dev Administrative authorization follows USD3's live management address, deliberately including sUSD3's health
+/// configuration; the strategies are expected to share one management. USD3 health limits are denominated in
+/// USDC NAV, while sUSD3 health limits are denominated in USD3 shares. Junior loss limits must account for first-loss
+/// amplification, and junior profit limits must account for fee-mint amplification.
+/// @dev Disabling a health check skips only that strategy's next report, then automatically re-enables the check.
+/// ReportDeltaMismatch and wiring validation are always enforced.
+/// @dev Every report synchronizes USD3's tranche share before reporting either strategy. An invalid ProtocolConfig
+/// tranche share makes synchronization revert and fail-closes the report before either strategy records new state.
+contract KeeperRelayer {
+    uint256 internal constant MAX_BPS = 10_000;
+
+    address public immutable usd3;
+    address public immutable susd3;
+
+    mapping(address keeper => bool authorized) public keepers;
+
+    struct HealthCheckConfig {
+        uint32 profitLimitRatio;
+        uint16 lossLimitRatio;
+        bool doHealthCheck;
+    }
+
+    mapping(address strategy => HealthCheckConfig config) public healthCheck;
+
+    event KeeperSet(address indexed keeper, bool indexed authorized);
+    event ProfitLimitRatioSet(address indexed strategy, uint256 ratio);
+    event LossLimitRatioSet(address indexed strategy, uint256 ratio);
+    event DoHealthCheckSet(address indexed strategy, bool doHealthCheck);
+    event Reported(address indexed strategy, uint256 profit, uint256 loss, uint256 preTotalAssets, bool healthChecked);
+
+    error NotManagement(address caller);
+    error NotKeeper(address caller);
+    error InvalidStrategy(address strategy);
+    error HealthCheckFailed(address strategy, uint256 profit, uint256 loss, uint256 preTotalAssets);
+    error ReportDeltaMismatch(
+        address strategy, uint256 reportedProfit, uint256 reportedLoss, uint256 expectedProfit, uint256 expectedLoss
+    );
+    error RelayerNotKeeper(address strategy, address configuredKeeper);
+    error Susd3LinkMismatch(address actual);
+    error Susd3AssetMismatch(address actual);
+    error FeeRecipientNotSusd3(address actual);
+    error NonzeroSusd3PerformanceFee(uint256 fee);
+    error InvalidProfitLimit(uint256 ratio);
+    error InvalidLossLimit(uint256 ratio);
+
+    modifier onlyManagement() {
+        if (msg.sender != ITokenizedStrategy(usd3).management()) revert NotManagement(msg.sender);
+        _;
+    }
+
+    modifier onlyKeepers() {
+        if (!keepers[msg.sender] && msg.sender != ITokenizedStrategy(usd3).management()) revert NotKeeper(msg.sender);
+        _;
+    }
+
+    /// @notice Initializes the immutable strategy pair, keepers, and default health limits.
+    /// @param _usd3 Address of the USD3 strategy; sUSD3 is read from its configured link.
+    /// @param _keepers Initial accounts authorized to call keeper operations.
+    constructor(address _usd3, address[] memory _keepers) {
+        if (_usd3 == address(0)) revert ErrorsLib.ZeroAddress();
+        address _susd3 = IUSD3(_usd3).sUSD3();
+        if (_susd3 == address(0)) revert ErrorsLib.ZeroAddress();
+        address susd3Asset = ITokenizedStrategy(_susd3).asset();
+        if (susd3Asset != _usd3) revert Susd3AssetMismatch(susd3Asset);
+
+        usd3 = _usd3;
+        susd3 = _susd3;
+
+        address[2] memory strategies = [_usd3, _susd3];
+        for (uint256 i = 0; i < strategies.length; i++) {
+            healthCheck[strategies[i]] = HealthCheckConfig(uint32(MAX_BPS), 0, true);
+            emit ProfitLimitRatioSet(strategies[i], MAX_BPS);
+            emit LossLimitRatioSet(strategies[i], 0);
+        }
+
+        for (uint256 i = 0; i < _keepers.length; i++) {
+            _setKeeper(_keepers[i], true);
+        }
+    }
+
+    /// @notice Reports USD3 and then sUSD3 in the same transaction.
+    /// @return usd3Profit Profit reported by USD3 in USDC NAV units.
+    /// @return usd3Loss Loss reported by USD3 in USDC NAV units.
+    /// @return susd3Profit Profit reported by sUSD3 in USD3-share units.
+    /// @return susd3Loss Loss reported by sUSD3 in USD3-share units.
+    function report()
+        external
+        onlyKeepers
+        returns (uint256 usd3Profit, uint256 usd3Loss, uint256 susd3Profit, uint256 susd3Loss)
+    {
+        _validateWiring();
+        IUSD3(usd3).syncTrancheShare();
+
+        (usd3Profit, usd3Loss) = _reportStrategy(usd3);
+        (susd3Profit, susd3Loss) = _reportStrategy(susd3);
+    }
+
+    /// @notice Rebalances USD3 without recording a report or applying health checks.
+    function tend() external onlyKeepers {
+        ITokenizedStrategy(usd3).tend();
+    }
+
+    /// @notice Forwards USD3's tend trigger with calldata retargeted at this relayer's tend().
+    function tendTrigger() external view returns (bool shouldTend, bytes memory callData) {
+        (shouldTend,) = IUSD3(usd3).tendTrigger();
+        callData = abi.encodeWithSelector(this.tend.selector);
+    }
+
+    /// @notice Adds or removes an authorized keeper account.
+    function setKeeper(address keeper, bool authorized) external onlyManagement {
+        _setKeeper(keeper, authorized);
+    }
+
+    /// @notice Sets a strategy's maximum profit ratio for one report, in basis points of pre-report assets.
+    /// @dev Ratios above 10,000 are permitted; junior fee-mint amplification can exceed 100% legitimately.
+    function setProfitLimitRatio(address strategy, uint32 ratio) external onlyManagement {
+        HealthCheckConfig storage config = _config(strategy);
+        if (ratio == 0) revert InvalidProfitLimit(ratio);
+        config.profitLimitRatio = ratio;
+        emit ProfitLimitRatioSet(strategy, ratio);
+    }
+
+    /// @notice Sets a strategy's maximum loss ratio for one report, in basis points of pre-report assets.
+    function setLossLimitRatio(address strategy, uint16 ratio) external onlyManagement {
+        HealthCheckConfig storage config = _config(strategy);
+        if (ratio >= MAX_BPS) revert InvalidLossLimit(ratio);
+        config.lossLimitRatio = ratio;
+        emit LossLimitRatioSet(strategy, ratio);
+    }
+
+    /// @notice Enables or disables a strategy's health check for its next report.
+    function setDoHealthCheck(address strategy, bool doHealthCheck) external onlyManagement {
+        _config(strategy).doHealthCheck = doHealthCheck;
+        emit DoHealthCheckSet(strategy, doHealthCheck);
+    }
+
+    function _setKeeper(address keeper, bool authorized) internal {
+        if (keeper == address(0)) revert ErrorsLib.ZeroAddress();
+        if (keepers[keeper] == authorized) revert ErrorsLib.AlreadySet();
+        keepers[keeper] = authorized;
+        emit KeeperSet(keeper, authorized);
+    }
+
+    function _validateWiring() internal view {
+        address usd3Keeper = ITokenizedStrategy(usd3).keeper();
+        if (usd3Keeper != address(this)) revert RelayerNotKeeper(usd3, usd3Keeper);
+
+        address susd3Keeper = ITokenizedStrategy(susd3).keeper();
+        if (susd3Keeper != address(this)) revert RelayerNotKeeper(susd3, susd3Keeper);
+
+        _validatePair(usd3, susd3);
+
+        address feeRecipient = ITokenizedStrategy(usd3).performanceFeeRecipient();
+        if (feeRecipient != susd3) revert FeeRecipientNotSusd3(feeRecipient);
+
+        uint256 susd3PerformanceFee = ITokenizedStrategy(susd3).performanceFee();
+        if (susd3PerformanceFee != 0) revert NonzeroSusd3PerformanceFee(susd3PerformanceFee);
+    }
+
+    function _reportStrategy(address strategy) internal returns (uint256 profit, uint256 loss) {
+        ITokenizedStrategy tokenizedStrategy = ITokenizedStrategy(strategy);
+        uint256 preTotalAssets = tokenizedStrategy.totalAssets();
+        (profit, loss) = tokenizedStrategy.report();
+        uint256 postTotalAssets = tokenizedStrategy.totalAssets();
+
+        uint256 expectedProfit = postTotalAssets > preTotalAssets ? postTotalAssets - preTotalAssets : 0;
+        uint256 expectedLoss = preTotalAssets > postTotalAssets ? preTotalAssets - postTotalAssets : 0;
+        if (profit != expectedProfit || loss != expectedLoss) {
+            revert ReportDeltaMismatch(strategy, profit, loss, expectedProfit, expectedLoss);
+        }
+
+        HealthCheckConfig storage config = healthCheck[strategy];
+        bool checked = config.doHealthCheck;
+        if (checked) {
+            if (
+                profit > (preTotalAssets * config.profitLimitRatio) / MAX_BPS
+                    || loss > (preTotalAssets * config.lossLimitRatio) / MAX_BPS
+            ) {
+                revert HealthCheckFailed(strategy, profit, loss, preTotalAssets);
+            }
+        } else {
+            config.doHealthCheck = true;
+        }
+
+        emit Reported(strategy, profit, loss, preTotalAssets, checked);
+    }
+
+    function _config(address strategy) internal view returns (HealthCheckConfig storage config) {
+        if (strategy != usd3 && strategy != susd3) revert InvalidStrategy(strategy);
+        return healthCheck[strategy];
+    }
+
+    function _validatePair(address _usd3, address _susd3) private view {
+        address linkedSusd3 = IUSD3(_usd3).sUSD3();
+        if (linkedSusd3 != _susd3) revert Susd3LinkMismatch(linkedSusd3);
+
+        address susd3Asset = ITokenizedStrategy(_susd3).asset();
+        if (susd3Asset != _usd3) revert Susd3AssetMismatch(susd3Asset);
+    }
+}

--- a/src/usd3/KeeperRelayer.sol
+++ b/src/usd3/KeeperRelayer.sol
@@ -117,6 +117,36 @@ contract KeeperRelayer {
         callData = abi.encodeWithSelector(this.tend.selector);
     }
 
+    /// @notice Reports-due trigger: true once either strategy's profit-unlock window has elapsed
+    /// since its own last report. Cadence-eligible, not guaranteed-to-succeed — wiring and health
+    /// checks still fail closed in report(). Calldata must be executed against this relayer.
+    function reportTrigger() external view returns (bool shouldReport, bytes memory callData) {
+        callData = abi.encodeWithSelector(this.report.selector);
+
+        ITokenizedStrategy senior = ITokenizedStrategy(usd3);
+        ITokenizedStrategy junior = ITokenizedStrategy(susd3);
+
+        // Shutdown stops automatic cadence; manual reports through the relayer remain possible.
+        if (senior.isShutdown() || junior.isShutdown()) return (false, callData);
+
+        // A zero-asset senior leg is silenced while its health check is armed. The junior leg is only
+        // silenced while a senior fee mint could make its zero-base health check fail closed
+        // (senior.performanceFee() != 0); with a zero fee there is no revert risk, so the junior check
+        // does not block the trigger.
+        if (senior.totalAssets() == 0 && healthCheck[usd3].doHealthCheck) return (false, callData);
+        if (junior.totalAssets() == 0 && healthCheck[susd3].doHealthCheck && senior.performanceFee() != 0) {
+            return (false, callData);
+        }
+
+        shouldReport = _reportDue(senior) || _reportDue(junior);
+    }
+
+    function _reportDue(ITokenizedStrategy strategy) private view returns (bool) {
+        uint256 unlockTime = strategy.profitMaxUnlockTime();
+        // Zero unlock means no profit stream (used during migrations) — no time cadence for that leg.
+        return unlockTime != 0 && block.timestamp - strategy.lastReport() > unlockTime;
+    }
+
     /// @notice Adds or removes an authorized keeper account.
     function setKeeper(address keeper, bool authorized) external onlyManagement {
         _setKeeper(keeper, authorized);

--- a/test/forge/usd3/KeeperRelayer.t.sol
+++ b/test/forge/usd3/KeeperRelayer.t.sol
@@ -1,0 +1,955 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.22;
+
+import {Setup} from "./utils/Setup.sol";
+import {IUSD3} from "../../../src/usd3/interfaces/IUSD3.sol";
+import {ITokenizedStrategy} from "@tokenized-strategy/interfaces/ITokenizedStrategy.sol";
+import {KeeperRelayer} from "../../../src/usd3/KeeperRelayer.sol";
+import {USD3} from "../../../src/usd3/USD3.sol";
+import {sUSD3 as SUSD3Strategy} from "../../../src/usd3/sUSD3.sol";
+import {ErrorsLib} from "../../../src/libraries/ErrorsLib.sol";
+import {ERC20} from "../../../lib/openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Math} from "../../../lib/openzeppelin/contracts/utils/math/Math.sol";
+import {
+    TransparentUpgradeableProxy
+} from "../../../lib/openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "../../../lib/openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+contract MockRelayerStrategy {
+    address public asset;
+    address internal _susd3;
+    address public management;
+    address public keeper;
+    address public performanceFeeRecipient;
+    uint16 public performanceFee;
+    uint256 public totalAssets;
+    uint256 public reportCalls;
+    uint256 public tendCalls;
+
+    uint256 internal _nextTotalAssets;
+    uint256 internal _nextProfit;
+    uint256 internal _nextLoss;
+    bool internal _reportReverts;
+
+    error MockReportFailed(address strategy);
+    error MockNotKeeper();
+
+    constructor(uint256 initialTotalAssets) {
+        totalAssets = initialTotalAssets;
+        _nextTotalAssets = initialTotalAssets;
+    }
+
+    function setAsset(address newAsset) external {
+        asset = newAsset;
+    }
+
+    function setSUSD3(address newSusd3) external {
+        _susd3 = newSusd3;
+    }
+
+    function sUSD3() external view returns (address) {
+        return _susd3;
+    }
+
+    function setKeeper(address newKeeper) external {
+        keeper = newKeeper;
+    }
+
+    function setManagement(address newManagement) external {
+        management = newManagement;
+    }
+
+    function setPerformanceFeeRecipient(address newRecipient) external {
+        performanceFeeRecipient = newRecipient;
+    }
+
+    function setTotalAssets(uint256 newTotalAssets) external {
+        totalAssets = newTotalAssets;
+    }
+
+    function configureReport(uint256 newTotalAssets, uint256 profit, uint256 loss, bool shouldRevert) external {
+        _nextTotalAssets = newTotalAssets;
+        _nextProfit = profit;
+        _nextLoss = loss;
+        _reportReverts = shouldRevert;
+    }
+
+    function report() external returns (uint256 profit, uint256 loss) {
+        if (msg.sender != keeper) revert MockNotKeeper();
+        if (_reportReverts) revert MockReportFailed(address(this));
+        reportCalls++;
+        totalAssets = _nextTotalAssets;
+        return (_nextProfit, _nextLoss);
+    }
+
+    function tend() external {
+        if (msg.sender != keeper) revert MockNotKeeper();
+        tendCalls++;
+    }
+
+    bool internal _tendTriggerValue;
+
+    function setTendTrigger(bool value) external {
+        _tendTriggerValue = value;
+    }
+
+    function tendTrigger() external view returns (bool, bytes memory) {
+        return (_tendTriggerValue, abi.encodeWithSelector(this.tend.selector));
+    }
+
+    function syncTrancheShare() external view {
+        if (msg.sender != keeper) revert MockNotKeeper();
+    }
+}
+
+contract KeeperRelayerTest is Setup {
+    event KeeperSet(address indexed keeper, bool indexed authorized);
+    event ProfitLimitRatioSet(address indexed strategy, uint256 ratio);
+    event LossLimitRatioSet(address indexed strategy, uint256 ratio);
+    event Reported(address indexed strategy, uint256 profit, uint256 loss, uint256 preTotalAssets, bool healthChecked);
+
+    USD3 public usd3Strategy;
+    SUSD3Strategy public susd3Strategy;
+    KeeperRelayer public relayer;
+
+    address public backupKeeper = makeAddr("backupKeeper");
+    address public thirdKeeper = makeAddr("thirdKeeper");
+    address public random = makeAddr("random");
+    address public newManagement = makeAddr("newManagement");
+    address public alice = makeAddr("alice");
+    address public bob = makeAddr("bob");
+
+    uint256 internal constant SENIOR_DEPOSIT = 1_000_000e6;
+    uint256 internal constant JUNIOR_SOURCE_DEPOSIT = 100_000e6;
+
+    function setUp() public override {
+        super.setUp();
+        usd3Strategy = USD3(address(strategy));
+        _deploySUSD3AndRelayer();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         CONSTRUCTOR AND AUTH
+    //////////////////////////////////////////////////////////////*/
+
+    function test_constructor_revertsOnZeroAddresses() public {
+        address[] memory noKeepers = new address[](0);
+
+        vm.expectRevert(ErrorsLib.ZeroAddress.selector);
+        new KeeperRelayer(address(0), noKeepers);
+
+        MockRelayerStrategy unlinkedUsd3 = new MockRelayerStrategy(0);
+        vm.expectRevert(ErrorsLib.ZeroAddress.selector);
+        new KeeperRelayer(address(unlinkedUsd3), noKeepers);
+    }
+
+    function test_constructor_derivesSusd3AndRevertsOnAssetMismatch() public {
+        address[] memory noKeepers = new address[](0);
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3) = _configuredMockPair(0);
+
+        KeeperRelayer derived = new KeeperRelayer(address(mockUsd3), noKeepers);
+        assertEq(derived.susd3(), address(mockSusd3));
+
+        mockSusd3.setAsset(thirdKeeper);
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.Susd3AssetMismatch.selector, thirdKeeper));
+        new KeeperRelayer(address(mockUsd3), noKeepers);
+    }
+
+    function test_repointedSusd3LinkFailsClosedAtReport() public {
+        (MockRelayerStrategy mockUsd3,, KeeperRelayer mockRelayer) = _deployMockRelayer(10_000, keeper);
+        mockUsd3.setSUSD3(thirdKeeper);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.Susd3LinkMismatch.selector, thirdKeeper));
+        vm.prank(keeper);
+        mockRelayer.report();
+    }
+
+    function test_constructor_setsDefaultsAndInitialKeepers() public {
+        (uint32 usd3ProfitRatio, uint16 usd3LossRatio, bool usd3DoHealthCheck) =
+            relayer.healthCheck(address(usd3Strategy));
+        (uint32 susd3ProfitRatio, uint16 susd3LossRatio, bool susd3DoHealthCheck) =
+            relayer.healthCheck(address(susd3Strategy));
+
+        assertEq(usd3ProfitRatio, 10_000);
+        assertEq(usd3LossRatio, 0);
+        assertTrue(usd3DoHealthCheck);
+        assertEq(susd3ProfitRatio, 10_000);
+        assertEq(susd3LossRatio, 0);
+        assertTrue(susd3DoHealthCheck);
+        assertTrue(relayer.keepers(keeper));
+        assertTrue(relayer.keepers(backupKeeper));
+    }
+
+    function test_constructor_emitsDefaultLimitAndKeeperEvents() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3) = _configuredMockPair(0);
+        address[] memory initialKeepers = new address[](2);
+        initialKeepers[0] = keeper;
+        initialKeepers[1] = backupKeeper;
+
+        vm.expectEmit(true, false, false, true);
+        emit ProfitLimitRatioSet(address(mockUsd3), 10_000);
+        vm.expectEmit(true, false, false, true);
+        emit LossLimitRatioSet(address(mockUsd3), 0);
+        vm.expectEmit(true, false, false, true);
+        emit ProfitLimitRatioSet(address(mockSusd3), 10_000);
+        vm.expectEmit(true, false, false, true);
+        emit LossLimitRatioSet(address(mockSusd3), 0);
+        vm.expectEmit(true, true, false, true);
+        emit KeeperSet(keeper, true);
+        vm.expectEmit(true, true, false, true);
+        emit KeeperSet(backupKeeper, true);
+        new KeeperRelayer(address(mockUsd3), initialKeepers);
+    }
+
+    function test_constructor_revertsOnZeroOrDuplicateInitialKeeper() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3) = _configuredMockPair(0);
+        address[] memory initialKeepers = new address[](1);
+        initialKeepers[0] = address(0);
+
+        vm.expectRevert(ErrorsLib.ZeroAddress.selector);
+        new KeeperRelayer(address(mockUsd3), initialKeepers);
+
+        initialKeepers = new address[](2);
+        initialKeepers[0] = keeper;
+        initialKeepers[1] = keeper;
+
+        vm.expectRevert(ErrorsLib.AlreadySet.selector);
+        new KeeperRelayer(address(mockUsd3), initialKeepers);
+    }
+
+    function test_setKeeper_addRemoveAndGuards() public {
+        vm.expectEmit(true, true, false, true, address(relayer));
+        emit KeeperSet(thirdKeeper, true);
+        vm.prank(management);
+        relayer.setKeeper(thirdKeeper, true);
+        assertTrue(relayer.keepers(thirdKeeper));
+
+        vm.expectRevert(ErrorsLib.AlreadySet.selector);
+        vm.prank(management);
+        relayer.setKeeper(thirdKeeper, true);
+
+        vm.expectEmit(true, true, false, true, address(relayer));
+        emit KeeperSet(thirdKeeper, false);
+        vm.prank(management);
+        relayer.setKeeper(thirdKeeper, false);
+        assertFalse(relayer.keepers(thirdKeeper));
+
+        vm.expectRevert(ErrorsLib.AlreadySet.selector);
+        vm.prank(management);
+        relayer.setKeeper(thirdKeeper, false);
+
+        vm.expectRevert(ErrorsLib.ZeroAddress.selector);
+        vm.prank(management);
+        relayer.setKeeper(address(0), true);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            ACCESS CONTROL
+    //////////////////////////////////////////////////////////////*/
+
+    function test_nonKeeperCannotReportOrTend() public {
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.NotKeeper.selector, random));
+        vm.prank(random);
+        relayer.report();
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.NotKeeper.selector, random));
+        vm.prank(random);
+        relayer.tend();
+    }
+
+    function test_multipleKeepersCanReportAndTend() public {
+        vm.prank(keeper);
+        relayer.report();
+
+        vm.prank(backupKeeper);
+        relayer.report();
+
+        vm.prank(keeper);
+        relayer.tend();
+    }
+
+    function test_managementCanCallAllAdminAndKeeperOperations() public {
+        testProtocolConfig.setConfig(keccak256("TRANCHE_SHARE_VARIANT"), 3333);
+        assertFalse(relayer.keepers(management));
+
+        vm.startPrank(management);
+        relayer.setKeeper(thirdKeeper, true);
+        relayer.setProfitLimitRatio(address(usd3Strategy), 200_000);
+        relayer.setLossLimitRatio(address(usd3Strategy), 100);
+        relayer.setDoHealthCheck(address(susd3Strategy), false);
+        relayer.report();
+        relayer.tend();
+        vm.stopPrank();
+
+        assertTrue(relayer.keepers(thirdKeeper));
+        assertEq(ITokenizedStrategy(address(usd3Strategy)).performanceFee(), 3333);
+    }
+
+    function test_keepersAndRandomCannotCallAdminOperations() public {
+        _assertCannotCallAdmin(keeper);
+        _assertCannotCallAdmin(random);
+    }
+
+    function test_managementTransferUpdatesRelayerAuthorization() public {
+        vm.prank(management);
+        ITokenizedStrategy(address(usd3Strategy)).setPendingManagement(newManagement);
+        vm.prank(newManagement);
+        ITokenizedStrategy(address(usd3Strategy)).acceptManagement();
+
+        assertEq(ITokenizedStrategy(address(usd3Strategy)).management(), newManagement);
+
+        vm.prank(newManagement);
+        relayer.setKeeper(thirdKeeper, true);
+        assertTrue(relayer.keepers(thirdKeeper));
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.NotManagement.selector, management));
+        vm.prank(management);
+        relayer.setKeeper(backupKeeper, false);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.NotKeeper.selector, management));
+        vm.prank(management);
+        relayer.report();
+
+        vm.prank(newManagement);
+        relayer.report();
+    }
+
+    function test_reportSyncsTrancheShareBeforeFeeMint() public {
+        _seedSeniorAndJunior();
+        testProtocolConfig.setConfig(keccak256("TRANCHE_SHARE_VARIANT"), 3333);
+        uint256 juniorBalanceBefore = ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy));
+        _simulateYield(usd3Strategy, 10_000e6);
+
+        vm.prank(keeper);
+        (uint256 usd3Profit,, uint256 susd3Profit,) = relayer.report();
+
+        assertEq(ITokenizedStrategy(address(usd3Strategy)).performanceFee(), 3333);
+        assertEq(ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy)) - juniorBalanceBefore, susd3Profit);
+        assertApproxEqAbs(susd3Profit, (usd3Profit * 3333) / 10_000, 2);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                       ORDERING AND ATOMICITY
+    //////////////////////////////////////////////////////////////*/
+
+    function test_reportAccruedInterestReportsBothLegsInSameTransaction() public {
+        _seedSeniorAndJunior();
+        _simulateYield(usd3Strategy, 10_000e6);
+
+        vm.prank(keeper);
+        (uint256 usd3Profit, uint256 usd3Loss, uint256 susd3Profit, uint256 susd3Loss) = relayer.report();
+
+        assertGt(usd3Profit, 0);
+        assertEq(usd3Loss, 0);
+        assertGt(susd3Profit, 0);
+        assertEq(susd3Loss, 0);
+        assertEq(
+            ITokenizedStrategy(address(susd3Strategy)).totalAssets(),
+            ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy))
+        );
+    }
+
+    function test_emptyJuniorRecoversWithOneShotSusd3Skip() public {
+        mintAndDepositIntoStrategy(IUSD3(address(usd3Strategy)), alice, SENIOR_DEPOSIT);
+
+        vm.prank(keeper);
+        relayer.report();
+        assertEq(ITokenizedStrategy(address(susd3Strategy)).totalAssets(), 0);
+
+        _simulateYield(usd3Strategy, 5_000e6);
+
+        bool reportSucceeded;
+        bytes memory revertData;
+        try this.callReport() {
+            reportSucceeded = true;
+        } catch (bytes memory err) {
+            revertData = err;
+        }
+
+        assertFalse(reportSucceeded);
+        (bytes4 selector, address failedStrategy, uint256 profit, uint256 loss, uint256 preTotalAssets) =
+            _decodeHealthCheckFailed(revertData);
+        assertEq(selector, KeeperRelayer.HealthCheckFailed.selector);
+        assertEq(failedStrategy, address(susd3Strategy));
+        assertGt(profit, 0);
+        assertEq(loss, 0);
+        assertEq(preTotalAssets, 0);
+
+        vm.prank(management);
+        relayer.setDoHealthCheck(address(susd3Strategy), false);
+        vm.prank(backupKeeper);
+        (uint256 usd3Profit,, uint256 susd3Profit,) = relayer.report();
+
+        assertGt(usd3Profit, 0);
+        assertGt(susd3Profit, 0);
+        assertEq(ITokenizedStrategy(address(susd3Strategy)).totalAssets(), susd3Profit);
+        (,, bool doHealthCheck) = relayer.healthCheck(address(susd3Strategy));
+        assertTrue(doHealthCheck);
+
+        vm.prank(keeper);
+        (uint256 nextUsd3Profit, uint256 nextUsd3Loss, uint256 nextSusd3Profit, uint256 nextSusd3Loss) =
+            relayer.report();
+        assertEq(nextUsd3Profit, 0);
+        assertEq(nextUsd3Loss, 0);
+        assertEq(nextSusd3Profit, 0);
+        assertEq(nextSusd3Loss, 0);
+    }
+
+    function test_reportLossRecognizesJuniorBurnOnSecondLegInSameTransaction() public {
+        _seedSeniorAndJunior();
+        uint256 juniorBalanceBefore = ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy));
+        _simulateLoss(usd3Strategy, 5_000e6);
+        _setLossLimits(9000, 9000);
+
+        vm.prank(keeper);
+        (uint256 usd3Profit, uint256 usd3Loss, uint256 susd3Profit, uint256 susd3Loss) = relayer.report();
+
+        assertEq(usd3Profit, 0);
+        assertGt(usd3Loss, 0);
+        assertEq(susd3Profit, 0);
+        assertGt(susd3Loss, 0);
+        assertLt(ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy)), juniorBalanceBefore);
+        assertEq(
+            ITokenizedStrategy(address(susd3Strategy)).totalAssets(),
+            ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy))
+        );
+    }
+
+    function test_fullJuniorWipeRecoversWithOneShotSusd3Skip() public {
+        _seedSeniorAndJunior();
+        uint256 juniorAssetsBefore = ITokenizedStrategy(address(susd3Strategy)).totalAssets();
+        uint256 marketAssets = usd3Strategy.morphoCredit().market(usd3Strategy.marketId()).totalSupplyAssets;
+        assertGe(marketAssets, juniorAssetsBefore);
+        _simulateLoss(usd3Strategy, juniorAssetsBefore);
+        _setLossLimits(9000, 9999);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                KeeperRelayer.HealthCheckFailed.selector, susd3Strategy, 0, juniorAssetsBefore, juniorAssetsBefore
+            )
+        );
+        vm.prank(keeper);
+        relayer.report();
+
+        vm.prank(management);
+        relayer.setDoHealthCheck(address(susd3Strategy), false);
+        vm.prank(backupKeeper);
+        (, uint256 usd3Loss,, uint256 susd3Loss) = relayer.report();
+
+        assertGt(usd3Loss, 0);
+        assertEq(susd3Loss, juniorAssetsBefore);
+        assertEq(ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy)), 0);
+        assertEq(ITokenizedStrategy(address(susd3Strategy)).totalAssets(), 0);
+    }
+
+    function test_susd3LegFailureRollsBackUsd3ReportBurnTendAndMorphoPosition() public {
+        _seedSeniorAndJunior();
+        _simulateLoss(usd3Strategy, 5_000e6);
+        _setLossLimits(9000, 0);
+
+        uint256 usd3AssetsBefore = ITokenizedStrategy(address(usd3Strategy)).totalAssets();
+        uint256 usd3SupplyBefore = ERC20(address(usd3Strategy)).totalSupply();
+        uint256 susd3AssetsBefore = ITokenizedStrategy(address(susd3Strategy)).totalAssets();
+        uint256 susd3SupplyBefore = ERC20(address(susd3Strategy)).totalSupply();
+        uint256 susd3Usd3BalanceBefore = ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy));
+        uint256 morphoSharesBefore =
+            usd3Strategy.morphoCredit().position(usd3Strategy.marketId(), address(usd3Strategy)).supplyShares;
+        uint256 suppliedBefore = usd3Strategy.suppliedWaUSDC();
+        uint256 localWaUsdcBefore = usd3Strategy.balanceOfWaUSDC();
+
+        bool reportSucceeded;
+        bytes memory revertData;
+        try this.callReport() {
+            reportSucceeded = true;
+        } catch (bytes memory err) {
+            revertData = err;
+        }
+        assertFalse(reportSucceeded);
+        (bytes4 selector, address failedStrategy,,,) = _decodeHealthCheckFailed(revertData);
+        assertEq(selector, KeeperRelayer.HealthCheckFailed.selector);
+        assertEq(failedStrategy, address(susd3Strategy));
+
+        assertEq(ITokenizedStrategy(address(usd3Strategy)).totalAssets(), usd3AssetsBefore);
+        assertEq(ERC20(address(usd3Strategy)).totalSupply(), usd3SupplyBefore);
+        assertEq(ITokenizedStrategy(address(susd3Strategy)).totalAssets(), susd3AssetsBefore);
+        assertEq(ERC20(address(susd3Strategy)).totalSupply(), susd3SupplyBefore);
+        assertEq(ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy)), susd3Usd3BalanceBefore);
+        uint256 morphoSharesAfter =
+            usd3Strategy.morphoCredit().position(usd3Strategy.marketId(), address(usd3Strategy)).supplyShares;
+        assertEq(morphoSharesAfter, morphoSharesBefore);
+        assertEq(usd3Strategy.suppliedWaUSDC(), suppliedBefore);
+        assertEq(usd3Strategy.balanceOfWaUSDC(), localWaUsdcBefore);
+
+        vm.prank(management);
+        relayer.setLossLimitRatio(address(susd3Strategy), 9000);
+        vm.prank(keeper);
+        (, uint256 usd3Loss,, uint256 susd3Loss) = relayer.report();
+        assertGt(usd3Loss, 0);
+        assertGt(susd3Loss, 0);
+    }
+
+    function test_usd3LegFailureNeverReachesSusd3() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer) =
+            _deployMockRelayer(10_000, address(this));
+        mockUsd3.configureReport(10_000, 0, 0, true);
+        mockSusd3.configureReport(11_000, 1_000, 0, true);
+
+        vm.expectRevert(abi.encodeWithSelector(MockRelayerStrategy.MockReportFailed.selector, address(mockUsd3)));
+        mockRelayer.report();
+    }
+
+    function test_mockSecondLegFailureRevertsWithSecondLegError() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer) =
+            _deployMockRelayer(10_000, address(this));
+        mockUsd3.configureReport(10_100, 100, 0, false);
+        mockSusd3.configureReport(10_000, 0, 0, true);
+
+        vm.expectRevert(abi.encodeWithSelector(MockRelayerStrategy.MockReportFailed.selector, address(mockSusd3)));
+        mockRelayer.report();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            HEALTH CHECKS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_profitAtLimitPassesAndOneAboveRevertsForBothStrategies() public {
+        _assertBoundary(false, false);
+        _assertBoundary(true, false);
+    }
+
+    function test_lossAtMulDivLimitPassesAndOneAboveRevertsForBothStrategies() public {
+        _assertBoundary(false, true);
+        _assertBoundary(true, true);
+    }
+
+    function test_zeroLossLimitRejectsOneWei() public {
+        (MockRelayerStrategy mockUsd3,, KeeperRelayer mockRelayer) = _deployMockRelayer(100, address(this));
+        mockUsd3.configureReport(99, 0, 1, false);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.HealthCheckFailed.selector, mockUsd3, 0, 1, 100));
+        mockRelayer.report();
+    }
+
+    function test_limitsAreIndependentPerStrategy() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer) =
+            _deployMockRelayer(10_000, address(this));
+        mockRelayer.setProfitLimitRatio(address(mockUsd3), 1000);
+        mockRelayer.setProfitLimitRatio(address(mockSusd3), 500);
+        mockUsd3.configureReport(11_000, 1_000, 0, false);
+        mockSusd3.configureReport(10_501, 501, 0, false);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.HealthCheckFailed.selector, mockSusd3, 501, 0, 10_000));
+        mockRelayer.report();
+
+        assertEq(mockUsd3.totalAssets(), 10_000);
+        assertEq(mockSusd3.totalAssets(), 10_000);
+    }
+
+    function test_profitLimitAboveUint16AllowsAmplifiedJuniorFeeMint() public {
+        _seedSeniorAndJunior(100e6);
+        uint256 preTotalAssets = ITokenizedStrategy(address(susd3Strategy)).totalAssets();
+
+        vm.prank(management);
+        relayer.setProfitLimitRatio(address(susd3Strategy), 200_000);
+        _simulateYield(usd3Strategy, 10_000e6);
+
+        vm.prank(keeper);
+        (,, uint256 susd3Profit, uint256 susd3Loss) = relayer.report();
+
+        assertGt(susd3Profit, Math.mulDiv(preTotalAssets, type(uint16).max, 10_000));
+        assertLe(susd3Profit, Math.mulDiv(preTotalAssets, 200_000, 10_000));
+        assertEq(susd3Loss, 0);
+    }
+
+    function test_oneShotSkipIsPerLegConsumedByNextKeeperAndAutoReenables() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer) =
+            _deployMockRelayer(10_000, keeper);
+        mockRelayer.setProfitLimitRatio(address(mockUsd3), 1);
+        mockRelayer.setProfitLimitRatio(address(mockSusd3), 1);
+        mockUsd3.configureReport(11_000, 1_000, 0, false);
+        mockSusd3.configureReport(11_000, 1_000, 0, false);
+        mockRelayer.setDoHealthCheck(address(mockSusd3), false);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.HealthCheckFailed.selector, mockUsd3, 1_000, 0, 10_000));
+        vm.prank(keeper);
+        mockRelayer.report();
+
+        (,, bool doHealthCheckAfterRevert) = mockRelayer.healthCheck(address(mockSusd3));
+        assertFalse(doHealthCheckAfterRevert);
+
+        mockUsd3.configureReport(10_000, 0, 0, false);
+        vm.expectEmit(true, false, false, true, address(mockRelayer));
+        emit Reported(address(mockUsd3), 0, 0, 10_000, true);
+        vm.expectEmit(true, false, false, true, address(mockRelayer));
+        emit Reported(address(mockSusd3), 1_000, 0, 10_000, false);
+        vm.prank(keeper);
+        mockRelayer.report();
+
+        (,, bool doHealthCheckAfterSkip) = mockRelayer.healthCheck(address(mockSusd3));
+        assertTrue(doHealthCheckAfterSkip);
+
+        mockSusd3.setTotalAssets(10_000);
+        mockSusd3.configureReport(11_000, 1_000, 0, false);
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.HealthCheckFailed.selector, mockSusd3, 1_000, 0, 10_000));
+        vm.prank(keeper);
+        mockRelayer.report();
+    }
+
+    function test_nearTotalWipeRevertsUnlessSkipArmed() public {
+        (MockRelayerStrategy mockUsd3,, KeeperRelayer mockRelayer) = _deployMockRelayer(3, keeper);
+        mockUsd3.configureReport(1, 0, 2, false);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.HealthCheckFailed.selector, mockUsd3, 0, 2, 3));
+        vm.prank(keeper);
+        mockRelayer.report();
+
+        mockRelayer.setDoHealthCheck(address(mockUsd3), false);
+        vm.prank(keeper);
+        mockRelayer.report();
+        assertEq(mockUsd3.totalAssets(), 1);
+    }
+
+    function test_reportDeltaMismatchAlwaysRevertsWhenSkipArmed() public {
+        (MockRelayerStrategy mockUsd3,, KeeperRelayer mockRelayer) = _deployMockRelayer(10_000, address(this));
+        mockUsd3.configureReport(10_010, 11, 0, false);
+        mockRelayer.setDoHealthCheck(address(mockUsd3), false);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.ReportDeltaMismatch.selector, mockUsd3, 11, 0, 10, 0));
+        mockRelayer.report();
+    }
+
+    function test_healthSettersValidateStrategyAndBounds() public {
+        vm.startPrank(management);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.InvalidStrategy.selector, random));
+        relayer.setProfitLimitRatio(random, 1);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.InvalidStrategy.selector, random));
+        relayer.setLossLimitRatio(random, 1);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.InvalidStrategy.selector, random));
+        relayer.setDoHealthCheck(random, false);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.InvalidProfitLimit.selector, 0));
+        relayer.setProfitLimitRatio(address(usd3Strategy), 0);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.InvalidLossLimit.selector, 10_000));
+        relayer.setLossLimitRatio(address(usd3Strategy), 10_000);
+
+        vm.expectEmit(true, false, false, true, address(relayer));
+        emit ProfitLimitRatioSet(address(usd3Strategy), type(uint32).max);
+        relayer.setProfitLimitRatio(address(usd3Strategy), type(uint32).max);
+
+        vm.expectEmit(true, false, false, true, address(relayer));
+        emit LossLimitRatioSet(address(usd3Strategy), 9999);
+        relayer.setLossLimitRatio(address(usd3Strategy), 9999);
+        relayer.setDoHealthCheck(address(usd3Strategy), false);
+        vm.stopPrank();
+
+        (uint32 profitRatio, uint16 lossRatio, bool doHealthCheck) = relayer.healthCheck(address(usd3Strategy));
+        assertEq(profitRatio, type(uint32).max);
+        assertEq(lossRatio, 9999);
+        assertFalse(doHealthCheck);
+    }
+
+    function testFuzz_profitLimitUsesFloorRounding(uint128 rawPreAssets, uint32 rawRatio) public {
+        uint256 preAssets = bound(uint256(rawPreAssets), 1, type(uint128).max);
+        uint32 ratio = uint32(bound(uint256(rawRatio), 1, type(uint32).max));
+        uint256 limit = Math.mulDiv(preAssets, ratio, 10_000);
+        (MockRelayerStrategy mockUsd3,, KeeperRelayer mockRelayer) = _deployMockRelayer(preAssets, address(this));
+        mockRelayer.setProfitLimitRatio(address(mockUsd3), ratio);
+        mockUsd3.configureReport(preAssets + limit, limit, 0, false);
+
+        mockRelayer.report();
+
+        mockUsd3.setTotalAssets(preAssets);
+        mockUsd3.configureReport(preAssets + limit + 1, limit + 1, 0, false);
+        vm.expectRevert(
+            abi.encodeWithSelector(KeeperRelayer.HealthCheckFailed.selector, mockUsd3, limit + 1, 0, preAssets)
+        );
+        mockRelayer.report();
+    }
+
+    function testFuzz_fullWipeAlwaysFailsHealthCheck(uint128 rawPreAssets, uint16 rawRatio) public {
+        uint256 preAssets = bound(uint256(rawPreAssets), 1, type(uint128).max);
+        uint16 ratio = uint16(bound(uint256(rawRatio), 0, 9999));
+        (MockRelayerStrategy mockUsd3,, KeeperRelayer mockRelayer) = _deployMockRelayer(preAssets, address(this));
+        mockRelayer.setLossLimitRatio(address(mockUsd3), ratio);
+        mockUsd3.configureReport(0, 0, preAssets, false);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(KeeperRelayer.HealthCheckFailed.selector, mockUsd3, 0, preAssets, preAssets)
+        );
+        mockRelayer.report();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          WIRING AND EDGES
+    //////////////////////////////////////////////////////////////*/
+
+    function test_repointedKeeperFailsClosedBeforeStateChanges() public {
+        _seedSeniorAndJunior();
+        _simulateYield(usd3Strategy, 1_000e6);
+        uint256 usd3AssetsBefore = ITokenizedStrategy(address(usd3Strategy)).totalAssets();
+        uint256 susd3AssetsBefore = ITokenizedStrategy(address(susd3Strategy)).totalAssets();
+
+        vm.prank(management);
+        ITokenizedStrategy(address(usd3Strategy)).setKeeper(thirdKeeper);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.RelayerNotKeeper.selector, usd3Strategy, thirdKeeper));
+        vm.prank(keeper);
+        relayer.report();
+
+        assertEq(ITokenizedStrategy(address(usd3Strategy)).totalAssets(), usd3AssetsBefore);
+        assertEq(ITokenizedStrategy(address(susd3Strategy)).totalAssets(), susd3AssetsBefore);
+    }
+
+    function test_repointedFeeRecipientFailsClosed() public {
+        vm.prank(management);
+        ITokenizedStrategy(address(usd3Strategy)).setPerformanceFeeRecipient(thirdKeeper);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.FeeRecipientNotSusd3.selector, thirdKeeper));
+        vm.prank(keeper);
+        relayer.report();
+    }
+
+    function test_nonzeroSusd3PerformanceFeeFailsClosed() public {
+        vm.prank(management);
+        ITokenizedStrategy(address(susd3Strategy)).setPerformanceFee(1);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.NonzeroSusd3PerformanceFee.selector, 1));
+        vm.prank(keeper);
+        relayer.report();
+    }
+
+    function test_tendTriggerForwardsUsd3StateWithRelayerCalldata() public {
+        (MockRelayerStrategy mockUsd3,, KeeperRelayer mockRelayer) = _deployMockRelayer(10_000, keeper);
+
+        (bool shouldTend, bytes memory callData) = mockRelayer.tendTrigger();
+        assertFalse(shouldTend);
+        assertEq(callData, abi.encodeWithSelector(KeeperRelayer.tend.selector));
+
+        mockUsd3.setTendTrigger(true);
+        (shouldTend, callData) = mockRelayer.tendTrigger();
+        assertTrue(shouldTend);
+        assertEq(callData, abi.encodeWithSelector(KeeperRelayer.tend.selector));
+    }
+
+    function test_tendTriggerCalldataExecutesTendOnRelayer() public {
+        _seedSeniorAndJunior();
+        (bool shouldTend, bytes memory callData) = relayer.tendTrigger();
+        assertFalse(shouldTend);
+
+        setMaxOnCredit(5_000);
+        (bool usd3ShouldTend,) = IUSD3(address(usd3Strategy)).tendTrigger();
+        (shouldTend, callData) = relayer.tendTrigger();
+        assertEq(shouldTend, usd3ShouldTend);
+        assertTrue(shouldTend);
+
+        uint256 deployedBefore = usd3Strategy.suppliedWaUSDC();
+        vm.prank(keeper);
+        (bool success,) = address(relayer).call(callData);
+        assertTrue(success);
+        assertLt(usd3Strategy.suppliedWaUSDC(), deployedBefore);
+
+        (shouldTend,) = relayer.tendTrigger();
+        assertFalse(shouldTend);
+    }
+
+    function test_managementCanStillDirectReportOutsideRelayer() public {
+        assertEq(ITokenizedStrategy(address(usd3Strategy)).keeper(), address(relayer));
+
+        vm.prank(management);
+        ITokenizedStrategy(address(usd3Strategy)).report();
+    }
+
+    function test_usd3DonationToSusd3RecoversWithOneShotSkip() public {
+        _seedSeniorAndJunior();
+        vm.prank(management);
+        relayer.setProfitLimitRatio(address(susd3Strategy), 100);
+
+        uint256 donation = 1_000e6;
+        uint256 preTotalAssets = ITokenizedStrategy(address(susd3Strategy)).totalAssets();
+        vm.prank(alice);
+        ERC20(address(usd3Strategy)).transfer(address(susd3Strategy), donation);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(KeeperRelayer.HealthCheckFailed.selector, susd3Strategy, donation, 0, preTotalAssets)
+        );
+        vm.prank(keeper);
+        relayer.report();
+
+        vm.prank(management);
+        relayer.setDoHealthCheck(address(susd3Strategy), false);
+        vm.prank(backupKeeper);
+        relayer.report();
+
+        assertEq(
+            ITokenizedStrategy(address(susd3Strategy)).totalAssets(),
+            ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy))
+        );
+    }
+
+    function test_shutdownStrategiesStillReport() public {
+        _seedSeniorAndJunior();
+        vm.startPrank(management);
+        ITokenizedStrategy(address(usd3Strategy)).shutdownStrategy();
+        ITokenizedStrategy(address(susd3Strategy)).shutdownStrategy();
+        vm.stopPrank();
+
+        vm.prank(keeper);
+        relayer.report();
+
+        assertTrue(ITokenizedStrategy(address(usd3Strategy)).isShutdown());
+        assertTrue(ITokenizedStrategy(address(susd3Strategy)).isShutdown());
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                               HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    function callReport() external {
+        vm.prank(keeper);
+        relayer.report();
+    }
+
+    function _decodeHealthCheckFailed(bytes memory revertData)
+        internal
+        view
+        returns (bytes4 selector, address failedStrategy, uint256 profit, uint256 loss, uint256 preTotalAssets)
+    {
+        return this.decodeHealthCheckFailedCalldata(revertData);
+    }
+
+    function decodeHealthCheckFailedCalldata(bytes calldata revertData)
+        external
+        pure
+        returns (bytes4 selector, address failedStrategy, uint256 profit, uint256 loss, uint256 preTotalAssets)
+    {
+        selector = bytes4(revertData[:4]);
+        (failedStrategy, profit, loss, preTotalAssets) =
+            abi.decode(revertData[4:], (address, uint256, uint256, uint256));
+    }
+
+    function _deploySUSD3AndRelayer() internal {
+        SUSD3Strategy susd3Implementation = new SUSD3Strategy();
+        ProxyAdmin susd3ProxyAdmin = new ProxyAdmin(management);
+        bytes memory susd3InitData =
+            abi.encodeWithSelector(SUSD3Strategy.initialize.selector, address(usd3Strategy), management, keeper);
+        TransparentUpgradeableProxy susd3Proxy =
+            new TransparentUpgradeableProxy(address(susd3Implementation), address(susd3ProxyAdmin), susd3InitData);
+        susd3Strategy = SUSD3Strategy(address(susd3Proxy));
+
+        vm.startPrank(management);
+        usd3Strategy.setSUSD3(address(susd3Strategy));
+        ITokenizedStrategy(address(usd3Strategy)).setPerformanceFeeRecipient(address(susd3Strategy));
+        ITokenizedStrategy(address(susd3Strategy)).setPerformanceFee(0);
+        vm.stopPrank();
+
+        vm.prank(keeper);
+        usd3Strategy.syncTrancheShare();
+
+        address[] memory initialKeepers = new address[](2);
+        initialKeepers[0] = keeper;
+        initialKeepers[1] = backupKeeper;
+        relayer = new KeeperRelayer(address(usd3Strategy), initialKeepers);
+
+        vm.startPrank(management);
+        ITokenizedStrategy(address(usd3Strategy)).setKeeper(address(relayer));
+        ITokenizedStrategy(address(susd3Strategy)).setKeeper(address(relayer));
+        vm.stopPrank();
+    }
+
+    function _seedSeniorAndJunior() internal {
+        _seedSeniorAndJunior(0);
+    }
+
+    function _seedSeniorAndJunior(uint256 juniorDeposit) internal {
+        mintAndDepositIntoStrategy(IUSD3(address(usd3Strategy)), alice, SENIOR_DEPOSIT);
+        mintAndDepositIntoStrategy(IUSD3(address(usd3Strategy)), bob, JUNIOR_SOURCE_DEPOSIT);
+
+        if (juniorDeposit == 0) juniorDeposit = ERC20(address(usd3Strategy)).balanceOf(bob) / 5;
+        vm.startPrank(bob);
+        ERC20(address(usd3Strategy)).approve(address(susd3Strategy), juniorDeposit);
+        susd3Strategy.deposit(juniorDeposit, bob);
+        vm.stopPrank();
+
+        vm.prank(keeper);
+        relayer.report();
+    }
+
+    function _setLossLimits(uint16 usd3Ratio, uint16 susd3Ratio) internal {
+        vm.startPrank(management);
+        relayer.setLossLimitRatio(address(usd3Strategy), usd3Ratio);
+        relayer.setLossLimitRatio(address(susd3Strategy), susd3Ratio);
+        vm.stopPrank();
+    }
+
+    function _assertCannotCallAdmin(address caller) internal {
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.NotManagement.selector, caller));
+        vm.prank(caller);
+        relayer.setKeeper(thirdKeeper, true);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.NotManagement.selector, caller));
+        vm.prank(caller);
+        relayer.setProfitLimitRatio(address(usd3Strategy), 1);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.NotManagement.selector, caller));
+        vm.prank(caller);
+        relayer.setLossLimitRatio(address(usd3Strategy), 1);
+
+        vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.NotManagement.selector, caller));
+        vm.prank(caller);
+        relayer.setDoHealthCheck(address(usd3Strategy), false);
+    }
+
+    function _configuredMockPair(uint256 assets)
+        internal
+        returns (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3)
+    {
+        mockUsd3 = new MockRelayerStrategy(assets);
+        mockSusd3 = new MockRelayerStrategy(assets);
+        mockUsd3.setSUSD3(address(mockSusd3));
+        mockUsd3.setPerformanceFeeRecipient(address(mockSusd3));
+        mockSusd3.setAsset(address(mockUsd3));
+        mockUsd3.configureReport(assets, 0, 0, false);
+        mockSusd3.configureReport(assets, 0, 0, false);
+    }
+
+    function _deployMockRelayer(uint256 assets, address authorizedKeeper)
+        internal
+        returns (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer)
+    {
+        (mockUsd3, mockSusd3) = _configuredMockPair(assets);
+        mockUsd3.setManagement(address(this));
+        address[] memory initialKeepers = new address[](1);
+        initialKeepers[0] = authorizedKeeper;
+        mockRelayer = new KeeperRelayer(address(mockUsd3), initialKeepers);
+        mockUsd3.setKeeper(address(mockRelayer));
+        mockSusd3.setKeeper(address(mockRelayer));
+    }
+
+    function _assertBoundary(bool junior, bool isLoss) internal {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer) =
+            _deployMockRelayer(10_000, address(this));
+        MockRelayerStrategy target = junior ? mockSusd3 : mockUsd3;
+        if (isLoss) {
+            mockRelayer.setLossLimitRatio(address(target), 1000);
+        } else {
+            mockRelayer.setProfitLimitRatio(address(target), 1000);
+        }
+
+        target.configureReport(isLoss ? 9_000 : 11_000, isLoss ? 0 : 1_000, isLoss ? 1_000 : 0, false);
+        mockRelayer.report();
+
+        target.setTotalAssets(10_000);
+        target.configureReport(isLoss ? 8_999 : 11_001, isLoss ? 0 : 1_001, isLoss ? 1_001 : 0, false);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                KeeperRelayer.HealthCheckFailed.selector, target, isLoss ? 0 : 1_001, isLoss ? 1_001 : 0, 10_000
+            )
+        );
+        mockRelayer.report();
+    }
+}

--- a/test/forge/usd3/KeeperRelayer.t.sol
+++ b/test/forge/usd3/KeeperRelayer.t.sol
@@ -23,6 +23,9 @@ contract MockRelayerStrategy {
     address public performanceFeeRecipient;
     uint16 public performanceFee;
     uint256 public totalAssets;
+    uint256 public lastReport;
+    uint256 public profitMaxUnlockTime;
+    bool public isShutdown;
     uint256 public reportCalls;
     uint256 public tendCalls;
 
@@ -37,6 +40,8 @@ contract MockRelayerStrategy {
     constructor(uint256 initialTotalAssets) {
         totalAssets = initialTotalAssets;
         _nextTotalAssets = initialTotalAssets;
+        lastReport = block.timestamp;
+        profitMaxUnlockTime = 10 days;
     }
 
     function setAsset(address newAsset) external {
@@ -63,8 +68,24 @@ contract MockRelayerStrategy {
         performanceFeeRecipient = newRecipient;
     }
 
+    function setPerformanceFee(uint16 newPerformanceFee) external {
+        performanceFee = newPerformanceFee;
+    }
+
     function setTotalAssets(uint256 newTotalAssets) external {
         totalAssets = newTotalAssets;
+    }
+
+    function setLastReport(uint256 newLastReport) external {
+        lastReport = newLastReport;
+    }
+
+    function setProfitMaxUnlockTime(uint256 newProfitMaxUnlockTime) external {
+        profitMaxUnlockTime = newProfitMaxUnlockTime;
+    }
+
+    function setIsShutdown(bool newIsShutdown) external {
+        isShutdown = newIsShutdown;
     }
 
     function configureReport(uint256 newTotalAssets, uint256 profit, uint256 loss, bool shouldRevert) external {
@@ -79,6 +100,7 @@ contract MockRelayerStrategy {
         if (_reportReverts) revert MockReportFailed(address(this));
         reportCalls++;
         totalAssets = _nextTotalAssets;
+        lastReport = block.timestamp;
         return (_nextProfit, _nextLoss);
     }
 
@@ -720,6 +742,301 @@ contract KeeperRelayerTest is Setup {
         vm.expectRevert(abi.encodeWithSelector(KeeperRelayer.NonzeroSusd3PerformanceFee.selector, 1));
         vm.prank(keeper);
         relayer.report();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            REPORT TRIGGER
+    //////////////////////////////////////////////////////////////*/
+
+    function test_reportTriggerFalseBeforeBothDeadlines() public {
+        (,, KeeperRelayer mockRelayer) = _deployMockRelayer(10_000, keeper);
+
+        (bool shouldReport, bytes memory callData) = mockRelayer.reportTrigger();
+
+        assertFalse(shouldReport);
+        assertEq(callData, abi.encodeWithSelector(KeeperRelayer.report.selector));
+    }
+
+    function test_reportTriggerUsesStrictDeadlineBoundary() public {
+        (,, KeeperRelayer mockRelayer) = _deployMockRelayer(10_000, keeper);
+        uint256 lastReport = block.timestamp;
+
+        vm.warp(lastReport + 10 days);
+        (bool shouldReport,) = mockRelayer.reportTrigger();
+        assertFalse(shouldReport);
+
+        vm.warp(lastReport + 10 days + 1);
+        (shouldReport,) = mockRelayer.reportTrigger();
+        assertTrue(shouldReport);
+    }
+
+    function test_reportTriggerTrueWhenOnlyUsd3IsDue() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer) =
+            _deployMockRelayer(10_000, keeper);
+        uint256 lastReport = block.timestamp;
+
+        vm.warp(lastReport + 10 days + 1);
+        mockSusd3.setLastReport(block.timestamp);
+
+        assertGt(block.timestamp - mockUsd3.lastReport(), mockUsd3.profitMaxUnlockTime());
+        assertEq(block.timestamp, mockSusd3.lastReport());
+        (bool shouldReport,) = mockRelayer.reportTrigger();
+        assertTrue(shouldReport);
+    }
+
+    function test_reportTriggerTrueWhenOnlySusd3IsDue() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer) =
+            _deployMockRelayer(10_000, keeper);
+        uint256 lastReport = block.timestamp;
+
+        vm.warp(lastReport + 10 days + 1);
+        mockUsd3.setLastReport(block.timestamp);
+
+        assertEq(block.timestamp, mockUsd3.lastReport());
+        assertGt(block.timestamp - mockSusd3.lastReport(), mockSusd3.profitMaxUnlockTime());
+        (bool shouldReport,) = mockRelayer.reportTrigger();
+        assertTrue(shouldReport);
+    }
+
+    function test_reportTriggerRespectsDivergentPerLegUnlockTimes() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer) =
+            _deployMockRelayer(10_000, keeper);
+        uint256 lastReport = block.timestamp;
+        mockUsd3.setProfitMaxUnlockTime(2 days);
+        mockSusd3.setProfitMaxUnlockTime(20 days);
+
+        vm.warp(lastReport + 2 days);
+        (bool shouldReport,) = mockRelayer.reportTrigger();
+        assertFalse(shouldReport);
+
+        vm.warp(lastReport + 2 days + 1);
+        (shouldReport,) = mockRelayer.reportTrigger();
+        assertTrue(shouldReport);
+
+        vm.warp(lastReport + 20 days);
+        mockUsd3.setLastReport(block.timestamp);
+        (shouldReport,) = mockRelayer.reportTrigger();
+        assertFalse(shouldReport);
+
+        vm.warp(lastReport + 20 days + 1);
+        (shouldReport,) = mockRelayer.reportTrigger();
+        assertTrue(shouldReport);
+    }
+
+    function test_reportTriggerFalseWhenEitherStrategyIsShutdown() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer) =
+            _deployMockRelayer(10_000, keeper);
+        vm.warp(block.timestamp + 10 days + 1);
+
+        mockUsd3.setIsShutdown(true);
+        (bool shouldReport,) = mockRelayer.reportTrigger();
+        assertFalse(shouldReport);
+
+        mockUsd3.setIsShutdown(false);
+        mockSusd3.setIsShutdown(true);
+        (shouldReport,) = mockRelayer.reportTrigger();
+        assertFalse(shouldReport);
+    }
+
+    function test_reportTriggerFalseWhenEitherZeroAssetHealthCheckIsArmed() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer) =
+            _deployMockRelayer(10_000, keeper);
+        vm.warp(block.timestamp + 10 days + 1);
+
+        mockUsd3.setTotalAssets(0);
+        (bool shouldReport,) = mockRelayer.reportTrigger();
+        assertFalse(shouldReport);
+
+        mockUsd3.setTotalAssets(10_000);
+        mockSusd3.setTotalAssets(0);
+        mockUsd3.setPerformanceFee(1);
+        (shouldReport,) = mockRelayer.reportTrigger();
+        assertFalse(shouldReport);
+    }
+
+    function test_reportTriggerTrueWhenZeroAssetLegSkipIsArmed() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer) =
+            _deployMockRelayer(10_000, keeper);
+        vm.warp(block.timestamp + 10 days + 1);
+        mockUsd3.setPerformanceFee(1);
+        mockSusd3.setTotalAssets(0);
+
+        (bool shouldReport,) = mockRelayer.reportTrigger();
+        assertFalse(shouldReport);
+
+        mockRelayer.setDoHealthCheck(address(mockSusd3), false);
+        (shouldReport,) = mockRelayer.reportTrigger();
+        assertTrue(shouldReport);
+    }
+
+    function test_reportTriggerTrueWhenZeroAssetSeniorSkipIsArmed() public {
+        (MockRelayerStrategy mockUsd3,, KeeperRelayer mockRelayer) = _deployMockRelayer(10_000, keeper);
+        vm.warp(block.timestamp + 10 days + 1);
+        mockUsd3.setTotalAssets(0);
+
+        (bool shouldReport,) = mockRelayer.reportTrigger();
+        assertFalse(shouldReport);
+
+        mockRelayer.setDoHealthCheck(address(mockUsd3), false);
+        (shouldReport,) = mockRelayer.reportTrigger();
+        assertTrue(shouldReport);
+    }
+
+    function test_reportTriggerFalseWhenZeroAssetLegSkipIsArmedBeforeBothDeadlines() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer) =
+            _deployMockRelayer(10_000, keeper);
+        mockUsd3.setPerformanceFee(1);
+        mockSusd3.setTotalAssets(0);
+        mockRelayer.setDoHealthCheck(address(mockSusd3), false);
+
+        (bool shouldReport,) = mockRelayer.reportTrigger();
+        assertFalse(shouldReport);
+    }
+
+    function test_reportTriggerEmptyJuniorGuardRequiresNonzeroSeniorPerformanceFee() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer) =
+            _deployMockRelayer(10_000, keeper);
+        vm.warp(block.timestamp + 10 days + 1);
+        mockSusd3.setTotalAssets(0);
+
+        (bool shouldReport,) = mockRelayer.reportTrigger();
+        assertTrue(shouldReport);
+
+        mockUsd3.setPerformanceFee(1);
+        (shouldReport,) = mockRelayer.reportTrigger();
+        assertFalse(shouldReport);
+
+        mockRelayer.setDoHealthCheck(address(mockSusd3), false);
+        (shouldReport,) = mockRelayer.reportTrigger();
+        assertTrue(shouldReport);
+    }
+
+    function test_reportTriggerZeroUnlockDisablesOnlyThatLeg() public {
+        (MockRelayerStrategy mockUsd3, MockRelayerStrategy mockSusd3, KeeperRelayer mockRelayer) =
+            _deployMockRelayer(10_000, keeper);
+        uint256 lastReport = block.timestamp;
+        mockUsd3.setProfitMaxUnlockTime(0);
+
+        vm.warp(lastReport + 10 days);
+        (bool shouldReport,) = mockRelayer.reportTrigger();
+        assertFalse(shouldReport);
+
+        vm.warp(lastReport + 10 days + 1);
+        (shouldReport,) = mockRelayer.reportTrigger();
+        assertTrue(shouldReport);
+
+        mockSusd3.setLastReport(block.timestamp);
+        (shouldReport,) = mockRelayer.reportTrigger();
+        assertFalse(shouldReport);
+
+        mockSusd3.setProfitMaxUnlockTime(0);
+        vm.warp(block.timestamp + 100 days);
+        (shouldReport,) = mockRelayer.reportTrigger();
+        assertFalse(shouldReport);
+    }
+
+    function test_reportTriggerRealStrategiesUsesStrictProfitUnlockDeadline() public {
+        _seedSeniorAndJunior();
+        uint256 lastReport = ITokenizedStrategy(address(usd3Strategy)).lastReport();
+        assertEq(lastReport, ITokenizedStrategy(address(susd3Strategy)).lastReport());
+
+        (bool shouldReport,) = relayer.reportTrigger();
+        assertFalse(shouldReport);
+
+        vm.warp(lastReport + 10 days);
+        (shouldReport,) = relayer.reportTrigger();
+        assertFalse(shouldReport);
+
+        vm.warp(lastReport + 10 days + 1);
+        (shouldReport,) = relayer.reportTrigger();
+        assertTrue(shouldReport);
+    }
+
+    function test_reportTriggerCalldataReportsBothStrategiesAndResetsCadence() public {
+        _seedSeniorAndJunior();
+        uint256 previousReport = ITokenizedStrategy(address(usd3Strategy)).lastReport();
+        vm.warp(previousReport + 10 days + 1);
+
+        (bool shouldReport, bytes memory callData) = relayer.reportTrigger();
+        assertTrue(shouldReport);
+        assertEq(callData, abi.encodeWithSelector(KeeperRelayer.report.selector));
+
+        vm.prank(keeper);
+        (bool success,) = address(relayer).call(callData);
+        assertTrue(success);
+        assertEq(ITokenizedStrategy(address(usd3Strategy)).lastReport(), block.timestamp);
+        assertEq(ITokenizedStrategy(address(susd3Strategy)).lastReport(), block.timestamp);
+
+        (shouldReport,) = relayer.reportTrigger();
+        assertFalse(shouldReport);
+    }
+
+    function test_reportTriggerStaysTrueWhenManagementDirectReportsOnlyUsd3() public {
+        _seedSeniorAndJunior();
+        uint256 previousReport = ITokenizedStrategy(address(usd3Strategy)).lastReport();
+        vm.warp(previousReport + 10 days + 1);
+
+        (bool shouldReport,) = relayer.reportTrigger();
+        assertTrue(shouldReport);
+
+        vm.prank(management);
+        ITokenizedStrategy(address(usd3Strategy)).report();
+        assertEq(ITokenizedStrategy(address(usd3Strategy)).lastReport(), block.timestamp);
+        assertEq(ITokenizedStrategy(address(susd3Strategy)).lastReport(), previousReport);
+
+        (shouldReport,) = relayer.reportTrigger();
+        assertTrue(shouldReport);
+    }
+
+    function test_reportTriggerEmptyJuniorRecoveryUsesOneShotSkip() public {
+        mintAndDepositIntoStrategy(IUSD3(address(usd3Strategy)), alice, SENIOR_DEPOSIT);
+        vm.prank(keeper);
+        relayer.report();
+        uint256 previousReport = ITokenizedStrategy(address(usd3Strategy)).lastReport();
+        assertEq(ITokenizedStrategy(address(susd3Strategy)).totalAssets(), 0);
+
+        _simulateYield(usd3Strategy, 5_000e6);
+        vm.warp(previousReport + 10 days + 1);
+
+        (bool shouldReport,) = relayer.reportTrigger();
+        assertFalse(shouldReport);
+
+        vm.prank(management);
+        relayer.setDoHealthCheck(address(susd3Strategy), false);
+        bytes memory callData;
+        (shouldReport, callData) = relayer.reportTrigger();
+        assertTrue(shouldReport);
+
+        vm.prank(keeper);
+        (bool success,) = address(relayer).call(callData);
+        assertTrue(success);
+        assertGt(ITokenizedStrategy(address(susd3Strategy)).totalAssets(), 0);
+        (,, bool doHealthCheck) = relayer.healthCheck(address(susd3Strategy));
+        assertTrue(doHealthCheck);
+
+        (shouldReport,) = relayer.reportTrigger();
+        assertFalse(shouldReport);
+    }
+
+    function test_reportTriggerShutdownDisablesCadenceButManualReportStillSucceeds() public {
+        _seedSeniorAndJunior();
+        uint256 previousReport = ITokenizedStrategy(address(usd3Strategy)).lastReport();
+        vm.warp(previousReport + 10 days + 1);
+
+        vm.startPrank(management);
+        ITokenizedStrategy(address(usd3Strategy)).shutdownStrategy();
+        ITokenizedStrategy(address(susd3Strategy)).shutdownStrategy();
+        vm.stopPrank();
+
+        (bool shouldReport, bytes memory callData) = relayer.reportTrigger();
+        assertFalse(shouldReport);
+        assertEq(callData, abi.encodeWithSelector(KeeperRelayer.report.selector));
+
+        vm.prank(keeper);
+        (bool success,) = address(relayer).call(callData);
+        assertTrue(success);
+        assertEq(ITokenizedStrategy(address(usd3Strategy)).lastReport(), block.timestamp);
+        assertEq(ITokenizedStrategy(address(susd3Strategy)).lastReport(), block.timestamp);
     }
 
     function test_tendTriggerForwardsUsd3StateWithRelayerCalldata() public {

--- a/test/forge/usd3/utils/Setup.sol
+++ b/test/forge/usd3/utils/Setup.sol
@@ -14,6 +14,7 @@ import {IEvents} from "@tokenized-strategy/interfaces/IEvents.sol";
 import {USD3} from "../../../../src/usd3/USD3.sol";
 import {IMorpho, MarketParams, Id} from "../../../../src/interfaces/IMorpho.sol";
 import {MarketParamsLib} from "../../../../src/libraries/MarketParamsLib.sol";
+import {MorphoStorageLib} from "../../../../src/libraries/periphery/MorphoStorageLib.sol";
 import {MorphoCredit} from "../../../../src/MorphoCredit.sol";
 import {IrmMock} from "../../../../src/mocks/IrmMock.sol";
 import {HelperMock} from "../../../../src/mocks/HelperMock.sol";
@@ -290,6 +291,35 @@ contract Setup is Test, IEvents {
         // Execute borrow through helper - only helper is authorized to borrow
         vm.prank(borrower);
         helper.borrow(marketParams, borrowAmountWaUSDC, 0, borrower, borrower);
+    }
+
+    /// @dev Increases Morpho's packed market totalSupplyAssets while preserving totalSupplyShares.
+    function _simulateYield(USD3 usd3Strategy, uint256 amount) internal {
+        _simulateMarketAssetsDelta(usd3Strategy, amount, true);
+    }
+
+    /// @dev Decreases Morpho's packed market totalSupplyAssets while preserving totalSupplyShares.
+    function _simulateLoss(USD3 usd3Strategy, uint256 amount) internal {
+        _simulateMarketAssetsDelta(usd3Strategy, amount, false);
+    }
+
+    function _simulateMarketAssetsDelta(USD3 usd3Strategy, uint256 amount, bool increase) internal {
+        IMorpho morpho = usd3Strategy.morphoCredit();
+        bytes32 marketSlot = MorphoStorageLib.marketTotalSupplyAssetsAndSharesSlot(usd3Strategy.marketId());
+        uint256 currentTotal = uint256(vm.load(address(morpho), marketSlot));
+        uint128 totalSupplyAssets = uint128(currentTotal);
+        uint256 updatedTotalSupplyAssets;
+
+        if (increase) {
+            updatedTotalSupplyAssets = uint256(totalSupplyAssets) + amount;
+            assertLe(updatedTotalSupplyAssets, type(uint128).max);
+        } else {
+            assertGe(uint256(totalSupplyAssets), amount);
+            updatedTotalSupplyAssets = uint256(totalSupplyAssets) - amount;
+        }
+
+        uint256 preservedTotalSupplyShares = currentTotal & ~uint256(type(uint128).max);
+        vm.store(address(morpho), marketSlot, bytes32(preservedTotalSupplyShares | updatedTotalSupplyAssets));
     }
 
     function _setTokenAddrs() internal {


### PR DESCRIPTION
## Summary

- **`src/usd3/KeeperRelayer.sol`** — sole-keeper relayer for the USD3/sUSD3 pair: `report()` validates wiring fail-closed (keeper slots, sUSD3 link, fee recipient, zero junior fee), syncs the tranche share, then reports USD3 → sUSD3 atomically with BaseHealthCheck-style per-strategy profit/loss limit ratios. Authorization derives from USD3's live `management()` (no ownership state); keepers are a management-managed allowlist, with management passing the keeper gate (Yearn parity).
- **Bot surface** — `tendTrigger()` and profit-unlock-based `reportTrigger()` (fires when either leg's `profitMaxUnlockTime` has elapsed since its own last report; silenced on shutdown or while a zero-asset leg's health check is armed with a fee mint possible), both returning calldata retargeted at the relayer.
- **One-shot health-check skip** — `setDoHealthCheck(strategy, false)` armed by management, consumed by the next keeper report, auto-re-enables (BaseHealthCheck semantics).
- **`script/deploy/upgrade/v1.1.4-keeper/`** — CREATE2 deploy script (initial keepers: deployer EOA + protocol Safe) and a Safe batch script that sets the relayer as keeper on both strategies plus any missing report wiring (`setPerformanceFeeRecipient`, `setPerformanceFee(0)`) in one multisig transaction. Ports the newer `SafeHelper` from `deployment-script` and adds a `[profile.script]` foundry profile with pinned solc 0.8.22 / `cbor_metadata = false` for deterministic CREATE2 addresses.

## Test plan

- `yarn run test:forge --match-path 'test/forge/usd3/KeeperRelayer.t.sol'` — 56 tests: constructor/auth, atomic ordering + rollback, health-check boundaries, skip semantics, wiring drift, trigger decision matrix, donation griefing recovery, shutdown.
- Full non-invariant USD3 suite green (594 tests); `FOUNDRY_PROFILE=script forge build` clean; lint clean.
- Outstanding before mainnet execution: fork dry-run of the deploy script with a real `MAINNET_RPC_URL`, then the runbook (deploy → simulate Safe batch → propose → `verify()`).

https://claude.ai/code/session_01FUdnM9ALpxsmkBeb3aiZr1