### PR TITLE
fix(credit): store markdown actually applied, not requested

### DIFF
--- a/src/MorphoCredit.sol
+++ b/src/MorphoCredit.sol
@@ -76,7 +76,8 @@ contract MorphoCredit is Morpho, IMorphoCredit {
     mapping(Id => mapping(address => RepaymentObligation)) public repaymentObligation;
 
     /// @notice Markdown state for tracking defaulted debt value reduction
-    mapping(Id => mapping(address => MarkdownState)) public markdownState;
+    /// @dev The default-entry latch packs into the same slot; the external getter exposes only the applied markdown.
+    mapping(Id => mapping(address => MarkdownState)) internal _markdownState;
 
     /// @inheritdoc IMorphoCredit
     mapping(Id => bool) public marketInWindDown;
@@ -742,18 +743,25 @@ contract MorphoCredit is Morpho, IMorphoCredit {
         address manager = ICreditLine(idToMarketParams[id].creditLine).mm();
         if (manager == address(0)) return; // No markdown manager set
 
-        uint256 lastMarkdown = markdownState[id][borrower].lastCalculatedMarkdown;
+        MarkdownState storage state = _markdownState[id][borrower];
+        uint256 lastMarkdown = state.lastCalculatedMarkdown;
         (RepaymentStatus status, uint256 statusStartTime) = getRepaymentStatus(id, borrower);
 
-        // Check if in default and emit status change events
+        // Check if in default and emit status change events. The latch keeps default entry observable when the
+        // supply-share floor truncates the whole markdown increase; state written before the latch existed is
+        // inferred from a nonzero applied markdown.
         bool isInDefault = status == RepaymentStatus.Default && statusStartTime > 0;
-        bool wasInDefault = lastMarkdown > 0;
+        bool wasInDefault = state.inDefault != 0 || lastMarkdown > 0;
 
-        if (isInDefault && !wasInDefault) {
-            IMarkdownController(manager).resetBorrowerState(borrower);
-            emit EventsLib.DefaultStarted(id, borrower, statusStartTime);
-        } else if (!isInDefault && wasInDefault) {
-            emit EventsLib.DefaultCleared(id, borrower);
+        if (isInDefault != wasInDefault) {
+            if (isInDefault) {
+                state.inDefault = 1;
+                IMarkdownController(manager).resetBorrowerState(borrower);
+                emit EventsLib.DefaultStarted(id, borrower, statusStartTime);
+            } else {
+                state.inDefault = 0;
+                emit EventsLib.DefaultCleared(id, borrower);
+            }
         }
 
         // Calculate new markdown
@@ -775,25 +783,38 @@ contract MorphoCredit is Morpho, IMorphoCredit {
         }
 
         if (newMarkdown != lastMarkdown) {
-            // Update borrower state
-            markdownState[id][borrower].lastCalculatedMarkdown = uint128(newMarkdown);
+            // Update market totals - use a separate function to avoid stack issues.
+            // Store only what the market actually absorbed so a later decrease restores exactly
+            // what was deducted for this borrower and never consumes other borrowers' markdown.
+            uint256 appliedMarkdown = _updateMarketMarkdown(id, lastMarkdown, newMarkdown);
 
-            // Update market totals - use a separate function to avoid stack issues
-            _updateMarketMarkdown(id, int256(newMarkdown) - int256(lastMarkdown));
+            if (appliedMarkdown < newMarkdown) {
+                emit EventsLib.MarkdownTruncated(id, borrower, newMarkdown, appliedMarkdown);
+            }
+            if (appliedMarkdown != lastMarkdown) {
+                state.lastCalculatedMarkdown = uint128(appliedMarkdown);
 
-            emit EventsLib.BorrowerMarkdownUpdated(id, borrower, lastMarkdown, newMarkdown);
+                emit EventsLib.BorrowerMarkdownUpdated(id, borrower, lastMarkdown, appliedMarkdown);
+            }
         }
+    }
+
+    /// @inheritdoc IMorphoCredit
+    function markdownState(Id id, address borrower) external view returns (uint128) {
+        return _markdownState[id][borrower].lastCalculatedMarkdown;
     }
 
     /// @notice Update market totals for markdown changes
     /// @param id Market ID
-    /// @param markdownDelta Change in markdown (positive = increase, negative = decrease)
-    function _updateMarketMarkdown(Id id, int256 markdownDelta) internal {
+    /// @param lastMarkdown Markdown currently applied to the market for the borrower
+    /// @param newMarkdown Requested markdown for the borrower
+    /// @return Markdown applied to the market for the borrower after clamping
+    function _updateMarketMarkdown(Id id, uint256 lastMarkdown, uint256 newMarkdown) internal returns (uint256) {
         Market storage m = market[id];
 
-        if (markdownDelta > 0) {
+        if (newMarkdown > lastMarkdown) {
             // Markdown increasing (borrower deeper in default)
-            uint256 increase = uint256(markdownDelta);
+            uint256 increase = newMarkdown - lastMarkdown;
             uint256 totalSupplyAssets = m.totalSupplyAssets;
             uint256 minAssets = _minSupplyAssets(m.totalSupplyShares);
             uint256 available = totalSupplyAssets > minAssets ? totalSupplyAssets - minAssets : 0;
@@ -807,9 +828,10 @@ contract MorphoCredit is Morpho, IMorphoCredit {
             // Apply the reduction to supply and record what was marked down
             m.totalSupplyAssets = uint128(totalSupplyAssets - increase);
             m.totalMarkdownAmount = (m.totalMarkdownAmount + increase).toUint128();
+            return lastMarkdown + increase;
         } else {
             // Markdown decreasing (borrower repaying/recovering)
-            uint256 decrease = uint256(-markdownDelta);
+            uint256 decrease = lastMarkdown - newMarkdown;
 
             // Cap at previously marked down amount to avoid creating phantom supply
             if (decrease > m.totalMarkdownAmount) {
@@ -819,6 +841,7 @@ contract MorphoCredit is Morpho, IMorphoCredit {
             // Restore the supply and reduce the tracked markdown amount
             m.totalSupplyAssets = (m.totalSupplyAssets + decrease).toUint128();
             m.totalMarkdownAmount = (m.totalMarkdownAmount - decrease).toUint128();
+            return lastMarkdown - decrease;
         }
     }
 
@@ -896,13 +919,13 @@ contract MorphoCredit is Morpho, IMorphoCredit {
 
     /// @notice Apply settlement to storage
     function _applySettlement(Id id, address borrower, uint256 writtenOffShares, uint256 writtenOffAssets) internal {
-        uint256 lastMarkdown = markdownState[id][borrower].lastCalculatedMarkdown;
+        uint256 lastMarkdown = _markdownState[id][borrower].lastCalculatedMarkdown;
         Market storage m = market[id];
 
         // Clear borrower position and related state
         position[id][borrower].borrowShares = 0;
         position[id][borrower].collateral = 0;
-        delete markdownState[id][borrower];
+        delete _markdownState[id][borrower];
         delete repaymentObligation[id][borrower];
         delete borrowerPremium[id][borrower];
 
@@ -920,11 +943,10 @@ contract MorphoCredit is Morpho, IMorphoCredit {
         uint256 totalSupplyAssets = m.totalSupplyAssets;
         if (writtenOffAssets > lastMarkdown) {
             uint256 loss = writtenOffAssets - lastMarkdown;
-            if (totalSupplyAssets < loss) revert ErrorsLib.InsufficientLiquidity();
 
             uint256 minAssets = _minSupplyAssets(m.totalSupplyShares);
             uint256 protectedAssets = minAssets < totalSupplyAssets ? minAssets : totalSupplyAssets;
-            uint256 remainingAssets = totalSupplyAssets - loss;
+            uint256 remainingAssets = totalSupplyAssets > loss ? totalSupplyAssets - loss : 0;
 
             if (remainingAssets < protectedAssets) {
                 remainingAssets = protectedAssets;

--- a/src/interfaces/IMorpho.sol
+++ b/src/interfaces/IMorpho.sol
@@ -64,9 +64,14 @@ struct RepaymentObligation {
 }
 
 /// @notice Markdown state for tracking defaulted debt value reduction
-/// @param lastCalculatedMarkdown Last calculated markdown amount
+/// @param lastCalculatedMarkdown Markdown currently applied to the market for this borrower; may be less than the
+/// requested markdown when the supply-share price floor truncated the increase
+/// @param inDefault Default-entry latch: 1 once the borrower's default entry has been processed, 0 otherwise.
+/// State written before this field existed carries 0 while in default, so a nonzero applied markdown also counts
+/// as a processed entry
 struct MarkdownState {
     uint128 lastCalculatedMarkdown;
+    uint128 inDefault;
 }
 
 struct Authorization {
@@ -432,7 +437,7 @@ interface IMorphoCredit {
     /// @notice Get markdown state for a borrower
     /// @param id Market ID
     /// @param borrower Borrower address
-    /// @return lastCalculatedMarkdown Last calculated markdown amount
+    /// @return lastCalculatedMarkdown Markdown currently applied to the market for this borrower
     function markdownState(Id id, address borrower) external view returns (uint128 lastCalculatedMarkdown);
 
     /// @notice Whether a supply-share floor truncated a market's markdown or settlement loss.

--- a/src/libraries/EventsLib.sol
+++ b/src/libraries/EventsLib.sol
@@ -142,12 +142,21 @@ library EventsLib {
     /// @param remainingDue Remaining amount due after payment.
     event RepaymentTracked(Id indexed id, address indexed borrower, uint256 payment, uint256 remainingDue);
 
-    /// @notice Emitted when a borrower's markdown is updated.
+    /// @notice Emitted when a borrower's markdown applied to the market changes.
     /// @param id Market id.
     /// @param borrower Borrower address.
-    /// @param oldMarkdown Previous markdown amount.
-    /// @param newMarkdown New markdown amount.
+    /// @param oldMarkdown Previous markdown applied to the market for the borrower.
+    /// @param newMarkdown New markdown applied to the market for the borrower.
     event BorrowerMarkdownUpdated(Id indexed id, address indexed borrower, uint256 oldMarkdown, uint256 newMarkdown);
+
+    /// @notice Emitted when the supply-share price floor truncates a borrower's markdown increase.
+    /// @param id Market id.
+    /// @param borrower Borrower address.
+    /// @param requestedMarkdown Markdown requested by the markdown controller.
+    /// @param appliedMarkdown Markdown applied to the market for the borrower after truncation.
+    event MarkdownTruncated(
+        Id indexed id, address indexed borrower, uint256 requestedMarkdown, uint256 appliedMarkdown
+    );
 
     /// @notice Emitted when a borrower enters default status.
     /// @param id Market id.

--- a/src/libraries/periphery/MorphoCreditLib.sol
+++ b/src/libraries/periphery/MorphoCreditLib.sol
@@ -144,7 +144,8 @@ library MorphoCreditLib {
     /// @param morpho The MorphoCredit instance
     /// @param id Market ID
     /// @param borrower Borrower address
-    /// @return lastCalculatedMarkdown The last calculated markdown amount
+    /// @return lastCalculatedMarkdown The markdown currently applied to the market for this borrower; the slot's
+    /// upper 128 bits carry the default-entry latch and are masked off here
     function getMarkdownState(IMorphoCredit morpho, Id id, address borrower)
         internal
         view

--- a/test/forge/integration/markdown/MarkdownDefaultLatchTest.sol
+++ b/test/forge/integration/markdown/MarkdownDefaultLatchTest.sol
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import "../../BaseTest.sol";
+import {Jane} from "../../../../src/jane/Jane.sol";
+import {MarkdownController} from "../../../../src/MarkdownController.sol";
+import {CreditLineMock} from "../../../../src/mocks/CreditLineMock.sol";
+import {Market} from "../../../../src/interfaces/IMorpho.sol";
+import {MarketParamsLib} from "../../../../src/libraries/MarketParamsLib.sol";
+import {MorphoCreditLib} from "../../../../src/libraries/periphery/MorphoCreditLib.sol";
+import {MorphoCreditStorageLib} from "../../../../src/libraries/periphery/MorphoCreditStorageLib.sol";
+import {SharesMathLib} from "../../../../src/libraries/SharesMathLib.sol";
+import {ProtocolConfigLib} from "../../../../src/libraries/ProtocolConfigLib.sol";
+
+/// @title MarkdownDefaultLatchTest
+/// @notice Regression tests for default-entry tracking with the real MarkdownController + Jane stack.
+/// The supply-share price floor can truncate a markdown increase to zero, so the stored applied markdown
+/// cannot be used to infer whether a borrower already entered default.
+contract MarkdownDefaultLatchTest is BaseTest {
+    using MarketParamsLib for MarketParams;
+    using SharesMathLib for uint256;
+
+    uint256 internal constant SUPPLY_SHARE_PRICE_FLOOR_RATIO = 1e15;
+    uint256 internal constant SUPPLY_AMOUNT = 1 ether;
+    uint256 internal constant DUST_DEBT = 5e8;
+    uint256 internal constant JANE_BALANCE = 10_000e18;
+
+    bytes32 internal constant DEFAULT_STARTED_TOPIC = keccak256("DefaultStarted(bytes32,address,uint256)");
+    bytes32 internal constant DEFAULT_CLEARED_TOPIC = keccak256("DefaultCleared(bytes32,address)");
+    bytes32 internal constant MARKDOWN_UPDATED_TOPIC =
+        keccak256("BorrowerMarkdownUpdated(bytes32,address,uint256,uint256)");
+    bytes32 internal constant MARKDOWN_TRUNCATED_TOPIC =
+        keccak256("MarkdownTruncated(bytes32,address,uint256,uint256)");
+
+    bytes32 internal constant MINTER_ROLE = keccak256("MINTER_ROLE");
+
+    Jane internal jane;
+    MarkdownController internal markdownController;
+    CreditLineMock internal creditLine;
+    IMorphoCredit internal morphoCredit;
+
+    address internal janeOwner;
+    address internal janeMinter;
+    address internal janeDistributor;
+
+    function setUp() public override {
+        super.setUp();
+
+        morphoCredit = IMorphoCredit(morphoAddress);
+
+        janeOwner = makeAddr("janeOwner");
+        janeMinter = makeAddr("janeMinter");
+        janeDistributor = makeAddr("janeDistributor");
+        jane = new Jane(janeOwner, janeDistributor);
+        vm.prank(janeOwner);
+        jane.grantRole(MINTER_ROLE, janeMinter);
+
+        creditLine = new CreditLineMock(morphoAddress);
+
+        marketParams = MarketParams({
+            loanToken: address(loanToken),
+            collateralToken: address(collateralToken),
+            oracle: address(oracle),
+            irm: address(0),
+            lltv: DEFAULT_TEST_LLTV,
+            creditLine: address(creditLine)
+        });
+        id = marketParams.id();
+
+        vm.prank(OWNER);
+        morpho.createMarket(marketParams);
+
+        markdownController = new MarkdownController(address(protocolConfig), OWNER, address(jane), morphoAddress, id);
+        creditLine.setMm(address(markdownController));
+
+        vm.prank(janeOwner);
+        jane.setMarkdownController(address(markdownController));
+
+        vm.startPrank(OWNER);
+        protocolConfig.setConfig(ProtocolConfigLib.FULL_MARKDOWN_DURATION, 100 days);
+        protocolConfig.setConfig(keccak256("IRP"), 0);
+        markdownController.setEnableMarkdown(BORROWER, true);
+        markdownController.setEnableMarkdown(ONBEHALF, true);
+        vm.stopPrank();
+
+        _ensureMarketActive(id);
+
+        loanToken.setBalance(SUPPLIER, SUPPLY_AMOUNT);
+        vm.prank(SUPPLIER);
+        morpho.supply(marketParams, SUPPLY_AMOUNT, 0, SUPPLIER, hex"");
+
+        vm.prank(janeMinter);
+        jane.mint(ONBEHALF, JANE_BALANCE);
+        vm.prank(janeOwner);
+        jane.setTransferable();
+    }
+
+    /// @notice BORROWER's full markdown drives the market to the supply-share floor, then ONBEHALF's markdown
+    /// increase is fully truncated: ONBEHALF is 50 days into default (50% intended slash) with zero stored markdown.
+    function _floorTruncatedDefault() internal {
+        _setupBorrowerWithLoan(ONBEHALF, DUST_DEBT);
+        _setupBorrowerWithLoan(BORROWER, SUPPLY_AMOUNT - DUST_DEBT);
+
+        uint256 cycleEndA = _closeCycleWithObligation(BORROWER, SUPPLY_AMOUNT - DUST_DEBT, CYCLE_DURATION + 1 days);
+        uint256 cycleEndB = _closeCycleWithObligation(ONBEHALF, DUST_DEBT, 61 days);
+        assertEq(cycleEndB, cycleEndA + 61 days, "cycle spacing");
+
+        uint256 defaultStartB = cycleEndB + GRACE_PERIOD_DURATION + DELINQUENCY_PERIOD_DURATION;
+        vm.warp(defaultStartB + 50 days);
+
+        // BORROWER is 111 days into default: full markdown, truncated at the floor, market winds down.
+        morphoCredit.accruePremiumsForBorrowers(id, _toArray(BORROWER));
+
+        Market memory atFloor = morpho.market(id);
+        uint256 minAssets = _minSupplyAssets(atFloor.totalSupplyShares);
+        assertEq(atFloor.totalSupplyAssets, minAssets, "market not at floor");
+        assertTrue(morphoCredit.marketInWindDown(id), "floor markdown did not wind down market");
+    }
+
+    function _closeCycleWithObligation(address borrower, uint256 endingBalance, uint256 gap)
+        internal
+        returns (uint256 cycleEnd)
+    {
+        uint256 cycleCount = MorphoCreditLib.getPaymentCycleLength(morphoCredit, id);
+        uint256 lastCycleEnd = MorphoCredit(address(morpho)).paymentCycle(id, cycleCount - 1);
+        cycleEnd = lastCycleEnd + gap;
+
+        address[] memory borrowers = new address[](1);
+        borrowers[0] = borrower;
+        uint256[] memory repaymentBps = new uint256[](1);
+        repaymentBps[0] = 10_000;
+        uint256[] memory endingBalances = new uint256[](1);
+        endingBalances[0] = endingBalance;
+
+        vm.warp(cycleEnd);
+        vm.prank(address(creditLine));
+        MorphoCredit(address(morpho))
+            .closeCycleAndPostObligations(id, cycleEnd, borrowers, repaymentBps, endingBalances);
+    }
+
+    function _countLogs(Vm.Log[] memory logs, bytes32 topic, address borrower)
+        internal
+        view
+        returns (uint256 count, bytes memory data)
+    {
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].emitter != morphoAddress) continue;
+            if (logs[i].topics[0] != topic) continue;
+            if (address(uint160(uint256(logs[i].topics[2]))) != borrower) continue;
+            count++;
+            data = logs[i].data;
+        }
+    }
+
+    function _minSupplyAssets(uint256 totalSupplyShares) internal pure returns (uint256) {
+        return (totalSupplyShares + SharesMathLib.VIRTUAL_SHARES - 1) / SUPPLY_SHARE_PRICE_FLOOR_RATIO;
+    }
+
+    /// @notice Finding 1: repeated touches of a fully-truncated defaulted borrower at one timestamp must slash
+    /// exactly the intended fraction once, not compound it per touch.
+    function testRepeatedTouchOfFullyTruncatedBorrowerSlashesIntendedFractionOnce() public {
+        _floorTruncatedDefault();
+
+        // Three permissionless touches in the same block.
+        for (uint256 i = 0; i < 3; i++) {
+            morphoCredit.accruePremiumsForBorrowers(id, _toArray(ONBEHALF));
+        }
+
+        assertEq(morphoCredit.markdownState(id, ONBEHALF), 0, "truncated markdown was stored");
+        assertEq(jane.balanceOf(ONBEHALF), JANE_BALANCE / 2, "cumulative slash exceeds intended 50%");
+        assertEq(jane.balanceOf(janeDistributor), JANE_BALANCE / 2, "distributor received more than intended 50%");
+        assertEq(markdownController.janeSlashed(ONBEHALF), JANE_BALANCE / 2, "slash tracking diverged");
+        assertEq(markdownController.initialJaneBalance(ONBEHALF), JANE_BALANCE, "initial balance was re-initialised");
+    }
+
+    /// @notice Full truncation must stay observable: DefaultStarted fires once, refused markdown emits a
+    /// truncation event on every refused increase, and no BorrowerMarkdownUpdated fires for an unchanged store.
+    function testFullTruncationEventBehaviour() public {
+        _floorTruncatedDefault();
+
+        uint256 requested = DUST_DEBT * 50 / 100;
+
+        vm.recordLogs();
+        morphoCredit.accruePremiumsForBorrowers(id, _toArray(ONBEHALF));
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        (uint256 started,) = _countLogs(logs, DEFAULT_STARTED_TOPIC, ONBEHALF);
+        (uint256 updated,) = _countLogs(logs, MARKDOWN_UPDATED_TOPIC, ONBEHALF);
+        (uint256 truncated, bytes memory truncData) = _countLogs(logs, MARKDOWN_TRUNCATED_TOPIC, ONBEHALF);
+        assertEq(started, 1, "first touch must emit DefaultStarted once");
+        assertEq(updated, 0, "unchanged store must not emit BorrowerMarkdownUpdated");
+        assertEq(truncated, 1, "refused markdown must emit a truncation event");
+        assertEq(truncData, abi.encode(requested, uint256(0)), "truncation event payload");
+
+        vm.recordLogs();
+        morphoCredit.accruePremiumsForBorrowers(id, _toArray(ONBEHALF));
+        logs = vm.getRecordedLogs();
+
+        (started,) = _countLogs(logs, DEFAULT_STARTED_TOPIC, ONBEHALF);
+        (updated,) = _countLogs(logs, MARKDOWN_UPDATED_TOPIC, ONBEHALF);
+        (truncated, truncData) = _countLogs(logs, MARKDOWN_TRUNCATED_TOPIC, ONBEHALF);
+        assertEq(started, 0, "repeat touch must not re-emit DefaultStarted");
+        assertEq(updated, 0, "repeat touch must not emit BorrowerMarkdownUpdated");
+        assertEq(truncated, 1, "still-refused markdown must stay observable");
+        assertEq(truncData, abi.encode(requested, uint256(0)), "repeat truncation event payload");
+    }
+
+    /// @notice Upgrade boundary, common case: a borrower mid-default with nonzero stored markdown (all live
+    /// pre-upgrade state that entered default and was touched) must not be reset or re-slashed when the
+    /// default latch bits are still zero.
+    function testUpgradeBoundaryMidDefaultWithStoredMarkdownIsNotReslashed() public {
+        _setupBorrowerWithLoan(ONBEHALF, DUST_DEBT);
+        uint256 cycleEnd = _closeCycleWithObligation(ONBEHALF, DUST_DEBT, CYCLE_DURATION + 1 days);
+        uint256 defaultStart = cycleEnd + GRACE_PERIOD_DURATION + DELINQUENCY_PERIOD_DURATION;
+
+        vm.warp(defaultStart + 30 days);
+        morphoCredit.accruePremiumsForBorrowers(id, _toArray(ONBEHALF));
+
+        uint256 stored = morphoCredit.markdownState(id, ONBEHALF);
+        assertEq(stored, DUST_DEBT * 30 / 100, "expected applied markdown at 30 days");
+        assertEq(jane.balanceOf(ONBEHALF), JANE_BALANCE * 70 / 100, "expected 30% slash at 30 days");
+
+        // Model the upgrade boundary: live storage predates the latch, so its upper 128 bits are zero.
+        bytes32 slot = MorphoCreditStorageLib.markdownStateSlot(id, ONBEHALF);
+        vm.store(morphoAddress, slot, bytes32(stored));
+
+        vm.warp(defaultStart + 50 days);
+        vm.recordLogs();
+        morphoCredit.accruePremiumsForBorrowers(id, _toArray(ONBEHALF));
+
+        (uint256 started,) = _countLogs(vm.getRecordedLogs(), DEFAULT_STARTED_TOPIC, ONBEHALF);
+        assertEq(started, 0, "legacy mid-default borrower re-entered default");
+        assertEq(jane.balanceOf(ONBEHALF), JANE_BALANCE / 2, "cumulative slash must continue, not restart");
+        assertEq(markdownController.janeSlashed(ONBEHALF), JANE_BALANCE / 2, "slash tracking was reset");
+        assertEq(morphoCredit.markdownState(id, ONBEHALF), DUST_DEBT / 2, "markdown did not continue from 30%");
+    }
+
+    /// @notice Upgrade boundary, degenerate case: a live borrower mid-default whose stored markdown is zero
+    /// (markdown rounded to zero on every pre-upgrade touch) is indistinguishable from a fresh default. The
+    /// first post-upgrade touch re-enters default once — accepted behaviour — but must latch afterwards.
+    function testUpgradeBoundaryZeroStoredMarkdownReslashesAtMostOnce() public {
+        _floorTruncatedDefault();
+
+        morphoCredit.accruePremiumsForBorrowers(id, _toArray(ONBEHALF));
+        assertEq(jane.balanceOf(ONBEHALF), JANE_BALANCE / 2, "expected 50% slash on first touch");
+
+        // Model the upgrade boundary: wipe the whole slot (stored markdown is already zero, latch predates upgrade).
+        bytes32 slot = MorphoCreditStorageLib.markdownStateSlot(id, ONBEHALF);
+        vm.store(morphoAddress, slot, bytes32(0));
+
+        // First post-upgrade touch may re-enter default once and re-slash from the reduced balance.
+        morphoCredit.accruePremiumsForBorrowers(id, _toArray(ONBEHALF));
+        assertEq(jane.balanceOf(ONBEHALF), JANE_BALANCE / 4, "expected one accepted re-slash");
+
+        // Every further touch must be latched.
+        morphoCredit.accruePremiumsForBorrowers(id, _toArray(ONBEHALF));
+        morphoCredit.accruePremiumsForBorrowers(id, _toArray(ONBEHALF));
+        assertEq(jane.balanceOf(ONBEHALF), JANE_BALANCE / 4, "re-slash repeated after the first touch");
+        assertEq(markdownController.janeSlashed(ONBEHALF), JANE_BALANCE / 4, "slash tracking kept resetting");
+    }
+}

--- a/test/forge/integration/markdown/SupplySharePriceFloorTest.sol
+++ b/test/forge/integration/markdown/SupplySharePriceFloorTest.sol
@@ -118,6 +118,73 @@ contract SupplySharePriceFloorTest is BaseTest {
         assertTrue(morphoCredit.marketInWindDown(id), "wind-down cleared without governance");
     }
 
+    function testFloorTruncatedBorrowerCureRestoresOnlyAppliedMarkdown() public {
+        uint256 assets = 1 ether;
+        _supplyFrom(SUPPLIER, 2 * assets);
+        _setupBorrowerWithLoan(BORROWER, assets);
+        _setupBorrowerWithLoan(ONBEHALF, assets);
+
+        vm.prank(OWNER);
+        markdownManager.setEnableMarkdown(ONBEHALF, true);
+
+        address[] memory borrowers = new address[](2);
+        borrowers[0] = BORROWER;
+        borrowers[1] = ONBEHALF;
+        uint256[] memory bpsList = new uint256[](2);
+        bpsList[0] = 10_000;
+        bpsList[1] = 10_000;
+        uint256[] memory balances = new uint256[](2);
+        balances[0] = assets;
+        balances[1] = assets;
+        _createMultipleObligations(id, borrowers, bpsList, balances, 0);
+
+        markdownManager.setMarkdownForBorrower(BORROWER, assets);
+        markdownManager.setMarkdownForBorrower(ONBEHALF, assets);
+        _continueMarketCycles(id, block.timestamp + GRACE_PERIOD_DURATION + DELINQUENCY_PERIOD_DURATION + 1);
+
+        uint256 minAssets = _minSupplyAssets(morpho.market(id).totalSupplyShares);
+        uint256 appliedForOnBehalf = assets - minAssets;
+
+        // BORROWER's full markdown applies first; ONBEHALF's is truncated at the floor.
+        vm.expectEmit(true, true, false, true, address(morphoCredit));
+        emit EventsLib.BorrowerMarkdownUpdated(id, ONBEHALF, 0, appliedForOnBehalf);
+        morphoCredit.accruePremiumsForBorrowers(id, borrowers);
+
+        Market memory atFloor = morpho.market(id);
+        assertEq(atFloor.totalSupplyAssets, minAssets, "second markdown did not stop at floor");
+        assertTrue(morphoCredit.marketInWindDown(id), "truncated markdown did not wind down market");
+        assertEq(atFloor.totalMarkdownAmount, assets + appliedForOnBehalf, "market markdown tally");
+        assertEq(morphoCredit.markdownState(id, BORROWER), assets, "untruncated stored markdown");
+        assertEq(
+            morphoCredit.markdownState(id, ONBEHALF), appliedForOnBehalf, "stored markdown exceeds applied markdown"
+        );
+
+        // The truncated borrower cures in full; only the markdown applied for it may be restored.
+        Position memory onBehalfPosition = morpho.position(id, ONBEHALF);
+        loanToken.setBalance(ONBEHALF, assets);
+        vm.prank(ONBEHALF);
+        morpho.repay(marketParams, 0, onBehalfPosition.borrowShares, ONBEHALF, "");
+
+        Market memory afterCure = morpho.market(id);
+        assertEq(afterCure.totalSupplyAssets, assets, "cure restored more than was applied for the borrower");
+        assertEq(afterCure.totalMarkdownAmount, assets, "cure consumed the defaulted borrower's markdown");
+        assertEq(morphoCredit.markdownState(id, ONBEHALF), 0, "cured borrower markdown not cleared");
+
+        // Settle the still-defaulted borrower; supply must not exceed the tokens actually backing the market.
+        vm.prank(address(creditLine));
+        morphoCredit.settleAccount(marketParams, BORROWER);
+
+        Market memory settled = morpho.market(id);
+        assertEq(settled.totalBorrowAssets, 0, "borrow assets not cleared");
+        assertEq(settled.totalMarkdownAmount, 0, "markdown tally not cleared");
+        assertEq(
+            settled.totalSupplyAssets,
+            loanToken.balanceOf(address(morpho)),
+            "supply assets exceed tokens backing the market"
+        );
+        _assertSupplySharePriceFloor(settled);
+    }
+
     function testWithdrawThenMarkdownUsesSaturatingAvailableAssets() public {
         uint256 assets = 1 ether;
         _supplyFrom(SUPPLIER, assets);
@@ -257,6 +324,33 @@ contract SupplySharePriceFloorTest is BaseTest {
         morpho.withdraw(marketParams, 1, 0, SUPPLIER, SUPPLIER);
 
         assertTrue(morphoCredit.marketInWindDown(id), "exit paths cleared wind-down");
+    }
+
+    function testSettleFullyTruncatedBorrowerOnLegacySubFloorMarketSaturates() public {
+        uint256 assets = 1 ether;
+        _supplyFrom(SUPPLIER, assets);
+        _setupBorrowerWithLoan(BORROWER, assets / 2);
+
+        // Model a legacy market whose supply collapsed below the floor before this implementation was installed.
+        Market memory legacy = morpho.market(id);
+        _setSupplyTotals(10, legacy.totalSupplyShares);
+
+        // No capacity above the floor remains, so the borrower's markdown increase is fully truncated.
+        _moveToDefaultAndTouch(BORROWER, assets / 2);
+        assertEq(morphoCredit.markdownState(id, BORROWER), 0, "truncated markdown was stored");
+        assertTrue(morphoCredit.marketInWindDown(id), "full truncation did not wind down market");
+
+        // Settlement must saturate at the protected assets instead of reverting: wind-down blocks new supply,
+        // so a revert here would make the bad debt permanently unwritable.
+        vm.prank(address(creditLine));
+        morphoCredit.settleAccount(marketParams, BORROWER);
+
+        Market memory settled = morpho.market(id);
+        assertEq(settled.totalBorrowAssets, 0, "borrow assets not cleared");
+        assertEq(settled.totalBorrowShares, 0, "borrow shares not cleared");
+        assertEq(settled.totalSupplyAssets, 10, "settlement changed protected assets");
+        assertEq(settled.totalMarkdownAmount, 0, "markdown tally not cleared");
+        assertTrue(morphoCredit.marketInWindDown(id), "settlement cleared wind-down");
     }
 
     function testSupplyConsistencyCheckIncludesVirtualShares() public {

--- a/test/forge/invariant/MarkdownInvariantTest.sol
+++ b/test/forge/invariant/MarkdownInvariantTest.sol
@@ -239,16 +239,23 @@ contract MarkdownInvariantTest is BaseTest {
         }
     }
 
-    /// @notice Invariant: Total market markdown equals sum of individual markdowns
+    /// @notice Invariant: Total market markdown equals sum of individual applied markdowns
     function invariant_TotalMarkdownConsistency() public {
         updateAllMarkdowns();
 
         Market memory market = morpho.market(id);
         uint256 marketTotalMarkdown = market.totalMarkdownAmount;
-        uint256 calculatedTotal = totalCalculatedMarkdown;
 
-        // Allow small difference for rounding
-        assertApproxEqAbs(marketTotalMarkdown, calculatedTotal, 100, "Total markdown mismatch");
+        // The market total must match the sum of the per-borrower applied markdowns exactly; the floor can
+        // truncate what is applied below what the manager requested, so the requested sum is only an upper bound.
+        uint256 appliedTotal;
+        for (uint256 i = 0; i < borrowers.length; i++) {
+            appliedTotal += morphoCredit.markdownState(id, borrowers[i]);
+        }
+
+        assertEq(marketTotalMarkdown, appliedTotal, "Total markdown mismatch");
+        // Small tolerance for rounding between the handler's recomputed borrow assets and the contract's.
+        assertLe(marketTotalMarkdown, totalCalculatedMarkdown + 100, "Applied markdown exceeds requested");
     }
 
     /// @notice Invariant: Markdown only applies to enabled borrowers


### PR DESCRIPTION
Stacked on `worktree-ccf` (#120), not `main` — this repairs `d4d422d3` (the F-03 remediation), which exists only on that branch.

## What was wrong

The supply-share price floor can truncate a markdown increase, but `_updateBorrowerMarkdown` stored the full **requested** amount. The decrease path bounds the restore only against market-wide `totalMarkdownAmount`, never per-borrower, so a truncated borrower recovering could restore more than was ever deducted for it — consuming markdown recorded for a different, still-defaulted borrower and overstating `totalSupplyAssets` against unbacked value.

`marketInWindDown` does not gate this. `_requireNewLendingAllowed` blocks new supply and new borrowing, but not **repay** and not **withdraw**, which are exactly the two legs this needs.

Reproduced at stored `1e18` vs applied `999999998000000000`, yielding `1.000000002e18` of supply against `1e18` of backing.

## The fix

`_updateMarketMarkdown` now takes `(id, lastMarkdown, newMarkdown)` and returns the amount it **actually applied**, which the caller persists. `sum(borrowers.lastCalculatedMarkdown) == totalMarkdownAmount` now holds unconditionally for state written by this implementation — strengthening `invariant_markdownSumMatchesMarketTotal`, which was previously violable.

## Two readers assumed the old meaning

Review found both; neither was in the original change.

**Repeated JANE confiscation.** Default entry was inferred from `lastCalculatedMarkdown > 0`. With a fully-truncated increase storing nothing, the flag never latched, so every permissionless `accruePremiumsForBorrowers` re-entered the default-entry branch — resetting the controller's `janeSlashed` and re-slashing from an already-reduced balance. Measured at an intended 50% slash: 3 touches in one block left 12.5%. A normal `repay` touches markdown twice, so it double-slashed.

Default entry is now an explicit latch in the previously-zero upper half of the `MarkdownState` slot. Nonzero applied markdown is retained as a legacy fallback, which is what makes the upgrade safe.

**Settlement DoS.** `_applySettlement` derives `loss` from `lastMarkdown`, now larger under truncation, so its pre-floor `InsufficientLiquidity` revert fired *before* the clamp that would have handled it — leaving bad debt permanently unwritable-off with wind-down blocking new supply. The subtraction now saturates.

## Upgrade safety

- **ABI byte-identical.** `markdownState(bytes32,address) → uint128` unchanged; the mapping is internal with a hand-written getter.
- **No storage slot moves.** `_markdownState` stays slot 24 offset 0, `marketInWindDown` 25, `__gap` 26. `inDefault` packs into previously-zero bits.
- **Borrowers mid-default at upgrade are not re-slashed** — they carry nonzero stored markdown, so the fallback reads them as already-in-default. Pinned by `testUpgradeBoundaryMidDefaultWithStoredMarkdownIsNotReslashed`.
- **Size improved**: 24,545 → 24,520 bytes, EIP-170 margin 31 → 56, despite adding the latch, the getter, and a new event.

## ⚠️ Required before deploying

Legacy state written before this change is **not** reconciled. The pre-floor deployed generation clamped markdown increases while storing the requested value, so divergence is possible in principle.

Per live market, verify:

```
Σ_borrowers markdownState(id, b) == market(id).totalMarkdownAmount
```

enumerating borrowers from `DefaultStarted` / `BorrowerMarkdownUpdated` logs. No `DefaultStarted` events ⇒ trivially clean. **If it fails anywhere, settle the affected borrowers on the old implementation first** rather than adding reconciliation machinery.

(The floor predicate `totalSupplyAssets < (totalSupplyShares + 1e6 - 1) / 1e15` was verified to match `_minSupplyAssets` exactly, but it detects *currently below floor*, which is neither necessary nor sufficient for stored-value divergence. Use it to identify markets starting in wind-down; use the sum check above to decide migration.)

## Also

- New `MarkdownTruncated(id, borrower, requested, applied)` — refused markdown was previously observable only as a repeating `DefaultStarted`.
- `invariant_TotalMarkdownConsistency` tightened to exact equality.

## Verification

- Full suite **195 suites / 1,821 tests / 0 failures**; lint clean; core invariants 11/11
- Five new regressions, each written to fail against the pre-fix tree first:
  - `testRepeatedTouchOfFullyTruncatedBorrowerSlashesIntendedFractionOnce`
  - `testSettleFullyTruncatedBorrowerOnLegacySubFloorMarketSaturates`
  - `testFullTruncationEventBehaviour`
  - `testUpgradeBoundaryZeroStoredMarkdownReslashesAtMostOnce`
  - `testUpgradeBoundaryMidDefaultWithStoredMarkdownIsNotReslashed`

Existing floor tests all use `MarkdownManagerMock`, whose `resetBorrowerState` and `slashJaneProportional` are `pure` no-ops — which is why the JANE issue was invisible. The new regressions use the real `MarkdownController` and `Jane`.
