### PR TITLE
fix(susd3): block deposits while sUSD3 accounting is stale

### DIFF
--- a/src/usd3/sUSD3.sol
+++ b/src/usd3/sUSD3.sol
@@ -248,6 +248,13 @@ contract sUSD3 is BaseHooksUpgradeable {
     /// @param _owner Address to check limit for
     /// @return Maximum deposit amount allowed
     function availableDepositLimit(address _owner) public view override returns (uint256) {
+        uint256 currentUSD3Holdings = asset.balanceOf(address(this));
+
+        // Harden non-atomic reporting paths where USD3 burns this balance before sUSD3 reports the loss.
+        if (currentUSD3Holdings + 2 < TokenizedStrategy.totalAssets()) {
+            return 0;
+        }
+
         // Get the subordinated debt cap in USDC terms
         uint256 subordinatedDebtCapUSDC = getSubordinatedDebtCapInUSDC();
 
@@ -256,7 +263,6 @@ contract sUSD3 is BaseHooksUpgradeable {
             return 0;
         }
 
-        uint256 currentUSD3Holdings = asset.balanceOf(address(this));
         uint256 currentHoldingsUSDC = IStrategy(address(asset)).convertToAssets(currentUSD3Holdings);
 
         if (currentHoldingsUSDC >= subordinatedDebtCapUSDC) {

--- a/test/forge/usd3/Invariants.t.sol
+++ b/test/forge/usd3/Invariants.t.sol
@@ -147,7 +147,10 @@ contract InvariantsTest is StdInvariant, Setup {
         uint256 holdingsUsdc = ITokenizedStrategy(address(usd3Strategy)).convertToAssets(susd3Usd3Balance);
 
         uint256 expectedLimit;
-        if (debtCapUsdc > holdingsUsdc) {
+        if (
+            susd3Usd3Balance + 2 >= ITokenizedStrategy(address(susd3Strategy)).totalAssets()
+                && debtCapUsdc > holdingsUsdc
+        ) {
             expectedLimit = ITokenizedStrategy(address(usd3Strategy)).convertToShares(debtCapUsdc - holdingsUsdc);
         }
 
@@ -217,7 +220,10 @@ contract InvariantsTest is StdInvariant, Setup {
         uint256 holdingsUsdc = ITokenizedStrategy(address(usd3Strategy))
             .convertToAssets(ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy)));
 
-        if (handler.attemptedDepositSUSD3() > 32 && capUsdc > holdingsUsdc) {
+        if (
+            handler.attemptedDepositSUSD3() > 32 && capUsdc > holdingsUsdc
+                && susd3Strategy.availableDepositLimit(actors[0]) > 0
+        ) {
             assertGt(handler.successfulDepositSUSD3(), 0, "susd3 deposits are no-op");
         }
 

--- a/test/forge/usd3/integration/USD3sUSD3Integration.t.sol
+++ b/test/forge/usd3/integration/USD3sUSD3Integration.t.sol
@@ -372,6 +372,133 @@ contract USD3sUSD3IntegrationTest is Setup {
         assertGt(susd3Strategy.availableWithdrawLimit(bob), 0, "sUSD3 withdrawals should reopen after report");
     }
 
+    function test_staleSusd3AccountingBlocksDepositsUntilReport() public {
+        uint256 borrowAmount = 5_000e6;
+
+        vm.startPrank(alice);
+        asset.approve(address(usd3Strategy), LARGE_DEPOSIT);
+        usd3Strategy.deposit(LARGE_DEPOSIT, alice);
+        vm.stopPrank();
+
+        createMarketDebt(charlie, borrowAmount);
+
+        vm.startPrank(bob);
+        asset.approve(address(usd3Strategy), MEDIUM_DEPOSIT);
+        usd3Strategy.deposit(MEDIUM_DEPOSIT, bob);
+
+        uint256 bobDepositAmount = ERC20(address(usd3Strategy)).balanceOf(bob) / 10;
+        ERC20(address(usd3Strategy)).approve(address(susd3Strategy), type(uint256).max);
+        susd3Strategy.deposit(bobDepositAmount, bob);
+        vm.stopPrank();
+
+        MarketParams memory params = usd3Strategy.marketParams();
+        IMorpho morpho = usd3Strategy.morphoCredit();
+        vm.prank(params.creditLine);
+        MorphoCredit(address(morpho)).settleAccount(params, charlie);
+
+        vm.prank(keeper);
+        (uint256 profit, uint256 loss) = usd3Strategy.report();
+        assertEq(profit, 0, "settlement should not report profit");
+        assertApproxEqAbs(loss, borrowAmount, 1, "report should recognize settled debt");
+
+        uint256 storedAssets = ITokenizedStrategy(address(susd3Strategy)).totalAssets();
+        uint256 liveAssets = ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy));
+        assertLt(liveAssets + 2, storedAssets, "USD3 report should leave stale sUSD3 accounting");
+        assertEq(susd3Strategy.availableDepositLimit(bob), 0, "stale accounting should block deposits");
+        assertEq(ITokenizedStrategy(address(susd3Strategy)).maxDeposit(bob), 0, "maxDeposit should be zero");
+        assertEq(ITokenizedStrategy(address(susd3Strategy)).maxMint(bob), 0, "maxMint should be zero");
+
+        vm.startPrank(bob);
+        vm.expectRevert(bytes("ERC4626: deposit more than max"));
+        susd3Strategy.deposit(1_000e6, bob);
+        vm.expectRevert(bytes("ERC4626: mint more than max"));
+        susd3Strategy.mint(1_000e6, bob);
+        vm.stopPrank();
+
+        vm.prank(keeper);
+        susd3Strategy.report();
+
+        uint256 reconciledAssets = ITokenizedStrategy(address(susd3Strategy)).totalAssets();
+        assertEq(
+            reconciledAssets,
+            ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy)),
+            "report should reconcile sUSD3 accounting"
+        );
+        assertGt(susd3Strategy.availableDepositLimit(bob), 0, "deposits should reopen after report");
+        assertGt(ITokenizedStrategy(address(susd3Strategy)).maxDeposit(bob), 0, "maxDeposit should reopen");
+        assertGt(ITokenizedStrategy(address(susd3Strategy)).maxMint(bob), 0, "maxMint should reopen");
+
+        uint256 depositAmount = 1_000e6;
+        uint256 expectedShares = ITokenizedStrategy(address(susd3Strategy)).previewDeposit(depositAmount);
+        vm.prank(bob);
+        uint256 mintedShares = susd3Strategy.deposit(depositAmount, bob);
+        assertEq(mintedShares, expectedShares, "deposit should use the reconciled share price");
+        assertGt(mintedShares, depositAmount, "new shares should reflect the recognized first loss");
+    }
+
+    function test_susd3DepositLimitAllowsTwoUnitAccountingTolerance() public {
+        vm.startPrank(alice);
+        asset.approve(address(usd3Strategy), MEDIUM_DEPOSIT);
+        usd3Strategy.deposit(MEDIUM_DEPOSIT, alice);
+
+        ERC20(address(usd3Strategy)).approve(address(susd3Strategy), SMALL_DEPOSIT);
+        susd3Strategy.deposit(SMALL_DEPOSIT, alice);
+        vm.stopPrank();
+
+        uint256 storedAssets = ITokenizedStrategy(address(susd3Strategy)).totalAssets();
+        assertEq(
+            ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy)),
+            storedAssets,
+            "setup accounting should be synchronized"
+        );
+
+        address roundingSink = makeAddr("roundingSink");
+        vm.prank(address(susd3Strategy));
+        ERC20(address(usd3Strategy)).transfer(roundingSink, 1);
+        assertGt(susd3Strategy.availableDepositLimit(bob), 0, "one-unit discrepancy should be tolerated");
+
+        vm.prank(address(susd3Strategy));
+        ERC20(address(usd3Strategy)).transfer(roundingSink, 1);
+        assertEq(
+            ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy)) + 2,
+            storedAssets,
+            "setup should leave a two-unit discrepancy"
+        );
+        assertGt(susd3Strategy.availableDepositLimit(bob), 0, "two-unit discrepancy should be tolerated");
+    }
+
+    function test_susd3DepositLimitPreservesSubordinationCapWhenAccountingIsSynchronized() public {
+        setMorphoDebtCap(1_000e6);
+
+        vm.startPrank(bob);
+        asset.approve(address(usd3Strategy), MEDIUM_DEPOSIT);
+        usd3Strategy.deposit(MEDIUM_DEPOSIT, bob);
+
+        uint256 initialDeposit = 50e6;
+        ERC20(address(usd3Strategy)).approve(address(susd3Strategy), type(uint256).max);
+        susd3Strategy.deposit(initialDeposit, bob);
+        vm.stopPrank();
+
+        assertEq(
+            ERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy)),
+            ITokenizedStrategy(address(susd3Strategy)).totalAssets(),
+            "setup accounting should be synchronized"
+        );
+
+        uint256 capUSDC = susd3Strategy.getSubordinatedDebtCapInUSDC();
+        uint256 holdingsUSDC = ITokenizedStrategy(address(usd3Strategy)).convertToAssets(initialDeposit);
+        uint256 expectedCapacity = ITokenizedStrategy(address(usd3Strategy)).convertToShares(capUSDC - holdingsUSDC);
+        assertEq(
+            susd3Strategy.availableDepositLimit(bob),
+            expectedCapacity,
+            "available capacity should retain the subordination-cap conversion"
+        );
+
+        vm.prank(bob);
+        susd3Strategy.deposit(expectedCapacity, bob);
+        assertEq(susd3Strategy.availableDepositLimit(bob), 0, "deposit limit should be zero at the cap");
+    }
+
     /*//////////////////////////////////////////////////////////////
                     HELPER FUNCTIONS
     //////////////////////////////////////////////////////////////*/

