### PR TITLE
fix(usd3): require exempt receivers to deposit for themselves (I-03)

### DIFF
--- a/src/usd3/USD3.sol
+++ b/src/usd3/USD3.sol
@@ -92,7 +92,7 @@ contract USD3 is BaseHooksUpgradeable {
 
     mapping(address => uint256) private __deprecated_depositTimestamp;
 
-    /// @notice Receivers that bypass USD3 supply-cap headroom and first-time minimum-deposit checks.
+    /// @notice Receivers whose self-deposits bypass USD3 supply-cap headroom and first-time minimum-deposit checks.
     mapping(address => bool) public supplyCapExempt;
 
     /// @notice Conduits whose self-deposits add to the ring-fenced liquidity accumulator.
@@ -525,7 +525,7 @@ contract USD3 is BaseHooksUpgradeable {
                         HOOKS IMPLEMENTATION
     //////////////////////////////////////////////////////////////*/
 
-    /// @dev Pre-deposit hook to enforce the first-time minimum deposit
+    /// @dev Requires exempt receivers to self-deposit and enforces the first-time minimum for non-exempt receivers.
     function _preDepositHook(uint256 assets, uint256 shares, address receiver) internal override {
         if (assets == 0 && shares > 0) {
             assets = TokenizedStrategy.previewMint(shares);
@@ -536,9 +536,12 @@ contract USD3 is BaseHooksUpgradeable {
             assets = asset.balanceOf(msg.sender);
         }
 
+        bool exempt = supplyCapExempt[receiver];
+        require(!exempt || msg.sender == receiver, "!self");
+
         // Enforce minimum deposit only for first-time depositors
         uint256 currentBalance = TokenizedStrategy.balanceOf(receiver);
-        if (currentBalance == 0 && !supplyCapExempt[receiver]) {
+        if (currentBalance == 0 && !exempt) {
             require(assets >= minDeposit, "<min");
         }
     }
@@ -712,9 +715,17 @@ contract USD3 is BaseHooksUpgradeable {
 
     /**
      * @notice Update supply-cap and first-time minimum-deposit exemption status for a receiver.
+     * @dev An exempt receiver may only be deposited to by itself. Granting this flag to a router or aggregator that
+     * deposits on behalf of users makes those deposits revert. For example, exempting Helper breaks its non-hop path
+     * for every retail user because Helper deposits to the user, while its hop path keeps working because Helper
+     * deposits to itself; there is no signal at the Helper layer that only one path is broken.
+     * @dev Pair this flag operationally with `ringFenceConduit`. When both flags are set, every accepted deposit is a
+     * self-deposit and receives ring-fence credit. Revoking this exemption while leaving the conduit flag set permits
+     * third-party deposits that receive no ring-fence credit. LCC deployment grants both flags atomically; revoke them
+     * atomically as well.
      * @param _account Receiver address to update.
-     * @param _exempt True to bypass supply-cap headroom and first-time minimum-deposit checks, false to remove
-     * exemption.
+     * @param _exempt True to require self-deposits that bypass supply-cap headroom and first-time minimum-deposit
+     * checks; false to allow third-party deposits and apply the ordinary checks.
      */
     function setSupplyCapExempt(address _account, bool _exempt) external onlyManagement {
         supplyCapExempt[_account] = _exempt;
@@ -723,6 +734,10 @@ contract USD3 is BaseHooksUpgradeable {
 
     /**
      * @notice Update whether a conduit self-deposit adds to ring-fenced liquidity.
+     * @dev Pair this flag operationally with `supplyCapExempt`. When both flags are set, every accepted deposit is a
+     * self-deposit and receives ring-fence credit. Revoking the exemption while leaving this conduit flag set permits
+     * third-party deposits that receive no ring-fence credit. LCC deployment grants both flags atomically; revoke them
+     * atomically as well.
      * @param _conduit Receiver address to update.
      * @param _enabled True to accumulate self-deposits into the ring fence, false to disable accumulation.
      */

--- a/test/forge/usd3/USD3RingFence.t.sol
+++ b/test/forge/usd3/USD3RingFence.t.sol
@@ -128,7 +128,7 @@ contract USD3RingFenceTest is Setup {
         assertApproxEqAbs(expectedFence, balance, balance / 1000, "under-fencing bounded to rounding");
     }
 
-    function test_nonConduitAndThirdPartyDepositsDoNotIncrement() public {
+    function test_nonConduitAndNonExemptThirdPartyDepositsDoNotIncrement() public {
         vm.prank(management);
         usd3Strategy.setRingFenceConduit(address(conduit), true);
 
@@ -141,12 +141,27 @@ contract USD3RingFenceTest is Setup {
         unlistedConduit.depositSelf(MEDIUM_AMOUNT);
         assertEq(usd3Strategy.ringFencedLiquidity(), 0, "non-conduit self-deposit");
 
+        assertFalse(usd3Strategy.supplyCapExempt(address(conduit)), "conduit remains non-exempt");
         vm.prank(alice);
         usd3Strategy.deposit(SMALL_AMOUNT, address(conduit));
-        assertEq(usd3Strategy.ringFencedLiquidity(), 0, "third-party deposit to conduit");
+        assertEq(usd3Strategy.ringFencedLiquidity(), 0, "third-party deposit to non-exempt conduit");
 
         conduit.depositTo(SMALL_AMOUNT, bob);
         assertEq(usd3Strategy.ringFencedLiquidity(), 0, "conduit sender to different receiver");
+    }
+
+    function test_thirdPartyDepositToExemptConduitReverts() public {
+        vm.startPrank(management);
+        usd3Strategy.setRingFenceConduit(address(conduit), true);
+        usd3Strategy.setSupplyCapExempt(address(conduit), true);
+        vm.stopPrank();
+
+        vm.prank(alice);
+        vm.expectRevert(bytes("!self"));
+        usd3Strategy.deposit(SMALL_AMOUNT, address(conduit));
+
+        assertEq(usd3Strategy.ringFencedLiquidity(), 0, "reverted deposit does not increment fence");
+        assertEq(IERC20(address(usd3Strategy)).balanceOf(address(conduit)), 0, "reverted deposit does not mint shares");
     }
 
     function test_availableWithdrawLimitSubtractsFenceAndFeedsMaxWithdrawRedeem() public {

--- a/test/forge/usd3/USD3SupplyCap.t.sol
+++ b/test/forge/usd3/USD3SupplyCap.t.sol
@@ -170,6 +170,35 @@ contract USD3SupplyCapTest is Setup {
         assertEq(strategy.totalAssets(), TEST_CAP + SMALL_AMOUNT, "exempt deposit may exceed cap");
     }
 
+    function test_supplyCap_thirdPartyDepositToExemptReceiverReverts() public {
+        vm.prank(management);
+        usd3Strategy.setSupplyCapExempt(bob, true);
+
+        vm.prank(alice);
+        vm.expectRevert(bytes("!self"));
+        strategy.deposit(SMALL_AMOUNT, bob);
+    }
+
+    function test_supplyCap_thirdPartyDepositToNonExemptReceiverSucceeds() public {
+        assertFalse(usd3Strategy.supplyCapExempt(bob), "receiver is non-exempt");
+        assertEq(strategy.balanceOf(bob), 0, "receiver starts without shares");
+
+        vm.prank(alice);
+        uint256 shares = strategy.deposit(SMALL_AMOUNT, bob);
+
+        assertGt(shares, 0, "deposit mints shares");
+        assertEq(strategy.balanceOf(bob), shares, "receiver gets the shares");
+    }
+
+    function test_supplyCap_thirdPartyMintToExemptReceiverReverts() public {
+        vm.prank(management);
+        usd3Strategy.setSupplyCapExempt(bob, true);
+
+        vm.prank(alice);
+        vm.expectRevert(bytes("!self"));
+        strategy.mint(SMALL_AMOUNT, bob);
+    }
+
     function test_supplyCap_zeroCapBlocksExemptReceiver() public {
         vm.prank(management);
         usd3Strategy.setSupplyCapExempt(bob, true);
@@ -193,6 +222,18 @@ contract USD3SupplyCapTest is Setup {
 
         assertGt(shares, 0, "exempt receiver can deposit below first-time minimum");
         assertEq(strategy.balanceOf(bob), shares);
+    }
+
+    function test_supplyCap_thirdPartySubMinimumFirstDepositToExemptReceiverReverts() public {
+        vm.prank(management);
+        usd3Strategy.setMinDeposit(1_000e6);
+        vm.prank(management);
+        usd3Strategy.setSupplyCapExempt(bob, true);
+
+        assertEq(strategy.balanceOf(bob), 0, "receiver starts without shares");
+        vm.prank(alice);
+        vm.expectRevert(bytes("!self"));
+        strategy.deposit(SMALL_AMOUNT, bob);
     }
 
     function test_nonExemptReceiverStillEnforcesFirstTimeMinDeposit() public {

--- a/test/forge/usd3/invariants/DebtFloorInvariants.t.sol
+++ b/test/forge/usd3/invariants/DebtFloorInvariants.t.sol
@@ -58,8 +58,10 @@ contract DebtFloorInvariantsTest is StdInvariant, Setup {
             handlerActors[i] = address(uint160(uint256(keccak256(abi.encode("debt-floor-actor", i - 1)))));
         }
         conduit = makeAddr("debt-floor-conduit");
-        vm.prank(management);
+        vm.startPrank(management);
         usd3Strategy.setRingFenceConduit(conduit, true);
+        usd3Strategy.setSupplyCapExempt(conduit, true);
+        vm.stopPrank();
 
         handler = new DebtFloorHandler(
             address(usd3Strategy),


### PR DESCRIPTION
Remediates Guardian finding I-03 on live USD3.

The supply-cap exemption was keyed on the deposit receiver, and ERC-4626 deposits may be initiated by anyone, so the exemption was usable by a party that did not hold it — a third party could deposit naming an exempt address as receiver, bypassing supply-cap headroom on its behalf. The first-time minimum was keyed the same way.

`_preDepositHook` now reads the exemption once and requires an exempt receiver to be the caller, closing both bypasses with one condition. Non-exempt receivers are unchanged.

**Stacked on #126**, which carries F-04 part 1 on sUSD3. A build from this branch therefore ships **two** implementation changes behind **two** proxies — USD3 (this) and sUSD3 (#126). The timelock queue needs both; do not assume one artifact covers them.

F-04 part 2 changes sUSD3 and has no ordering dependency on this.

### Verification
- 511/511 USD3 tests, 18/18 USD3 invariants
- LCC real-stack integration passes **unmodified** — the proof exempt self-call funding still works
- Storage layout unchanged, no new state, +114 runtime bytes
- Reviewed independently by two reviewers; no Critical/High/Medium

### Behaviour change worth flagging
A call that previously succeeded silently now reverts. No production caller wraps a USD3 deposit in try/catch, the revert precedes any transfer, and shares gifted this way were unaccounted and stranded.

`supplyCapExempt` is also no longer purely permissive — granting it to a router would make its on-behalf deposits revert. Both setters now document that, and the operational pairing with `ringFenceConduit`.