### PR TITLE
fix(credit): floor the supply share price against outstanding shares

### DIFF
--- a/src/MorphoCredit.sol
+++ b/src/MorphoCredit.sol
@@ -78,8 +78,11 @@ contract MorphoCredit is Morpho, IMorphoCredit {
     /// @notice Markdown state for tracking defaulted debt value reduction
     mapping(Id => mapping(address => MarkdownState)) public markdownState;
 
-    /// @dev Storage gap for future upgrades (14 slots).
-    uint256[14] private __gap;
+    /// @inheritdoc IMorphoCredit
+    mapping(Id => bool) public marketInWindDown;
+
+    /// @dev Storage gap for future upgrades (13 slots).
+    uint256[13] private __gap;
 
     /* CONSTANTS */
 
@@ -90,6 +93,9 @@ contract MorphoCredit is Morpho, IMorphoCredit {
 
     /// @notice Maximum basis points (100%)
     uint256 internal constant MAX_BPS = 10000;
+
+    /// @notice Maximum supply shares, including virtual shares, per unit of supply assets.
+    uint256 internal constant SUPPLY_SHARE_PRICE_FLOOR_RATIO = 1e15;
 
     /* INITIALIZER */
 
@@ -116,6 +122,22 @@ contract MorphoCredit is Morpho, IMorphoCredit {
     /// @inheritdoc IMorphoCredit
     function setUsd3(address newUsd3) external onlyOwner {
         usd3 = newUsd3;
+    }
+
+    /// @inheritdoc IMorphoCredit
+    function clearMarketWindDown(Id id) external onlyOwner {
+        if (!marketInWindDown[id]) revert ErrorsLib.AlreadySet();
+        Market storage m = market[id];
+        if (
+            uint256(m.totalSupplyShares) + SharesMathLib.VIRTUAL_SHARES
+                > (uint256(m.totalSupplyAssets) + 1) * (SUPPLY_SHARE_PRICE_FLOOR_RATIO / 2)
+        ) {
+            revert ErrorsLib.SupplySharePriceBelowFloor();
+        }
+
+        delete marketInWindDown[id];
+
+        emit EventsLib.MarketWindDownCleared(id);
     }
 
     /* EXTERNAL FUNCTIONS - PREMIUM MANAGEMENT */
@@ -559,6 +581,7 @@ contract MorphoCredit is Morpho, IMorphoCredit {
         override
     {
         if (msg.sender != usd3) revert ErrorsLib.NotUsd3();
+        _requireNewLendingAllowed(id);
         if (IProtocolConfig(protocolConfig).getIsPaused() > 0) revert ErrorsLib.Paused();
     }
 
@@ -581,6 +604,7 @@ contract MorphoCredit is Morpho, IMorphoCredit {
         override
     {
         if (msg.sender != helper) revert ErrorsLib.NotHelper();
+        _requireNewLendingAllowed(id);
         if (IProtocolConfig(protocolConfig).getIsPaused() > 0) revert ErrorsLib.Paused();
         if (_isMarketFrozen(id)) revert ErrorsLib.MarketFrozen();
 
@@ -765,21 +789,23 @@ contract MorphoCredit is Morpho, IMorphoCredit {
     /// @param id Market ID
     /// @param markdownDelta Change in markdown (positive = increase, negative = decrease)
     function _updateMarketMarkdown(Id id, int256 markdownDelta) internal {
-        if (markdownDelta == 0) return;
-
-        Market memory m = market[id];
+        Market storage m = market[id];
 
         if (markdownDelta > 0) {
             // Markdown increasing (borrower deeper in default)
             uint256 increase = uint256(markdownDelta);
+            uint256 totalSupplyAssets = m.totalSupplyAssets;
+            uint256 minAssets = _minSupplyAssets(m.totalSupplyShares);
+            uint256 available = totalSupplyAssets > minAssets ? totalSupplyAssets - minAssets : 0;
 
-            // Cap at available supply to avoid underflow
-            if (increase > m.totalSupplyAssets) {
-                increase = m.totalSupplyAssets;
+            // Preserve the minimum supply share price and wind down if the markdown reaches the floor.
+            if (increase > available) {
+                increase = available;
+                marketInWindDown[id] = true;
             }
 
             // Apply the reduction to supply and record what was marked down
-            m.totalSupplyAssets = (m.totalSupplyAssets - increase).toUint128();
+            m.totalSupplyAssets = uint128(totalSupplyAssets - increase);
             m.totalMarkdownAmount = (m.totalMarkdownAmount + increase).toUint128();
         } else {
             // Markdown decreasing (borrower repaying/recovering)
@@ -794,8 +820,6 @@ contract MorphoCredit is Morpho, IMorphoCredit {
             m.totalSupplyAssets = (m.totalSupplyAssets + decrease).toUint128();
             m.totalMarkdownAmount = (m.totalMarkdownAmount - decrease).toUint128();
         }
-
-        market[id] = m;
     }
 
     /// @notice Get borrower's current borrow assets
@@ -873,6 +897,7 @@ contract MorphoCredit is Morpho, IMorphoCredit {
     /// @notice Apply settlement to storage
     function _applySettlement(Id id, address borrower, uint256 writtenOffShares, uint256 writtenOffAssets) internal {
         uint256 lastMarkdown = markdownState[id][borrower].lastCalculatedMarkdown;
+        Market storage m = market[id];
 
         // Clear borrower position and related state
         position[id][borrower].borrowShares = 0;
@@ -882,25 +907,52 @@ contract MorphoCredit is Morpho, IMorphoCredit {
         delete borrowerPremium[id][borrower];
 
         // Update borrow totals
-        market[id].totalBorrowShares = (market[id].totalBorrowShares - writtenOffShares).toUint128();
-        market[id].totalBorrowAssets = (market[id].totalBorrowAssets - writtenOffAssets).toUint128();
+        m.totalBorrowShares = (m.totalBorrowShares - writtenOffShares).toUint128();
+        m.totalBorrowAssets = (m.totalBorrowAssets - writtenOffAssets).toUint128();
 
-        // Apply net supply adjustment
-        uint128 totalSupplyAssets = market[id].totalSupplyAssets;
-        int256 netAdjustment = int256(lastMarkdown) - int256(writtenOffAssets);
-        if (netAdjustment > 0) {
-            market[id].totalSupplyAssets = (totalSupplyAssets + uint256(netAdjustment)).toUint128();
-        } else if (netAdjustment < 0) {
-            uint256 loss = uint256(-netAdjustment);
+        // Apply net supply adjustment. Only the loss direction is applied: when the written-off amount exceeds the
+        // markdown already deducted, the excess is taken from supply assets. The opposite case, where the recorded
+        // markdown exceeds the amount ultimately written off, does not credit the difference back. That case needs
+        // markdown state to go stale, which requires the markdown manager to be unset after a markdown was recorded,
+        // since every repay path otherwise refreshes and re-caps it against current debt. Where it does occur the
+        // repaid value stays in the market without being attributed to supply assets, so suppliers see it as a
+        // permanent reduction rather than a recovery.
+        uint256 totalSupplyAssets = m.totalSupplyAssets;
+        if (writtenOffAssets > lastMarkdown) {
+            uint256 loss = writtenOffAssets - lastMarkdown;
             if (totalSupplyAssets < loss) revert ErrorsLib.InsufficientLiquidity();
-            market[id].totalSupplyAssets = (totalSupplyAssets - loss).toUint128();
+
+            uint256 minAssets = _minSupplyAssets(m.totalSupplyShares);
+            uint256 protectedAssets = minAssets < totalSupplyAssets ? minAssets : totalSupplyAssets;
+            uint256 remainingAssets = totalSupplyAssets - loss;
+
+            if (remainingAssets < protectedAssets) {
+                remainingAssets = protectedAssets;
+                marketInWindDown[id] = true;
+            }
+
+            m.totalSupplyAssets = uint128(remainingAssets);
         }
 
         // Update markdown total
         if (lastMarkdown > 0) {
-            uint128 totalMarkdownAmount = market[id].totalMarkdownAmount;
-            market[id].totalMarkdownAmount =
+            uint128 totalMarkdownAmount = m.totalMarkdownAmount;
+            m.totalMarkdownAmount =
                 totalMarkdownAmount > lastMarkdown ? (totalMarkdownAmount - lastMarkdown).toUint128() : 0;
         }
+    }
+
+    /// @notice Minimum assets required by the supply share-price invariant.
+    function _minSupplyAssets(uint256 totalSupplyShares) internal pure returns (uint256) {
+        return (totalSupplyShares + SharesMathLib.VIRTUAL_SHARES - 1) / SUPPLY_SHARE_PRICE_FLOOR_RATIO;
+    }
+
+    /// @notice Reverts if the market cannot accept new supply or borrowing.
+    function _requireNewLendingAllowed(Id id) internal view {
+        Market storage m = market[id];
+        if (m.totalSupplyAssets < _minSupplyAssets(m.totalSupplyShares)) {
+            revert ErrorsLib.SupplySharePriceBelowFloor();
+        }
+        if (marketInWindDown[id]) revert ErrorsLib.MarketInWindDown();
     }
 }

--- a/src/interfaces/IMorpho.sol
+++ b/src/interfaces/IMorpho.sol
@@ -346,6 +346,11 @@ interface IMorphoCredit {
     /// @param newUsd3 The new usd3 address
     function setUsd3(address newUsd3) external;
 
+    /// @notice Clears wind-down once `S + V <= R * (T + 1) / 2`, providing 2x margin to the floor.
+    /// @dev Only callable by the governance owner.
+    /// @param id The market ID
+    function clearMarketWindDown(Id id) external;
+
     /// @notice Sets the credit line and premium rate for a borrower
     /// @param id The market ID
     /// @param borrower The borrower address
@@ -429,4 +434,9 @@ interface IMorphoCredit {
     /// @param borrower Borrower address
     /// @return lastCalculatedMarkdown Last calculated markdown amount
     function markdownState(Id id, address borrower) external view returns (uint128 lastCalculatedMarkdown);
+
+    /// @notice Whether a supply-share floor truncated a market's markdown or settlement loss.
+    /// @dev Wind-down blocks new supply and borrowing while permitting withdrawal, repayment, and settlement. It can
+    /// only be cleared by governance through `clearMarketWindDown` once `S + V <= R * (T + 1) / 2`.
+    function marketInWindDown(Id id) external view returns (bool);
 }

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -146,4 +146,10 @@ library ErrorsLib {
 
     /// @notice Thrown when borrow or repay would result in debt below minimum borrow amount.
     error BelowMinimumBorrow();
+
+    /// @notice Thrown when supply shares exceed the maximum ratio to supply assets.
+    error SupplySharePriceBelowFloor();
+
+    /// @notice Thrown when new lending is attempted in a market that is winding down.
+    error MarketInWindDown();
 }

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -166,6 +166,10 @@ library EventsLib {
     /// @param newManager New markdown manager.
     event MarkdownManagerSet(Id indexed id, address oldManager, address newManager);
 
+    /// @notice Emitted when governance clears a market's wind-down state.
+    /// @param id Market id.
+    event MarketWindDownCleared(Id indexed id);
+
     /// @notice Emitted when an account is settled with all remaining debt written off.
     /// @param id Market id.
     /// @param settler Address that initiated the settlement.

--- a/src/mocks/MorphoCreditMock.sol
+++ b/src/mocks/MorphoCreditMock.sol
@@ -10,13 +10,13 @@ contract MorphoCreditMock is MorphoCredit {
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _protocolConfig) MorphoCredit(_protocolConfig) {}
 
-    /// @dev Override _beforeSupply to do nothing (remove usd3 restriction)
+    /// @dev Override _beforeSupply to remove the usd3 restriction while retaining lending safety checks.
     function _beforeSupply(MarketParams memory, Id id, address onBehalf, uint256, uint256, bytes calldata)
         internal
         virtual
         override
     {
-        // Do nothing - remove usd3 restriction for testing
+        _requireNewLendingAllowed(id);
     }
 
     /// @dev Override _beforeWithdraw to do nothing (remove usd3 restriction)
@@ -28,6 +28,7 @@ contract MorphoCreditMock is MorphoCredit {
     function _beforeBorrow(MarketParams memory, Id id, address onBehalf, uint256, uint256) internal virtual override {
         // Remove helper and paused restrictions for testing
         // Keep the market freeze check, repayment status check and premium accrual
+        _requireNewLendingAllowed(id);
         if (_isMarketFrozen(id)) revert ErrorsLib.MarketFrozen();
 
         (RepaymentStatus status,) = getRepaymentStatus(id, onBehalf);

--- a/test/forge/integration/markdown/SupplySharePriceFloorTest.sol
+++ b/test/forge/integration/markdown/SupplySharePriceFloorTest.sol
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import "../../BaseTest.sol";
+import {ConfigurableIrmMock} from "../../mocks/ConfigurableIrmMock.sol";
+import {CreditLineMock} from "../../../../src/mocks/CreditLineMock.sol";
+import {MarkdownManagerMock} from "../../../../src/mocks/MarkdownManagerMock.sol";
+import {Market, Position} from "../../../../src/interfaces/IMorpho.sol";
+import {MarketParamsLib} from "../../../../src/libraries/MarketParamsLib.sol";
+import {MorphoBalancesLib} from "../../../../src/libraries/periphery/MorphoBalancesLib.sol";
+import {MorphoStorageLib} from "../../../../src/libraries/periphery/MorphoStorageLib.sol";
+import {SharesMathLib} from "../../../../src/libraries/SharesMathLib.sol";
+import {EventsLib} from "../../../../src/libraries/EventsLib.sol";
+import {MAX_FEE} from "../../../../src/libraries/ConstantsLib.sol";
+
+/// @title SupplySharePriceFloorTest
+/// @notice Regression tests for supply-share growth after credit losses.
+contract SupplySharePriceFloorTest is BaseTest {
+    using MarketParamsLib for MarketParams;
+    using MorphoBalancesLib for IMorpho;
+    using SharesMathLib for uint256;
+
+    uint256 internal constant SUPPLY_SHARE_PRICE_FLOOR_RATIO = 1e15;
+
+    CreditLineMock internal creditLine;
+    MarkdownManagerMock internal markdownManager;
+    IMorphoCredit internal morphoCredit;
+
+    function setUp() public override {
+        super.setUp();
+
+        creditLine = new CreditLineMock(morphoAddress);
+        markdownManager = new MarkdownManagerMock(address(protocolConfig), OWNER);
+        morphoCredit = IMorphoCredit(morphoAddress);
+
+        marketParams = MarketParams({
+            loanToken: address(loanToken),
+            collateralToken: address(collateralToken),
+            oracle: address(oracle),
+            irm: address(0),
+            lltv: DEFAULT_TEST_LLTV,
+            creditLine: address(creditLine)
+        });
+        id = marketParams.id();
+
+        vm.startPrank(OWNER);
+        morpho.createMarket(marketParams);
+        markdownManager.setEnableMarkdown(BORROWER, true);
+        protocolConfig.setConfig(keccak256("IRP"), 0);
+        vm.stopPrank();
+        creditLine.setMm(address(markdownManager));
+
+        _ensureMarketActive(id);
+    }
+
+    function testFeeZeroTwoCycleLossCannotOverflowSupplyShares() public {
+        uint256 assets = 1 ether;
+        uint256 firstCycleShares = _supplyFrom(SUPPLIER, assets);
+        assertLe(firstCycleShares, assets * SUPPLY_SHARE_PRICE_FLOOR_RATIO, "first-cycle shares exceed bound");
+
+        _setupBorrowerWithLoan(BORROWER, assets);
+        _moveToDefaultAndTouch(BORROWER, assets);
+
+        assertTrue(morphoCredit.marketInWindDown(id), "full-book markdown should wind down market");
+
+        vm.prank(address(creditLine));
+        morphoCredit.settleAccount(marketParams, BORROWER);
+
+        Market memory beforeSecondCycle = morpho.market(id);
+        uint256 quotedSecondCycleShares =
+            assets.toSharesDown(beforeSecondCycle.totalSupplyAssets, beforeSecondCycle.totalSupplyShares);
+
+        assertLe(quotedSecondCycleShares, assets * SUPPLY_SHARE_PRICE_FLOOR_RATIO, "second-cycle quote exceeds bound");
+        _assertSupplySharePriceFloor(beforeSecondCycle);
+
+        loanToken.setBalance(SUPPLIER, assets);
+        vm.expectRevert(ErrorsLib.MarketInWindDown.selector);
+        vm.prank(SUPPLIER);
+        morpho.supply(marketParams, assets, 0, SUPPLIER, "");
+
+        Market memory afterSecondCycle = morpho.market(id);
+        assertEq(afterSecondCycle.totalSupplyShares, beforeSecondCycle.totalSupplyShares, "shares changed on rejection");
+        assertLt(afterSecondCycle.totalSupplyShares, type(uint128).max, "supply shares saturated");
+        assertEq(morpho.expectedSupplyAssets(marketParams, SUPPLIER), afterSecondCycle.totalSupplyAssets);
+    }
+
+    function testMarkdownReversalFromFloorRestoresExactly() public {
+        uint256 assets = 1 ether;
+        _supplyFrom(SUPPLIER, assets);
+        _setupBorrowerWithLoan(BORROWER, assets);
+        _moveToDefaultAndTouch(BORROWER, assets);
+
+        Market memory atFloor = morpho.market(id);
+        uint256 appliedMarkdown = atFloor.totalMarkdownAmount;
+        uint256 supplySharesBefore = atFloor.totalSupplyShares;
+        assertGt(appliedMarkdown, 0, "markdown not applied");
+        _assertSupplySharePriceFloor(atFloor);
+
+        Position memory borrowerPosition = morpho.position(id, BORROWER);
+        loanToken.setBalance(BORROWER, assets);
+        vm.prank(BORROWER);
+        morpho.repay(marketParams, 0, borrowerPosition.borrowShares, BORROWER, "");
+
+        Market memory cured = morpho.market(id);
+        assertEq(
+            cured.totalSupplyAssets,
+            uint256(atFloor.totalSupplyAssets) + appliedMarkdown,
+            "cure did not reverse applied markdown"
+        );
+        assertEq(cured.totalSupplyAssets, assets, "supply assets not restored exactly");
+        assertEq(cured.totalMarkdownAmount, 0, "markdown tally not cleared");
+        assertEq(cured.totalSupplyShares, supplySharesBefore, "supply shares changed on cure");
+        assertEq(
+            cured.totalSupplyShares,
+            morpho.position(id, SUPPLIER).supplyShares + morpho.position(id, FEE_RECIPIENT).supplyShares,
+            "market supply shares differ from position sum"
+        );
+        assertTrue(morphoCredit.marketInWindDown(id), "wind-down cleared without governance");
+    }
+
+    function testWithdrawThenMarkdownUsesSaturatingAvailableAssets() public {
+        uint256 assets = 1 ether;
+        _supplyFrom(SUPPLIER, assets);
+        _setupBorrowerWithLoan(BORROWER, 1);
+
+        // Model a legacy market whose denominator had already collapsed before this implementation was installed.
+        Market memory legacy = morpho.market(id);
+        _setSupplyTotals(10, legacy.totalSupplyShares);
+
+        vm.prank(SUPPLIER);
+        morpho.withdraw(marketParams, 9, 0, SUPPLIER, SUPPLIER);
+
+        Market memory afterWithdraw = morpho.market(id);
+        uint256 minAssets = _minSupplyAssets(afterWithdraw.totalSupplyShares);
+        assertEq(afterWithdraw.totalSupplyAssets, 1, "unexpected post-withdraw assets");
+        assertLt(afterWithdraw.totalSupplyAssets, minAssets, "test did not construct T below the floor");
+
+        _moveToDefaultAndTouch(BORROWER, 1);
+
+        Market memory afterMarkdown = morpho.market(id);
+        assertEq(afterMarkdown.totalSupplyAssets, afterWithdraw.totalSupplyAssets, "markdown reduced protected assets");
+        assertEq(afterMarkdown.totalMarkdownAmount, 0, "unapplied markdown was recorded");
+        assertTrue(morphoCredit.marketInWindDown(id), "truncated markdown did not wind down market");
+    }
+
+    function testMaxFeeAccrualAtFloorKeepsFeeSharesBounded() public {
+        ConfigurableIrmMock feeIrm = new ConfigurableIrmMock();
+        feeIrm.setApr(0.1 ether);
+
+        marketParams.irm = address(feeIrm);
+        id = marketParams.id();
+
+        vm.startPrank(OWNER);
+        morpho.enableIrm(address(feeIrm));
+        morpho.createMarket(marketParams);
+        morpho.setFee(marketParams, MAX_FEE);
+        vm.stopPrank();
+        _ensureMarketActive(id);
+
+        uint256 assets = 1 ether;
+        _supplyFrom(SUPPLIER, assets);
+        _setupBorrowerWithLoan(BORROWER, assets * 2, uint128(PREMIUM_RATE_PER_SECOND), assets);
+        _moveToDefaultAndTouch(BORROWER, type(uint256).max);
+
+        assertTrue(morphoCredit.marketInWindDown(id), "full markdown did not reach floor");
+        _assertSupplySharePriceFloor(morpho.market(id));
+
+        uint256 totalInterest;
+        uint256 totalFeeShares;
+        for (uint256 i = 0; i < 8; i++) {
+            Market memory beforeAccrual = morpho.market(id);
+            uint256 feeSharesBefore = morpho.position(id, FEE_RECIPIENT).supplyShares;
+
+            _continueMarketCycles(id, block.timestamp + 1 days);
+            morphoCredit.accruePremiumsForBorrowers(id, _toArray(BORROWER));
+
+            Market memory afterAccrual = morpho.market(id);
+            uint256 interest = uint256(afterAccrual.totalBorrowAssets) - beforeAccrual.totalBorrowAssets;
+            uint256 feeShares = morpho.position(id, FEE_RECIPIENT).supplyShares - feeSharesBefore;
+            uint256 maxFeeShares = (interest * MAX_FEE / 1 ether) * SUPPLY_SHARE_PRICE_FLOOR_RATIO;
+
+            assertGt(interest, 0, "no interest accrued");
+            assertLe(feeShares, maxFeeShares, "fee shares exceed 25% interest times floor ratio");
+            // This exact per-iteration floor check carries the fee-path regression: pre-floor code leaves T at zero.
+            assertEq(
+                afterAccrual.totalSupplyAssets,
+                _minSupplyAssets(afterAccrual.totalSupplyShares),
+                "full markdown did not restore exact floor after fee issuance"
+            );
+            _assertSupplySharePriceFloor(afterAccrual);
+
+            totalInterest += interest;
+            totalFeeShares += feeShares;
+        }
+
+        assertGt(totalInterest, 0, "loop accrued no interest");
+        assertGt(totalFeeShares, 0, "loop issued no fee shares");
+        assertLt(morpho.market(id).totalSupplyShares, type(uint128).max, "fee shares saturated accumulator");
+        morpho.expectedSupplyAssets(marketParams, FEE_RECIPIENT);
+    }
+
+    function testSettlementLossFloorWithoutMarkdownManager() public {
+        creditLine.setMm(address(0));
+
+        uint256 assets = 1 ether;
+        _supplyFrom(SUPPLIER, assets);
+        _setupBorrowerWithLoan(BORROWER, assets);
+
+        vm.prank(address(creditLine));
+        morphoCredit.settleAccount(marketParams, BORROWER);
+
+        Market memory settled = morpho.market(id);
+        assertEq(settled.totalSupplyAssets, _minSupplyAssets(settled.totalSupplyShares), "loss did not stop at floor");
+        assertEq(settled.totalBorrowAssets, 0, "borrow assets not cleared");
+        assertEq(settled.totalBorrowShares, 0, "borrow shares not cleared");
+        assertEq(settled.totalMarkdownAmount, 0, "market without manager recorded markdown");
+        assertTrue(morphoCredit.marketInWindDown(id), "truncated settlement did not wind down market");
+        _assertSupplySharePriceFloor(settled);
+    }
+
+    function testWindDownTripsOnlyOnTruncationAndLeavesExitPathsOpen() public {
+        uint256 assets = 1 ether;
+        _supplyFrom(SUPPLIER, assets);
+        _setupBorrowerWithLoan(BORROWER, assets);
+
+        Market memory supplied = morpho.market(id);
+        uint256 available = uint256(supplied.totalSupplyAssets) - _minSupplyAssets(supplied.totalSupplyShares);
+        _moveToDefaultAndTouch(BORROWER, available);
+
+        assertFalse(morphoCredit.marketInWindDown(id), "exact available markdown tripped wind-down");
+        assertEq(morpho.market(id).totalMarkdownAmount, available, "exact markdown was truncated");
+
+        markdownManager.setMarkdownForBorrower(BORROWER, assets);
+        morphoCredit.accruePremiumsForBorrowers(id, _toArray(BORROWER));
+        assertTrue(morphoCredit.marketInWindDown(id), "truncated markdown did not trip wind-down");
+
+        loanToken.setBalance(SUPPLIER, 1);
+        vm.expectRevert(ErrorsLib.MarketInWindDown.selector);
+        vm.prank(SUPPLIER);
+        morpho.supply(marketParams, 1, 0, SUPPLIER, "");
+
+        vm.prank(address(creditLine));
+        morphoCredit.setCreditLine(id, ONBEHALF, assets, 0);
+        vm.expectRevert(ErrorsLib.MarketInWindDown.selector);
+        vm.prank(ONBEHALF);
+        morpho.borrow(marketParams, 1, 0, ONBEHALF, ONBEHALF);
+
+        Position memory borrowerPosition = morpho.position(id, BORROWER);
+        loanToken.setBalance(BORROWER, assets);
+        vm.prank(BORROWER);
+        morpho.repay(marketParams, 0, borrowerPosition.borrowShares, BORROWER, "");
+
+        vm.prank(address(creditLine));
+        morphoCredit.settleAccount(marketParams, BORROWER);
+
+        vm.prank(SUPPLIER);
+        morpho.withdraw(marketParams, 1, 0, SUPPLIER, SUPPLIER);
+
+        assertTrue(morphoCredit.marketInWindDown(id), "exit paths cleared wind-down");
+    }
+
+    function testSupplyConsistencyCheckIncludesVirtualShares() public {
+        uint256 assets = 1 ether;
+        _supplyFrom(SUPPLIER, assets);
+
+        _setSupplyTotals(0, uint128(SUPPLY_SHARE_PRICE_FLOOR_RATIO - SharesMathLib.VIRTUAL_SHARES + 1));
+
+        loanToken.setBalance(SUPPLIER, assets);
+        vm.expectRevert(ErrorsLib.SupplySharePriceBelowFloor.selector);
+        vm.prank(SUPPLIER);
+        morpho.supply(marketParams, assets, 0, SUPPLIER, "");
+    }
+
+    function testBorrowConsistencyCheckRejectsLegacyMarketBelowFloor() public {
+        uint256 assets = 1 ether;
+        _supplyFrom(SUPPLIER, assets);
+
+        uint128 totalSupplyAssets = 1;
+        uint128 totalSupplyShares = uint128(
+            (uint256(totalSupplyAssets) + 1) * SUPPLY_SHARE_PRICE_FLOOR_RATIO - SharesMathLib.VIRTUAL_SHARES + 1
+        );
+        _setSupplyTotals(totalSupplyAssets, totalSupplyShares);
+
+        vm.prank(address(creditLine));
+        morphoCredit.setCreditLine(id, BORROWER, assets, 0);
+        vm.expectRevert(ErrorsLib.SupplySharePriceBelowFloor.selector);
+        vm.prank(BORROWER);
+        morpho.borrow(marketParams, 1, 0, BORROWER, BORROWER);
+    }
+
+    function testGovernanceCanClearWindDownOnlyAfterTwoTimesMarginRecovery() public {
+        vm.expectRevert(ErrorsLib.AlreadySet.selector);
+        vm.prank(OWNER);
+        morphoCredit.clearMarketWindDown(id);
+
+        uint256 assets = 1 ether;
+        _supplyFrom(SUPPLIER, assets);
+        _setupBorrowerWithLoan(BORROWER, assets);
+        _moveToDefaultAndTouch(BORROWER, assets);
+        assertTrue(morphoCredit.marketInWindDown(id), "markdown did not trip wind-down");
+
+        vm.expectRevert(ErrorsLib.NotOwner.selector);
+        vm.prank(BORROWER);
+        morphoCredit.clearMarketWindDown(id);
+
+        vm.expectRevert(ErrorsLib.SupplySharePriceBelowFloor.selector);
+        vm.prank(OWNER);
+        morphoCredit.clearMarketWindDown(id);
+
+        Position memory borrowerPosition = morpho.position(id, BORROWER);
+        loanToken.setBalance(BORROWER, assets);
+        vm.prank(BORROWER);
+        morpho.repay(marketParams, 0, borrowerPosition.borrowShares, BORROWER, "");
+
+        Market memory recovered = morpho.market(id);
+        assertLe(
+            uint256(recovered.totalSupplyShares) + SharesMathLib.VIRTUAL_SHARES,
+            (uint256(recovered.totalSupplyAssets) + 1) * (SUPPLY_SHARE_PRICE_FLOOR_RATIO / 2),
+            "market did not recover two-times reopening margin"
+        );
+
+        vm.expectEmit(true, false, false, false, address(morphoCredit));
+        emit EventsLib.MarketWindDownCleared(id);
+        vm.prank(OWNER);
+        morphoCredit.clearMarketWindDown(id);
+        assertFalse(morphoCredit.marketInWindDown(id), "governance did not clear wind-down");
+
+        _supplyFrom(SUPPLIER, 1 ether);
+
+        vm.prank(address(creditLine));
+        morphoCredit.setCreditLine(id, ONBEHALF, assets, 0);
+        vm.prank(ONBEHALF);
+        morpho.borrow(marketParams, 1, 0, ONBEHALF, ONBEHALF);
+        assertEq(morpho.expectedBorrowAssets(marketParams, ONBEHALF), 1, "borrowing not re-enabled");
+    }
+
+    function _supplyFrom(address supplier, uint256 assets) internal returns (uint256 shares) {
+        loanToken.setBalance(supplier, assets);
+        vm.prank(supplier);
+        (, shares) = morpho.supply(marketParams, assets, 0, supplier, "");
+    }
+
+    function _moveToDefaultAndTouch(address borrower, uint256 markdown) internal {
+        uint256 borrowAssets = morpho.expectedBorrowAssets(marketParams, borrower);
+        _createPastObligation(borrower, 10_000, borrowAssets);
+        markdownManager.setMarkdownForBorrower(borrower, markdown);
+        _continueMarketCycles(id, block.timestamp + GRACE_PERIOD_DURATION + DELINQUENCY_PERIOD_DURATION + 1);
+        morphoCredit.accruePremiumsForBorrowers(id, _toArray(borrower));
+    }
+
+    function _minSupplyAssets(uint256 totalSupplyShares) internal pure returns (uint256) {
+        return (totalSupplyShares + SharesMathLib.VIRTUAL_SHARES - 1) / SUPPLY_SHARE_PRICE_FLOOR_RATIO;
+    }
+
+    function _assertSupplySharePriceFloor(Market memory marketState) internal pure {
+        assertLe(
+            uint256(marketState.totalSupplyShares) + SharesMathLib.VIRTUAL_SHARES,
+            SUPPLY_SHARE_PRICE_FLOOR_RATIO * (uint256(marketState.totalSupplyAssets) + 1),
+            "supply-share floor invariant"
+        );
+    }
+
+    function _setSupplyTotals(uint128 totalSupplyAssets, uint128 totalSupplyShares) internal {
+        bytes32 slot = MorphoStorageLib.marketTotalSupplyAssetsAndSharesSlot(id);
+        vm.store(address(morpho), slot, bytes32(uint256(totalSupplyAssets) | (uint256(totalSupplyShares) << 128)));
+    }
+}


### PR DESCRIPTION
Remediates an audit finding on supply-share accounting. Standalone: no other remediation work is included.

## Problem

Supply shares convert with `toSharesDown(assets, T, S)`, whose denominator is `totalSupplyAssets + 1`. Two credit paths reduce supply assets without reducing supply shares — the markdown increase branch (reversible) and the settlement loss branch (not). Either can drive supply assets to zero while shares remain outstanding, so a later `supply` issues shares in proportion to the existing share count rather than the value supplied. Repeating that compounds multiplicatively and eventually saturates the `uint128` share accumulator, after which accrual reverts and the market can no longer be settled, repaid or valued. USD3 supplies into this market from its own deploy/report path, so it can reach the state without an external actor.

Reproduced on the unmodified contracts: `MaxUint128Exceeded()` at the second supply, with `T = 0` and `S = 1e24`.

Note this is independent of the protocol fee. The fee-share mints are separately fee-gated, but the supply path is not, so leaving the fee at zero does not avoid it.

## Approach

Bound the conversion ratio rather than patching each path. With `V` the virtual share count and `R = 1e15`:

```
S + V <= R * (T + 1)
```

This caps issuance at roughly `R` shares per asset unit, making share growth linear in value actually supplied instead of multiplicative in shares already outstanding. Saturating the accumulator would then require supplying several hundred thousand tokens at the floor price.

- Both deflation sites stop at `minSupplyAssets = (S + V - 1) / R`, the least balance satisfying the invariant, and subtract with saturation because a market predating this change can already sit below the floor.
- Supply and borrow share one check, so a market that was already degenerate cannot take on new lending. Without it the wind-down flag — which only records truncation observed after the upgrade — would leave such a market open to fresh credit.
- Markdown still records only the amount actually applied, so reversing a markdown restores exactly what it removed; supplier shares are never touched.
- A market whose loss was truncated is flagged for wind-down: new supply and borrowing are refused, while withdrawal, repayment and settlement stay available. Governance can clear the flag once the market holds twice the floor, which prevents reopening one that would immediately trip again.

## Scope and compatibility

`totalSupplyAssets` keeps its current meaning, so `Morpho.sol`, `SharesMathLib`, and both balance libraries are untouched and USD3/sUSD3 need no redeploy.

`marketInWindDown` takes the first reserved slot and the trailing gap drops from 14 to 13, leaving every existing slot in place — verified with `forge inspect`.

MorphoCredit is 24,545 bytes, 31 below the EIP-170 limit and unchanged from the base commit.

## Known limitation

Only the loss direction of the settlement adjustment is applied. Where recorded markdown exceeds the amount ultimately written off, the difference is not credited back; that requires markdown state to go stale, which needs the markdown manager to be unset after a markdown was recorded. In that case the repaid value stays in the market without being attributed to supply assets. Documented at the call site.

## Before deploying

Confirm no live market currently sits below the floor. This change prevents conforming markets from breaching it but does not remediate one that already has.

## Verification

- New regression suite, 9 tests, including the two-cycle reproduction, markdown reversal, withdraw-then-markdown saturation, fee accrual at the floor, settlement with no markdown manager, and the wind-down and clear paths
- 45 markdown integration tests, 1,658 non-invariant tests, 11 core invariants
- `yarn lint`, `yarn build:forge:size`