--- a/test/forge/usd3/invariants/DebtFloorInvariants.t.sol
+++ b/test/forge/usd3/invariants/DebtFloorInvariants.t.sol
@@ -109,11 +109,12 @@ contract DebtFloorInvariantsTest is StdInvariant, Setup {
 
     function invariant_depositLimitTracksSubordinationCap() public view {
         uint256 capUsdc = susd3Strategy.getSubordinatedDebtCapInUSDC();
-        uint256 holdingsUsdc = ITokenizedStrategy(address(usd3Strategy))
-            .convertToAssets(IERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy)));
+        uint256 susd3Usd3Balance = IERC20(address(usd3Strategy)).balanceOf(address(susd3Strategy));
+        uint256 holdingsUsdc = ITokenizedStrategy(address(usd3Strategy)).convertToAssets(susd3Usd3Balance);
 
         uint256 expectedLimit;
-        if (capUsdc > holdingsUsdc) {
+        if (susd3Usd3Balance + 2 >= ITokenizedStrategy(address(susd3Strategy)).totalAssets() && capUsdc > holdingsUsdc)
+        {
             expectedLimit = ITokenizedStrategy(address(usd3Strategy)).convertToShares(capUsdc - holdingsUsdc);
         }
 


### PR DESCRIPTION
Remediates part 1 of an audit finding on junior-tranche deposit pricing. Standalone: part 2 (the dead-tranche recapitalization path) is separate work.

## Problem

When USD3 recognises a credit loss, `_postReportHook` → `_burnSharesFromSusd3` burns the USD3 shares held by sUSD3 by writing USD3's balance and supply slots directly. That moves `USD3.balanceOf(sUSD3)` but not the `totalAssets` that sUSD3's own TokenizedStrategy stores, so until sUSD3 reports, its two sides disagree.

`availableWithdrawLimit` already treated that deficit as unsafe and returned zero. `availableDepositLimit` did not — it sized capacity from the depleted live balance against the subordination cap, so the burn **advertised fresh junior capacity** while `deposit` priced the incoming USD3 against the stale pre-burn `totalAssets`. A depositor entering that window received far too few shares, and when sUSD3 later reported and wrote `totalAssets` down to its live balance, legacy shares kept nearly all ownership and captured most of the new principal.

## Change

Mirror the first limb of the withdraw guard:

```solidity
if (asset.balanceOf(address(this)) + 2 < TokenizedStrategy.totalAssets()) return 0;
```

Because `maxMint` derives from `availableDepositLimit`, this closes `mint` as well as `deposit`. The two-unit tolerance matches the withdraw side and keeps ordinary rounding from closing the tranche.

## Why it cannot close the tranche for a benign reason

Every path that moves the two operands was enumerated: deposit and mint move both in lockstep; withdraw and redeem can only *shrink* the deficit; an sUSD3 report resynchronises them; profit minted to sUSD3 raises the balance, which is the safe direction; and sUSD3 grants no allowances on its USD3 and has no sweep or transfer-out path. Only a first-loss burn can open a deficit greater than the tolerance, which is exactly the finding's window. The guard also reads the same storage slot the burn writes, live, so there is no window where the burn has happened but the guard cannot see it.

## Deliberately omitted

The withdraw guard's **second** limb — covering an unrecognised loss inside USD3 itself — is not mirrored here. That is a separate window, handled operationally, and it cannot coincide with this one: before a burn, sUSD3's two values still agree.

## Context

On the normal path this window does not open, because the production keeper reports USD3 and sUSD3 in the same transaction. This guard covers the residual where management reports USD3 directly, bypassing the relayer, or where the keeper is re-pointed or retired. It is hardening, not the primary control.

## Invariant changes

Two deposit-limit invariants now expect zero while accounting is stale. That is the exact logical negation of the guard rather than a relaxation — and the stale branch still asserts positively that the limit is closed, which is the assertion that fails without the fix.

The handler effectiveness check ("sUSD3 deposits are not a no-op") additionally requires a non-zero limit before asserting that some deposit succeeded, because one injected loss otherwise leaves the tranche legitimately closed for the remainder of the run. This is backstopped: if the guard were wrongly always-closed, the first invariant independently pins the limit and would fail.

## Verification

- New regressions: stale window blocks limit/`maxDeposit`/`maxMint` and reverts both `deposit` and `mint`; reconciliation via sUSD3 report reopens and prices at the loss-adjusted PPS; the two-unit tolerance still admits deposits at a 1–2 unit discrepancy; the subordination-cap formula is unchanged when in sync
- Pre-fix failure confirmed: `stale accounting should block deposits: 14995000000000 != 0`
- 505 USD3 tests (one pre-existing `USD3UpgradeForkTest` failure from an unreachable RPC), 18 USD3 invariants, 49 H-01 subordination/first-loss tests, 10 USD3/sUSD3 integration tests
- `yarn lint`, `yarn build:forge:size` — sUSD3 is 14,542 bytes, 10,034 below the EIP-170 limit